### PR TITLE
global: change SIMDE_POWER_ALTIVEC_P5_NATIVE to P6

### DIFF
--- a/simde/arm/neon/add.h
+++ b/simde/arm/neon/add.h
@@ -326,7 +326,7 @@ simde_vaddq_f32(simde_float32x4_t a, simde_float32x4_t b) {
     return vaddq_f32(a, b);
   #elif defined(SIMDE_X86_SSE_NATIVE)
     return _mm_add_ps(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     SIMDE_POWER_ALTIVEC_VECTOR(float) a_ , b_, r_;
     a_ = a;
     b_ = b;
@@ -398,7 +398,7 @@ simde_vaddq_s8(simde_int8x16_t a, simde_int8x16_t b) {
     return vaddq_s8(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_add_epi8(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_add(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_i8x16_add(a, b);
@@ -432,7 +432,7 @@ simde_vaddq_s16(simde_int16x8_t a, simde_int16x8_t b) {
     return vaddq_s16(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_add_epi16(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_add(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_i16x8_add(a, b);
@@ -466,7 +466,7 @@ simde_vaddq_s32(simde_int32x4_t a, simde_int32x4_t b) {
     return vaddq_s32(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_add_epi32(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_add(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_i32x4_add(a, b);
@@ -532,7 +532,7 @@ simde_uint8x16_t
 simde_vaddq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vaddq_u8(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_add(a, b);
   #else
     simde_uint8x16_private
@@ -562,7 +562,7 @@ simde_uint16x8_t
 simde_vaddq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vaddq_u16(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_add(a, b);
   #else
     simde_uint16x8_private
@@ -592,7 +592,7 @@ simde_uint32x4_t
 simde_vaddq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vaddq_u32(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_add(a, b);
   #else
     simde_uint32x4_private

--- a/simde/arm/neon/and.h
+++ b/simde/arm/neon/and.h
@@ -281,7 +281,7 @@ simde_vandq_s8(simde_int8x16_t a, simde_int8x16_t b) {
     return vandq_s8(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_and_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_and(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_and(a, b);
@@ -315,7 +315,7 @@ simde_vandq_s16(simde_int16x8_t a, simde_int16x8_t b) {
     return vandq_s16(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_and_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_and(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_and(a, b);
@@ -349,7 +349,7 @@ simde_vandq_s32(simde_int32x4_t a, simde_int32x4_t b) {
     return vandq_s32(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_and_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_and(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_and(a, b);
@@ -417,7 +417,7 @@ simde_vandq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
     return vandq_u8(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_and_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_and(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_and(a, b);
@@ -451,7 +451,7 @@ simde_vandq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
     return vandq_u16(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_and_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_and(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_and(a, b);
@@ -485,7 +485,7 @@ simde_vandq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
     return vandq_u32(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_and_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_and(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_and(a, b);

--- a/simde/arm/neon/dup_n.h
+++ b/simde/arm/neon/dup_n.h
@@ -265,7 +265,7 @@ simde_vdupq_n_f32(float value) {
     return _mm_set1_ps(value);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_f32x4_splat(value);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     (void) value;
     return vec_splats(value);
   #else
@@ -321,7 +321,7 @@ simde_vdupq_n_s8(int8_t value) {
     return _mm_set1_epi8(value);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_i8x16_splat(value);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_splats(value);
   #else
     simde_int8x16_private r_;
@@ -348,7 +348,7 @@ simde_vdupq_n_s16(int16_t value) {
     return _mm_set1_epi16(value);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_i16x8_splat(value);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_splats(value);
   #else
     simde_int16x8_private r_;
@@ -375,7 +375,7 @@ simde_vdupq_n_s32(int32_t value) {
     return _mm_set1_epi32(value);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_i32x4_splat(value);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_splats(value);
   #else
     simde_int32x4_private r_;
@@ -429,7 +429,7 @@ simde_vdupq_n_u8(uint8_t value) {
     return _mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, value));
   #elif defined (SIMDE_WASM_SIMD128_NATIVE)
     return wasm_i8x16_splat(HEDLEY_STATIC_CAST(int8_t, value));
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_splats(value);
   #else
     simde_uint8x16_private r_;
@@ -456,7 +456,7 @@ simde_vdupq_n_u16(uint16_t value) {
     return _mm_set1_epi16(HEDLEY_STATIC_CAST(int16_t, value));
   #elif defined (SIMDE_WASM_SIMD128_NATIVE)
     return wasm_i16x8_splat(HEDLEY_STATIC_CAST(int16_t, value));
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_splats(value);
   #else
     simde_uint16x8_private r_;
@@ -483,7 +483,7 @@ simde_vdupq_n_u32(uint32_t value) {
     return _mm_set1_epi32(HEDLEY_STATIC_CAST(int32_t, value));
   #elif defined (SIMDE_WASM_SIMD128_NATIVE)
     return wasm_i32x4_splat(HEDLEY_STATIC_CAST(int32_t, value));
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_splats(value);
   #else
     simde_uint32x4_private r_;

--- a/simde/arm/neon/eor.h
+++ b/simde/arm/neon/eor.h
@@ -281,7 +281,7 @@ simde_veorq_s8(simde_int8x16_t a, simde_int8x16_t b) {
     return veorq_s8(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_xor_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_xor(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_xor(a, b);
@@ -315,7 +315,7 @@ simde_veorq_s16(simde_int16x8_t a, simde_int16x8_t b) {
     return veorq_s16(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_xor_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_xor(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_xor(a, b);
@@ -349,7 +349,7 @@ simde_veorq_s32(simde_int32x4_t a, simde_int32x4_t b) {
     return veorq_s32(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_xor_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_xor(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_xor(a, b);
@@ -417,7 +417,7 @@ simde_veorq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
     return veorq_u8(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_xor_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_xor(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_xor(a, b);
@@ -451,7 +451,7 @@ simde_veorq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
     return veorq_u16(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_xor_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_xor(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_xor(a, b);
@@ -485,7 +485,7 @@ simde_veorq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
     return veorq_u32(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_xor_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_xor(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_xor(a, b);

--- a/simde/arm/neon/ld1.h
+++ b/simde/arm/neon/ld1.h
@@ -200,7 +200,7 @@ simde_vld1q_f32(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld1q_f32(ptr);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_loadu_ps(ptr);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) && 0
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
     (void) ptr;
     return vec_ld(0, HEDLEY_REINTERPRET_CAST(const float*, ptr));
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
@@ -243,7 +243,7 @@ simde_vld1q_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld1q_s8(ptr);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_loadu_si128(SIMDE_ALIGN_CAST(const __m128i*, ptr));
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) && 0
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
     (void) ptr;
     return vec_ld(0, ptr);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
@@ -266,7 +266,7 @@ simde_vld1q_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld1q_s16(ptr);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_loadu_si128(SIMDE_ALIGN_CAST(const __m128i*, ptr));
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) && 0
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
     (void) ptr;
     return vec_ld(0, ptr);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
@@ -289,7 +289,7 @@ simde_vld1q_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld1q_s32(ptr);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_loadu_si128(SIMDE_ALIGN_CAST(const __m128i*, ptr));
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) && 0
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
     (void) ptr;
     return vec_ld(0, ptr);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
@@ -332,7 +332,7 @@ simde_vld1q_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld1q_u8(ptr);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_loadu_si128(SIMDE_ALIGN_CAST(const __m128i*, ptr));
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) && 0
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
     (void) ptr;
     return vec_ld(0, ptr);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
@@ -355,7 +355,7 @@ simde_vld1q_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld1q_u16(ptr);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_loadu_si128(SIMDE_ALIGN_CAST(const __m128i*, ptr));
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) && 0
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
     (void) ptr;
     return vec_ld(0, ptr);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
@@ -378,7 +378,7 @@ simde_vld1q_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld1q_u32(ptr);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_loadu_si128(SIMDE_ALIGN_CAST(const __m128i*, ptr));
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) && 0
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
     (void) ptr;
     return vec_ld(0, ptr);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)

--- a/simde/arm/neon/max.h
+++ b/simde/arm/neon/max.h
@@ -25,8 +25,8 @@
  *   2020      Sean Maher <seanptmaher@gmail.com>
  */
 
-#if !defined(SIMDE_ARM_NEON_MIN_H)
-#define SIMDE_ARM_NEON_MIN_H
+#if !defined(SIMDE_ARM_NEON_MAX_H)
+#define SIMDE_ARM_NEON_MAX_H
 
 #include "types.h"
 
@@ -437,4 +437,4 @@ simde_vmaxq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
 SIMDE_END_DECLS_
 HEDLEY_DIAGNOSTIC_POP
 
-#endif /* !defined(SIMDE_ARM_NEON_MIN_H) */
+#endif /* !defined(SIMDE_ARM_NEON_MAX_H) */

--- a/simde/arm/neon/mla.h
+++ b/simde/arm/neon/mla.h
@@ -277,7 +277,7 @@ simde_vmlaq_f32(simde_float32x4_t a, simde_float32x4_t b, simde_float32x4_t c) {
     return _mm_fmadd_ps(b, c, a);
   #elif defined(SIMDE_X86_SSE_NATIVE)
     return _mm_add_ps(_mm_mul_ps(b, c), a);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_madd(b, c, a);
   #else
     simde_float32x4_private

--- a/simde/arm/neon/orr.h
+++ b/simde/arm/neon/orr.h
@@ -281,7 +281,7 @@ simde_vorrq_s8(simde_int8x16_t a, simde_int8x16_t b) {
     return vorrq_s8(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_or_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_or(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_or(a, b);
@@ -315,7 +315,7 @@ simde_vorrq_s16(simde_int16x8_t a, simde_int16x8_t b) {
     return vorrq_s16(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_or_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_or(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_or(a, b);
@@ -349,7 +349,7 @@ simde_vorrq_s32(simde_int32x4_t a, simde_int32x4_t b) {
     return vorrq_s32(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_or_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_or(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_or(a, b);
@@ -417,7 +417,7 @@ simde_vorrq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
     return vorrq_u8(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_or_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_or(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_or(a, b);
@@ -451,7 +451,7 @@ simde_vorrq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
     return vorrq_u16(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_or_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_or(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_or(a, b);
@@ -485,7 +485,7 @@ simde_vorrq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
     return vorrq_u32(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_or_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_or(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_or(a, b);

--- a/simde/arm/neon/shl.h
+++ b/simde/arm/neon/shl.h
@@ -405,7 +405,7 @@ simde_vshlq_s8 (const simde_int8x16_t a, const simde_int8x16_t b) {
                                       _mm256_srav_epi16(a256, _mm256_abs_epi16(b256)),
                                       _mm256_cmpgt_epi16(_mm256_setzero_si256(), b256));
     return _mm256_cvtepi16_epi8(r256);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     vector signed char a_shl, a_shr;
     vector unsigned char b_abs, b_max;
     vector bool char b_mask;
@@ -460,7 +460,7 @@ simde_vshlq_s16 (const simde_int16x8_t a, const simde_int16x8_t b) {
                                       _mm256_cmpgt_epi32(_mm256_setzero_si256(), b256));
     r256 = _mm256_shuffle_epi8(r256, _mm256_set1_epi64x(0x0D0C090805040100));
     return _mm_set_epi64x(_mm256_extract_epi64(r256, 2), _mm256_extract_epi64(r256, 0));
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     vector signed short a_shl, a_shr;
     vector unsigned short b_abs, b_max;
     vector bool short b_mask;
@@ -509,7 +509,7 @@ simde_vshlq_s32 (const simde_int32x4_t a, const simde_int32x4_t b) {
     return _mm_blendv_epi8(_mm_sllv_epi32(a, b_),
                            _mm_srav_epi32(a, _mm_abs_epi32(b_)),
                            _mm_cmpgt_epi32(_mm_setzero_si128(), b_));
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     vector signed int a_shl, a_shr;
     vector unsigned int b_abs, b_max;
     vector bool int b_mask;
@@ -615,7 +615,7 @@ simde_vshlq_u8 (const simde_uint8x16_t a, const simde_int8x16_t b) {
                                       _mm256_srlv_epi16(a256, _mm256_abs_epi16(b256)),
                                       _mm256_cmpgt_epi16(_mm256_setzero_si256(), b256));
     return _mm256_cvtepi16_epi8(r256);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     vector unsigned char b_abs;
     vector bool char b_mask;
     b_abs = HEDLEY_REINTERPRET_CAST(vector unsigned char, vec_abs(b));
@@ -663,7 +663,7 @@ simde_vshlq_u16 (const simde_uint16x8_t a, const simde_int16x8_t b) {
                                       _mm256_cmpgt_epi32(_mm256_setzero_si256(), b256));
     r256 = _mm256_shuffle_epi8(r256, _mm256_set1_epi64x(0x0D0C090805040100));
     return _mm_set_epi64x(_mm256_extract_epi64(r256, 2), _mm256_extract_epi64(r256, 0));
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     vector unsigned short b_abs;
     vector bool short b_mask;
     b_abs = vec_and(HEDLEY_REINTERPRET_CAST(vector unsigned short,
@@ -710,7 +710,7 @@ simde_vshlq_u32 (const simde_uint32x4_t a, const simde_int32x4_t b) {
     return _mm_blendv_epi8(_mm_sllv_epi32(a, b_),
                            _mm_srlv_epi32(a, _mm_abs_epi32(b_)),
                            _mm_cmpgt_epi32(_mm_setzero_si128(), b_));
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     vector unsigned int b_abs;
     vector bool int b_mask;
     b_abs = vec_and(HEDLEY_REINTERPRET_CAST(vector unsigned int,

--- a/simde/arm/neon/shl_n.h
+++ b/simde/arm/neon/shl_n.h
@@ -295,7 +295,7 @@ simde_vshlq_n_s8 (const simde_int8x16_t a, const int n)
 }
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vshlq_n_s8(a, n) vshlq_n_s8((a), (n))
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_vshlq_n_s8(a, n) vec_sl((a), vec_splats(SIMDE_CHECKED_STATIC_CAST(unsigned char, int, (n))))
 #endif
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -330,7 +330,7 @@ simde_vshlq_n_s16 (const simde_int16x8_t a, const int n)
 }
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vshlq_n_s16(a, n) vshlq_n_s16((a), (n))
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_vshlq_n_s16(a, n) vec_sl((a), vec_splats(SIMDE_CHECKED_STATIC_CAST(unsigned short, int, (n))))
 #endif
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -365,7 +365,7 @@ simde_vshlq_n_s32 (const simde_int32x4_t a, const int n)
 }
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vshlq_n_s32(a, n) vshlq_n_s32((a), (n))
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_vshlq_n_s32(a, n) vec_sl((a), vec_splats(HEDLEY_STATIC_CAST(unsigned int, (n))))
 #endif
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -435,7 +435,7 @@ simde_vshlq_n_u8 (const simde_uint8x16_t a, const int n)
 }
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vshlq_n_u8(a, n) vshlq_n_u8((a), (n))
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_vshlq_n_u8(a, n) vec_sl((a), vec_splat_u8(n))
 #endif
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -470,7 +470,7 @@ simde_vshlq_n_u16 (const simde_uint16x8_t a, const int n)
 }
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vshlq_n_u16(a, n) vshlq_n_u16((a), (n))
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_vshlq_n_u16(a, n) vec_sl((a), vec_splat_u16(n))
 #endif
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -505,7 +505,7 @@ simde_vshlq_n_u32 (const simde_uint32x4_t a, const int n)
 }
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vshlq_n_u32(a, n) vshlq_n_u32((a), (n))
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_vshlq_n_u32(a, n) vec_sl((a), vec_splats(HEDLEY_STATIC_CAST(unsigned int, (n))))
 #endif
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)

--- a/simde/arm/neon/shr_n.h
+++ b/simde/arm/neon/shr_n.h
@@ -322,7 +322,7 @@ simde_vshrq_n_s8 (const simde_int8x16_t a, const int n)
 }
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vshrq_n_s8(a, n) vshrq_n_s8((a), (n))
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_vshrq_n_s8(a, n) vec_sra((a), vec_splat_u8(((n) == 8) ? 7 : (n)))
 #endif
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -358,7 +358,7 @@ simde_vshrq_n_s16 (const simde_int16x8_t a, const int n)
 }
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vshrq_n_s16(a, n) vshrq_n_s16((a), (n))
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_vshrq_n_s16(a, n) vec_sra((a), vec_splat_u16(((n) == 16) ? 15 : (n)))
 #endif
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -394,7 +394,7 @@ simde_vshrq_n_s32 (const simde_int32x4_t a, const int n)
 }
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vshrq_n_s32(a, n) vshrq_n_s32((a), (n))
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_vshrq_n_s32(a, n) \
     vec_sra((a), vec_splats(HEDLEY_STATIC_CAST(unsigned int, ((n) == 32) ? 31 : (n))))
 #endif
@@ -469,7 +469,7 @@ simde_vshrq_n_u8 (const simde_uint8x16_t a, const int n)
 }
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vshrq_n_u8(a, n) vshrq_n_u8((a), (n))
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_vshrq_n_u8(a, n) \
     (((n) == 8) ? vec_splat_u8(0) : vec_sr((a), vec_splat_u8(n)))
 #endif
@@ -509,7 +509,7 @@ simde_vshrq_n_u16 (const simde_uint16x8_t a, const int n)
 }
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vshrq_n_u16(a, n) vshrq_n_u16((a), (n))
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_vshrq_n_u16(a, n) \
     (((n) == 16) ? vec_splat_u16(0) : vec_sr((a), vec_splat_u16(n)))
 #endif
@@ -549,7 +549,7 @@ simde_vshrq_n_u32 (const simde_uint32x4_t a, const int n)
 }
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vshrq_n_u32(a, n) vshrq_n_u32((a), (n))
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_vshrq_n_u32(a, n) \
     (((n) == 32) ? vec_splat_u32(0) : vec_sr((a), vec_splats(HEDLEY_STATIC_CAST(unsigned int, (n)))))
 #endif

--- a/simde/arm/neon/st1.h
+++ b/simde/arm/neon/st1.h
@@ -188,7 +188,7 @@ void
 simde_vst1q_f32(simde_float32_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_float32x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst1q_f32(ptr, val);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) && 0
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
     vec_st(val, 0, ptr);
   #else
     simde_float32x4_private val_ = simde_float32x4_to_private(val);
@@ -220,7 +220,7 @@ void
 simde_vst1q_s8(int8_t ptr[HEDLEY_ARRAY_PARAM(16)], simde_int8x16_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst1q_s8(ptr, val);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) && 0
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
     vec_st(val, 0, ptr);
   #else
     simde_int8x16_private val_ = simde_int8x16_to_private(val);
@@ -237,7 +237,7 @@ void
 simde_vst1q_s16(int16_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_int16x8_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst1q_s16(ptr, val);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) && 0
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
     vec_st(val, 0, ptr);
   #else
     simde_int16x8_private val_ = simde_int16x8_to_private(val);
@@ -254,7 +254,7 @@ void
 simde_vst1q_s32(int32_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_int32x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst1q_s32(ptr, val);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) && 0
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
     vec_st(val, 0, ptr);
   #else
     simde_int32x4_private val_ = simde_int32x4_to_private(val);
@@ -286,7 +286,7 @@ void
 simde_vst1q_u8(uint8_t ptr[HEDLEY_ARRAY_PARAM(16)], simde_uint8x16_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst1q_u8(ptr, val);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) && 0
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
     vec_st(val, 0, ptr);
   #else
     simde_uint8x16_private val_ = simde_uint8x16_to_private(val);
@@ -303,7 +303,7 @@ void
 simde_vst1q_u16(uint16_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_uint16x8_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst1q_u16(ptr, val);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) && 0
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
     vec_st(val, 0, ptr);
   #else
     simde_uint16x8_private val_ = simde_uint16x8_to_private(val);
@@ -320,7 +320,7 @@ void
 simde_vst1q_u32(uint32_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_uint32x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst1q_u32(ptr, val);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) && 0
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
     vec_st(val, 0, ptr);
   #else
     simde_uint32x4_private val_ = simde_uint32x4_to_private(val);

--- a/simde/arm/neon/sub.h
+++ b/simde/arm/neon/sub.h
@@ -332,7 +332,7 @@ simde_vsubq_f32(simde_float32x4_t a, simde_float32x4_t b) {
     return vsubq_f32(a, b);
   #elif defined(SIMDE_X86_SSE_NATIVE)
     return _mm_sub_ps(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     SIMDE_POWER_ALTIVEC_VECTOR(float) a_ , b_, r_;
     a_ = a;
     b_ = b;
@@ -404,7 +404,7 @@ simde_vsubq_s8(simde_int8x16_t a, simde_int8x16_t b) {
     return vsubq_s8(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_sub_epi8(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_sub(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_i8x16_sub(a, b);
@@ -438,7 +438,7 @@ simde_vsubq_s16(simde_int16x8_t a, simde_int16x8_t b) {
     return vsubq_s16(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_sub_epi16(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_sub(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_i16x8_sub(a, b);
@@ -472,7 +472,7 @@ simde_vsubq_s32(simde_int32x4_t a, simde_int32x4_t b) {
     return vsubq_s32(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_sub_epi32(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_sub(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_i32x4_sub(a, b);
@@ -538,7 +538,7 @@ simde_uint8x16_t
 simde_vsubq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vsubq_u8(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_sub(a, b);
   #else
     simde_uint8x16_private
@@ -568,7 +568,7 @@ simde_uint16x8_t
 simde_vsubq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vsubq_u16(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_sub(a, b);
   #else
     simde_uint16x8_private
@@ -598,7 +598,7 @@ simde_uint32x4_t
 simde_vsubq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vsubq_u32(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_sub(a, b);
   #else
     simde_uint32x4_private

--- a/simde/arm/neon/types.h
+++ b/simde/arm/neon/types.h
@@ -232,7 +232,7 @@ SIMDE_ARM_NEON_TYPE_FLOAT_DEFINE_(64, 2, 16)
   typedef v128_t  simde_uint64x2_t;
   typedef v128_t simde_float32x4_t;
   typedef v128_t simde_float64x2_t;
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define SIMDE_ARM_NEON_NEED_PORTABLE_F32
   #define SIMDE_ARM_NEON_NEED_PORTABLE_F64
 

--- a/simde/simde-features.h
+++ b/simde/simde-features.h
@@ -297,7 +297,7 @@
     #define SIMDE_POWER_ALTIVEC_P5_NATIVE
   #endif
 #endif
-#if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   /* stdbool.h conflicts with the bool in altivec.h */
   #if defined(bool) && !defined(SIMDE_POWER_ALTIVEC_NO_UNDEF_BOOL_)
     #undef bool

--- a/simde/x86/avx.h
+++ b/simde/x86/avx.h
@@ -76,7 +76,7 @@ typedef union {
 
 #if defined(SIMDE_X86_AVX_NATIVE)
   SIMDE_ALIGN(32) __m256         n;
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)      altivec_u8[2];
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)     altivec_u16[2];
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)       altivec_u32[2];
@@ -134,7 +134,7 @@ typedef union {
 
 #if defined(SIMDE_X86_AVX_NATIVE)
   SIMDE_ALIGN(32) __m256d        n;
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)      altivec_u8[2];
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)     altivec_u16[2];
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)       altivec_u32[2];
@@ -192,7 +192,7 @@ typedef union {
 
 #if defined(SIMDE_X86_AVX_NATIVE)
   SIMDE_ALIGN(32) __m256i        n;
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)      altivec_u8[2];
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)     altivec_u16[2];
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)       altivec_u32[2];
@@ -1392,7 +1392,7 @@ simde_mm256_blend_ps (simde__m256 a, simde__m256 b, const int imm8)
 }
 #if defined(SIMDE_X86_AVX_NATIVE)
 #  define simde_mm256_blend_ps(a, b, imm8) _mm256_blend_ps(a, b, imm8)
-#elif defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
 #  define simde_mm256_blend_ps(a, b, imm8) \
       simde_mm256_set_m128( \
           simde_mm_blend_ps(simde_mm256_extractf128_ps(a, 1), simde_mm256_extractf128_ps(b, 1), (imm8) >> 4), \
@@ -1420,7 +1420,7 @@ simde_mm256_blend_pd (simde__m256d a, simde__m256d b, const int imm8)
 }
 #if defined(SIMDE_X86_AVX_NATIVE)
 #  define simde_mm256_blend_pd(a, b, imm8) _mm256_blend_pd(a, b, imm8)
-#elif defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
 #  define simde_mm256_blend_pd(a, b, imm8) \
       simde_mm256_set_m128d( \
           simde_mm_blend_pd(simde_mm256_extractf128_pd(a, 1), simde_mm256_extractf128_pd(b, 1), (imm8) >> 2), \
@@ -1443,7 +1443,7 @@ simde_mm256_blendv_ps (simde__m256 a, simde__m256 b, simde__m256 mask) {
     b_ = simde__m256_to_private(b),
     mask_ = simde__m256_to_private(mask);
 
-#if defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#if defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   r_.m128[0] = simde_mm_blendv_ps(a_.m128[0], b_.m128[0], mask_.m128[0]);
   r_.m128[1] = simde_mm_blendv_ps(a_.m128[1], b_.m128[1], mask_.m128[1]);
 #else
@@ -1473,7 +1473,7 @@ simde_mm256_blendv_pd (simde__m256d a, simde__m256d b, simde__m256d mask) {
     b_ = simde__m256d_to_private(b),
     mask_ = simde__m256d_to_private(mask);
 
-#if defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#if defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   r_.m128d[0] = simde_mm_blendv_pd(a_.m128d[0], b_.m128d[0], mask_.m128d[0]);
   r_.m128d[1] = simde_mm_blendv_pd(a_.m128d[1], b_.m128d[1], mask_.m128d[1]);
 #else

--- a/simde/x86/avx2.h
+++ b/simde/x86/avx2.h
@@ -521,7 +521,7 @@ simde_mm_blend_epi32(simde__m128i a, simde__m128i b, const int imm8)
 }
 #if defined(SIMDE_X86_AVX2_NATIVE)
 #  define simde_mm_blend_epi32(a, b, imm8) _mm_blend_epi32(a, b, imm8)
-#elif defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
 #  define simde_mm_blend_epi32(a, b, imm8) \
   simde_mm_castps_si128(simde_mm_blend_ps(simde_mm_castsi128_ps(a), simde_mm_castsi128_ps(b), (imm8)))
 #endif
@@ -548,7 +548,7 @@ simde_mm256_blend_epi16(simde__m256i a, simde__m256i b, const int imm8)
 }
 #if defined(SIMDE_X86_AVX2_NATIVE)
 #  define simde_mm256_blend_epi16(a, b, imm8) _mm256_blend_epi16(a, b, imm8)
-#elif defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
 #  define simde_mm256_blend_epi16(a, b, imm8) \
       simde_mm256_set_m128i( \
           simde_mm_blend_epi16(simde_mm256_extracti128_si256(a, 1), simde_mm256_extracti128_si256(b, 1), (imm8)), \
@@ -578,7 +578,7 @@ simde_mm256_blend_epi32(simde__m256i a, simde__m256i b, const int imm8)
 }
 #if defined(SIMDE_X86_AVX2_NATIVE)
 #  define simde_mm256_blend_epi32(a, b, imm8) _mm256_blend_epi32(a, b, imm8)
-#elif defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
 #  define simde_mm256_blend_epi32(a, b, imm8) \
       simde_mm256_set_m128i( \
           simde_mm_blend_epi32(simde_mm256_extracti128_si256(a, 1), simde_mm256_extracti128_si256(b, 1), (imm8) >> 4), \
@@ -602,7 +602,7 @@ simde_mm256_blendv_epi8(simde__m256i a, simde__m256i b, simde__m256i mask) {
     b_ = simde__m256i_to_private(b),
     mask_ = simde__m256i_to_private(mask);
 
-#if defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#if defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   r_.m128i_private[0] = simde__m128i_to_private(simde_mm_blendv_epi8(simde__m128i_from_private(a_.m128i_private[0]), simde__m128i_from_private(b_.m128i_private[0]), simde__m128i_from_private(mask_.m128i_private[0])));
   r_.m128i_private[1] = simde__m128i_to_private(simde_mm_blendv_epi8(simde__m128i_from_private(a_.m128i_private[1]), simde__m128i_from_private(b_.m128i_private[1]), simde__m128i_from_private(mask_.m128i_private[1])));
 #else
@@ -2610,7 +2610,7 @@ simde_mm256_slli_epi16 (simde__m256i a, const int imm8)
     r_,
     a_ = simde__m256i_to_private(a);
 
-  #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) sv = vec_splats(HEDLEY_STATIC_CAST(unsigned short, imm8));
     for (size_t i = 0 ; i < (sizeof(a_.altivec_i16) / sizeof(a_.altivec_i16[0])) ; i++) {
       r_.altivec_i16[i] = vec_sl(a_.altivec_i16[i], sv);
@@ -2647,7 +2647,7 @@ simde_mm256_slli_epi32 (simde__m256i a, const int imm8)
     r_,
     a_ = simde__m256i_to_private(a);
 
-  #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) sv = vec_splats(HEDLEY_STATIC_CAST(unsigned int, imm8));
     for (size_t i = 0 ; i < (sizeof(a_.altivec_i32) / sizeof(a_.altivec_i32[0])) ; i++) {
       r_.altivec_i32[i] = vec_sl(a_.altivec_i32[i], sv);
@@ -2930,7 +2930,7 @@ simde_mm256_srli_epi16 (simde__m256i a, const int imm8)
   if (imm8 > 15)
     return simde_mm256_setzero_si256();
 
-  #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) sv = vec_splats(HEDLEY_STATIC_CAST(unsigned short, imm8));
     for (size_t i = 0 ; i < (sizeof(a_.altivec_u16) / sizeof(a_.altivec_u16[0])) ; i++) {
       r_.altivec_u16[i] = vec_sr(a_.altivec_u16[i], sv);
@@ -2972,7 +2972,7 @@ simde_mm256_srli_epi32 (simde__m256i a, const int imm8) {
     r_,
     a_ = simde__m256i_to_private(a);
 
-  #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) sv = vec_splats(HEDLEY_STATIC_CAST(unsigned int, imm8));
     for (size_t i = 0 ; i < (sizeof(a_.altivec_u32) / sizeof(a_.altivec_u32[0])) ; i++) {
       r_.altivec_u32[i] = vec_sr(a_.altivec_u32[i], sv);

--- a/simde/x86/avx512f.h
+++ b/simde/x86/avx512f.h
@@ -104,7 +104,7 @@ typedef union {
 
 #if defined(SIMDE_X86_AVX512F_NATIVE)
   SIMDE_AVX512_ALIGN __m512         n;
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)      altivec_u8[4];
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)     altivec_u16[4];
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)       altivec_u32[4];
@@ -164,7 +164,7 @@ typedef union {
 
 #if defined(SIMDE_X86_AVX512F_NATIVE)
   SIMDE_AVX512_ALIGN __m512d        n;
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)      altivec_u8[4];
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)     altivec_u16[4];
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)       altivec_u32[4];
@@ -224,7 +224,7 @@ typedef union {
 
 #if defined(SIMDE_X86_AVX512F_NATIVE)
   SIMDE_AVX512_ALIGN __m512i        n;
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)      altivec_u8[4];
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)     altivec_u16[4];
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)       altivec_u32[4];

--- a/simde/x86/fma.h
+++ b/simde/x86/fma.h
@@ -80,7 +80,7 @@ simde__m128
 simde_mm_fmadd_ps (simde__m128 a, simde__m128 b, simde__m128 c) {
   #if defined(SIMDE_X86_FMA_NATIVE)
     return _mm_fmadd_ps(a, b, c);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     simde__m128_private
       a_ = simde__m128_to_private(a),
       b_ = simde__m128_to_private(b),

--- a/simde/x86/sse.h
+++ b/simde/x86/sse.h
@@ -95,7 +95,7 @@ typedef union {
   #endif
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
   SIMDE_ALIGN(16) v128_t         wasm_v128;
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)      altivec_u8;
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)     altivec_u16;
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)       altivec_u32;
@@ -117,7 +117,7 @@ typedef union {
    typedef float32x4_t simde__m128;
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
    typedef v128_t simde__m128;
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
    typedef SIMDE_POWER_ALTIVEC_VECTOR(float) simde__m128;
 #elif defined(SIMDE_VECTOR_SUBSCRIPT)
   typedef simde_float32 simde__m128 SIMDE_ALIGN(16) SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
@@ -167,7 +167,7 @@ simde__m128_to_private(simde__m128 v) {
   #endif
 #endif /* defined(SIMDE_ARM_NEON_A32V7_NATIVE) */
 
-#if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, SIMDE_POWER_ALTIVEC_VECTOR(signed char), altivec, i8)
   SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, SIMDE_POWER_ALTIVEC_VECTOR(signed short), altivec, i16)
   SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, SIMDE_POWER_ALTIVEC_VECTOR(signed int), altivec, i32)
@@ -198,7 +198,7 @@ simde__m128_to_private(simde__m128 v) {
     SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, SIMDE_POWER_ALTIVEC_VECTOR(signed long long), altivec, i64)
     SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), altivec, u64)
   #endif
-#endif /* defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) */
+#endif /* defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) */
 
 enum {
 #if defined(SIMDE_X86_SSE_NATIVE)
@@ -396,7 +396,7 @@ simde_mm_round_ps (simde__m128 a, int rounding)
    * used, so we treat ARMv7 as having a rounding mode but ARMv8 as
    * not. */
   #if \
-      defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) || \
+      defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
       defined(SIMDE_ARM_NEON_A32V8)
     if ((rounding & 7) == SIMDE_MM_FROUND_CUR_DIRECTION)
       rounding = HEDLEY_STATIC_CAST(int, SIMDE_MM_GET_ROUNDING_MODE()) << 13;
@@ -404,7 +404,7 @@ simde_mm_round_ps (simde__m128 a, int rounding)
 
   switch (rounding & ~SIMDE_MM_FROUND_NO_EXC) {
     case SIMDE_MM_FROUND_CUR_DIRECTION:
-      #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+      #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
         r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_round(a_.altivec_f32));
       #elif defined(SIMDE_ARM_NEON_A32V8_NATIVE) && 0
         r_.neon_f32 = vrndiq_f32(a_.neon_f32);
@@ -419,7 +419,7 @@ simde_mm_round_ps (simde__m128 a, int rounding)
       break;
 
     case SIMDE_MM_FROUND_TO_NEAREST_INT:
-      #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+      #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
         r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_round(a_.altivec_f32));
       #elif defined(SIMDE_ARM_NEON_A32V8_NATIVE) && 0
         r_.neon_f32 = vrndaq_f32(a_.neon_f32);
@@ -434,7 +434,7 @@ simde_mm_round_ps (simde__m128 a, int rounding)
       break;
 
     case SIMDE_MM_FROUND_TO_NEG_INF:
-      #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+      #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
         r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_floor(a_.altivec_f32));
       #elif defined(SIMDE_ARM_NEON_A32V8_NATIVE) && 0
         r_.neon_f32 = vrndmq_f32(a_.neon_f32);
@@ -449,7 +449,7 @@ simde_mm_round_ps (simde__m128 a, int rounding)
       break;
 
     case SIMDE_MM_FROUND_TO_POS_INF:
-      #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+      #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
         r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_ceil(a_.altivec_f32));
       #elif defined(SIMDE_ARM_NEON_A32V8_NATIVE) && 0
         r_.neon_f32 = vrndpq_f32(a_.neon_f32);
@@ -464,7 +464,7 @@ simde_mm_round_ps (simde__m128 a, int rounding)
       break;
 
     case SIMDE_MM_FROUND_TO_ZERO:
-      #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+      #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
         r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_trunc(a_.altivec_f32));
       #elif defined(SIMDE_ARM_NEON_A32V8_NATIVE) && 0
         r_.neon_f32 = vrndq_f32(a_.neon_f32);
@@ -525,7 +525,7 @@ simde_mm_set_ps1 (simde_float32 a) {
   return _mm_set_ps1(a);
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   return vdupq_n_f32(a);
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   (void) a;
   return vec_splats(a);
 #else
@@ -551,7 +551,7 @@ simde_mm_move_ss (simde__m128 a, simde__m128 b) {
 
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   r_.neon_f32 = vsetq_lane_f32(vgetq_lane_f32(b_.neon_f32, 0), a_.neon_f32, 0);
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) m = {
     16, 17, 18, 19,
      4,  5,  6,  7,
@@ -592,7 +592,7 @@ simde_mm_add_ps (simde__m128 a, simde__m128 b) {
     r_.neon_f32 = vaddq_f32(a_.neon_f32, b_.neon_f32);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_f32x4_add(a_.wasm_v128, b_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_f32 = vec_add(a_.altivec_f32, b_.altivec_f32);
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.f32 = a_.f32 + b_.f32;
@@ -659,7 +659,7 @@ simde_mm_and_ps (simde__m128 a, simde__m128 b) {
     r_.wasm_v128 = wasm_v128_and(a_.wasm_v128, b_.wasm_v128);
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i32 = a_.i32 & b_.i32;
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_f32 = vec_and(a_.altivec_f32, b_.altivec_f32);
   #else
     SIMDE_VECTORIZE
@@ -690,7 +690,7 @@ simde_mm_andnot_ps (simde__m128 a, simde__m128 b) {
     r_.neon_i32 = vbicq_s32(b_.neon_i32, a_.neon_i32);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_v128_andnot(b_.wasm_v128, a_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_f32 = vec_andc(b_.altivec_f32, a_.altivec_f32);
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i32 = ~a_.i32 & b_.i32;
@@ -721,7 +721,7 @@ simde_mm_xor_ps (simde__m128 a, simde__m128 b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_i32 = veorq_s32(a_.neon_i32, b_.neon_i32);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i32 = vec_xor(a_.altivec_i32, b_.altivec_i32);
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i32f = a_.i32f ^ b_.i32f;
@@ -752,7 +752,7 @@ simde_mm_or_ps (simde__m128 a, simde__m128 b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_i32 = vorrq_s32(a_.neon_i32, b_.neon_i32);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i32 = vec_or(a_.altivec_i32, b_.altivec_i32);
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i32f = a_.i32f | b_.i32f;
@@ -859,7 +859,7 @@ simde_mm_cmpeq_ps (simde__m128 a, simde__m128 b) {
     r_.neon_u32 = vceqq_f32(a_.neon_f32, b_.neon_f32);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_f32x4_eq(a_.wasm_v128, b_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_cmpeq(a_.altivec_f32, b_.altivec_f32));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), a_.f32 == b_.f32);
@@ -918,7 +918,7 @@ simde_mm_cmpge_ps (simde__m128 a, simde__m128 b) {
     r_.neon_u32 = vcgeq_f32(a_.neon_f32, b_.neon_f32);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_f32x4_ge(a_.wasm_v128, b_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_cmpge(a_.altivec_f32, b_.altivec_f32));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 >= b_.f32));
@@ -977,7 +977,7 @@ simde_mm_cmpgt_ps (simde__m128 a, simde__m128 b) {
     r_.neon_u32 = vcgtq_f32(a_.neon_f32, b_.neon_f32);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_f32x4_gt(a_.wasm_v128, b_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_cmpgt(a_.altivec_f32, b_.altivec_f32));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 > b_.f32));
@@ -1036,7 +1036,7 @@ simde_mm_cmple_ps (simde__m128 a, simde__m128 b) {
     r_.neon_u32 = vcleq_f32(a_.neon_f32, b_.neon_f32);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_f32x4_le(a_.wasm_v128, b_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_cmple(a_.altivec_f32, b_.altivec_f32));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 <= b_.f32));
@@ -1095,7 +1095,7 @@ simde_mm_cmplt_ps (simde__m128 a, simde__m128 b) {
     r_.neon_u32 = vcltq_f32(a_.neon_f32, b_.neon_f32);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_f32x4_lt(a_.wasm_v128, b_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_cmplt(a_.altivec_f32, b_.altivec_f32));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 < b_.f32));
@@ -2246,7 +2246,7 @@ simde_mm_load_ps (simde_float32 const mem_addr[HEDLEY_ARRAY_PARAM(4)]) {
     r_.neon_f32 = vld1q_f32(mem_addr);
   #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     r_.altivec_f32 = vec_vsx_ld(0, mem_addr);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_f32 = vec_ld(0, mem_addr);
   #else
     r_ = *SIMDE_ALIGN_CAST(simde__m128_private const*, mem_addr);
@@ -2494,7 +2494,7 @@ simde_mm_max_ps (simde__m128 a, simde__m128 b) {
 
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_f32 = vmaxq_f32(a_.neon_f32, b_.neon_f32);
-    #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
       r_.altivec_f32 = vec_max(a_.altivec_f32, b_.altivec_f32);
     #else
       SIMDE_VECTORIZE
@@ -2605,7 +2605,7 @@ simde_mm_min_ps (simde__m128 a, simde__m128 b) {
     return _mm_min_ps(a, b);
   #elif defined(SIMDE_FAST_NANS) && defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return simde__m128_from_neon_f32(vminq_f32(simde__m128_to_neon_f32(a), simde__m128_to_neon_f32(b)));
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     simde__m128_private
       r_,
       a_ = simde__m128_to_private(a),
@@ -2962,7 +2962,7 @@ simde_mm_rcp_ps (simde__m128 a) {
       #endif
 
       r_.neon_f32 = recip;
-    #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
       r_.altivec_f32 = vec_re(a_.altivec_f32);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
       r_.f32 = 1.0f / a_.f32;
@@ -3190,7 +3190,7 @@ simde_mm_setzero_ps (void) {
   return _mm_setzero_ps();
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   return vdupq_n_f32(SIMDE_FLOAT32_C(0.0));
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   return vec_splats(SIMDE_FLOAT32_C(0.0));
 #else
   simde__m128 r;

--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -97,7 +97,7 @@ typedef union {
   #endif
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
   SIMDE_ALIGN(16) v128_t         wasm_v128;
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed char)          altivec_i8;
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed short)         altivec_i16;
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed int)           altivec_i32;
@@ -172,7 +172,7 @@ typedef union {
   #endif
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
   SIMDE_ALIGN(16) v128_t         wasm_v128;
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed char)          altivec_i8;
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed short)         altivec_i16;
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed int)           altivec_i32;
@@ -213,7 +213,7 @@ typedef union {
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
    typedef v128_t simde__m128i;
    typedef v128_t simde__m128d;
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   typedef SIMDE_POWER_ALTIVEC_VECTOR(float) simde__m128i;
   #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
      typedef SIMDE_POWER_ALTIVEC_VECTOR(double) simde__m128d;
@@ -289,7 +289,7 @@ simde__m128d_to_private(simde__m128d v) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, float64x2_t, neon, f64)
   #endif
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed char), altivec, i8)
   SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed short), altivec, i16)
   SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed int), altivec, i32)
@@ -315,7 +315,7 @@ simde__m128d_to_private(simde__m128d v) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, float64x2_t, neon, f64)
   #endif
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed char), altivec, i8)
   SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed short), altivec, i16)
   SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed int), altivec, i32)
@@ -359,7 +359,7 @@ simde_mm_add_epi8 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_i8 = vaddq_s8(a_.neon_i8, b_.neon_i8);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i8 = vec_add(a_.altivec_i8, b_.altivec_i8);
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i8 = a_.i8 + b_.i8;
@@ -390,7 +390,7 @@ simde_mm_add_epi16 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_i16 = vaddq_s16(a_.neon_i16, b_.neon_i16);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i16 = vec_add(a_.altivec_i16, b_.altivec_i16);
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i16 = a_.i16 + b_.i16;
@@ -421,7 +421,7 @@ simde_mm_add_epi32 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_i32 = vaddq_s32(a_.neon_i32, b_.neon_i32);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i32 = vec_add(a_.altivec_i32, b_.altivec_i32);
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i32 = a_.i32 + b_.i32;
@@ -601,7 +601,7 @@ simde_mm_adds_epi8 (simde__m128i a, simde__m128i b) {
 
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   r_.neon_i8 = vqaddq_s8(a_.neon_i8, b_.neon_i8);
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   r_.altivec_i8 = vec_adds(a_.altivec_i8, b_.altivec_i8);
 #else
   SIMDE_VECTORIZE
@@ -634,7 +634,7 @@ simde_mm_adds_epi16 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_i16 = vqaddq_s16(a_.neon_i16, b_.neon_i16);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i16 = vec_adds(a_.altivec_i16, b_.altivec_i16);
   #else
     SIMDE_VECTORIZE
@@ -666,7 +666,7 @@ simde_mm_adds_epu8 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_u8 = vqaddq_u8(a_.neon_u8, b_.neon_u8);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_u8 = vec_adds(a_.altivec_u8, b_.altivec_u8);
   #else
     SIMDE_VECTORIZE
@@ -695,7 +695,7 @@ simde_mm_adds_epu16 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_u16 = vqaddq_u16(a_.neon_u16, b_.neon_u16);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_u16 = vec_adds(a_.altivec_u16, b_.altivec_u16);
   #else
     SIMDE_VECTORIZE
@@ -757,7 +757,7 @@ simde_mm_and_si128 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_i32 = vandq_s32(b_.neon_i32, a_.neon_i32);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_u32f = vec_and(a_.altivec_u32f, b_.altivec_u32f);
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i32f = a_.i32f & b_.i32f;
@@ -790,7 +790,7 @@ simde_mm_andnot_pd (simde__m128d a, simde__m128d b) {
   r_.neon_i32 = vbicq_s32(a_.neon_i32, b_.neon_i32);
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
   r_.wasm_v128 = wasm_v128_andnot(b_.wasm_v128, a_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   r_.altivec_i32f = vec_andc(a_.altivec_i32f, b_.altivec_i32f);
 #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
   r_.i32f = ~a_.i32f & b_.i32f;
@@ -821,7 +821,7 @@ simde_mm_andnot_si128 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_i32 = vbicq_s32(b_.neon_i32, a_.neon_i32);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i32 = vec_andc(b_.altivec_i32, a_.altivec_i32);
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i32f = ~a_.i32f & b_.i32f;
@@ -852,7 +852,7 @@ simde_mm_avg_epu8 (simde__m128i a, simde__m128i b) {
 
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   r_.neon_u8 = vrhaddq_u8(b_.neon_u8, a_.neon_u8);
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   r_.altivec_u8 = vec_avg(a_.altivec_u8, b_.altivec_u8);
 #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && defined(SIMDE_CONVERT_VECTOR_)
   uint16_t wa SIMDE_VECTOR(32);
@@ -889,7 +889,7 @@ simde_mm_avg_epu16 (simde__m128i a, simde__m128i b) {
 
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   r_.neon_u16 = vrhaddq_u16(b_.neon_u16, a_.neon_u16);
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   r_.altivec_u16 = vec_avg(a_.altivec_u16, b_.altivec_u16);
 #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && defined(SIMDE_CONVERT_VECTOR_)
   uint32_t wa SIMDE_VECTOR(32);
@@ -923,7 +923,7 @@ simde_mm_setzero_si128 (void) {
 
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_i32 = vdupq_n_s32(0);
-    #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
       r_.altivec_i32 = vec_splats(HEDLEY_STATIC_CAST(signed int, 0));
     #elif defined(SIMDE_VECTOR_SUBSCRIPT)
       r_.i32 = __extension__ (__typeof__(r_.i32)) { 0, 0, 0, 0 };
@@ -953,7 +953,7 @@ simde_mm_bslli_si128 (simde__m128i a, const int imm8)
     return simde_mm_setzero_si128();
   }
 
-  #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) && defined(SIMDE_ENDIAN_ORDER)
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && defined(SIMDE_ENDIAN_ORDER)
     r_.altivec_i8 =
     #if (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
       vec_slo
@@ -977,7 +977,7 @@ simde_mm_bslli_si128 (simde__m128i a, const int imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
 #  define simde_mm_bslli_si128(a, imm8) \
   simde__m128i_from_neon_i8(((imm8) <= 0) ? simde__m128i_to_neon_i8(a) : (((imm8) > 15) ? (vdupq_n_s8(0)) : (vextq_s8(vdupq_n_s8(0), simde__m128i_to_neon_i8(a), 16 - (imm8)))))
-#elif defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_mm_bslli_si128(a, imm8) (__extension__ ({ \
     const simde__m128i_private simde__tmp_a_ = simde__m128i_to_private(a); \
     const simde__m128i_private simde__tmp_z_ = simde__m128i_to_private(simde_mm_setzero_si128()); \
@@ -1026,7 +1026,7 @@ simde_mm_bsrli_si128 (simde__m128i a, const int imm8)
     return simde_mm_setzero_si128();
   }
 
-  #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) && defined(SIMDE_ENDIAN_ORDER)
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && defined(SIMDE_ENDIAN_ORDER)
     r_.altivec_i8 =
     #if (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
       vec_sro
@@ -1049,7 +1049,7 @@ simde_mm_bsrli_si128 (simde__m128i a, const int imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
 #  define simde_mm_bsrli_si128(a, imm8) \
   simde__m128i_from_neon_i8(((imm8 < 0) || (imm8 > 15)) ? vdupq_n_s8(0) : (vextq_s8(simde__m128i_to_private(a).neon_i8, vdupq_n_s8(0), ((imm8 & 15) != 0) ? imm8 : (imm8 & 15))))
-#elif defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_mm_bsrli_si128(a, imm8) (__extension__ ({ \
     const simde__m128i_private simde__tmp_a_ = simde__m128i_to_private(a); \
     const simde__m128i_private simde__tmp_z_ = simde__m128i_to_private(simde_mm_setzero_si128()); \
@@ -1301,7 +1301,7 @@ simde__m128
 simde_mm_castsi128_ps (simde__m128i a) {
 #if defined(SIMDE_X86_SSE2_NATIVE)
   return _mm_castsi128_ps(a);
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), a);
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   return simde__m128_from_neon_i32(simde__m128i_to_private(a).neon_i32);
@@ -1330,7 +1330,7 @@ simde_mm_cmpeq_epi8 (simde__m128i a, simde__m128i b) {
     r_.neon_u8 = vceqq_s8(b_.neon_i8, a_.neon_i8);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_i8x16_eq(a_.wasm_v128, b_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i8 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), vec_cmpeq(a_.altivec_i8, b_.altivec_i8));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i8 = HEDLEY_STATIC_CAST(__typeof__(r_.i8), (a_.i8 == b_.i8));
@@ -1363,7 +1363,7 @@ simde_mm_cmpeq_epi16 (simde__m128i a, simde__m128i b) {
     r_.neon_u16 = vceqq_s16(b_.neon_i16, a_.neon_i16);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_i16x8_eq(a_.wasm_v128, b_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i16 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed short), vec_cmpeq(a_.altivec_i16, b_.altivec_i16));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i16 = (a_.i16 == b_.i16);
@@ -1396,7 +1396,7 @@ simde_mm_cmpeq_epi32 (simde__m128i a, simde__m128i b) {
     r_.neon_u32 = vceqq_s32(b_.neon_i32, a_.neon_i32);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_i32x4_eq(a_.wasm_v128, b_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int), vec_cmpeq(a_.altivec_i32, b_.altivec_i32));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), a_.i32 == b_.i32);
@@ -1538,7 +1538,7 @@ simde_mm_cmplt_epi8 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_u8 = vcltq_s8(a_.neon_i8, b_.neon_i8);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i8 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char),vec_cmplt(a_.altivec_i8, b_.altivec_i8));
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_i8x16_lt(a_.wasm_v128, b_.wasm_v128);
@@ -1571,7 +1571,7 @@ simde_mm_cmplt_epi16 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_u16 = vcltq_s16(a_.neon_i16, b_.neon_i16);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i16 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed short), vec_cmplt(a_.altivec_i16, b_.altivec_i16));
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_i16x8_lt(a_.wasm_v128, b_.wasm_v128);
@@ -1604,7 +1604,7 @@ simde_mm_cmplt_epi32 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_u32 = vcltq_s32(a_.neon_i32, b_.neon_i32);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int), vec_cmplt(a_.altivec_i32, b_.altivec_i32));
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_i32x4_lt(a_.wasm_v128, b_.wasm_v128);
@@ -1691,7 +1691,7 @@ simde_mm_cmple_pd (simde__m128d a, simde__m128d b) {
     r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 <= b_.f64));
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_f64x2_le(a_.wasm_v128, b_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmple(a_.altivec_f64, b_.altivec_f64));
   #else
     SIMDE_VECTORIZE
@@ -1745,7 +1745,7 @@ simde_mm_cmpgt_epi8 (simde__m128i a, simde__m128i b) {
     r_.neon_u8 = vcgtq_s8(a_.neon_i8, b_.neon_i8);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_i8x16_gt(a_.wasm_v128, b_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i8 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), vec_cmpgt(a_.altivec_i8, b_.altivec_i8));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i8 = HEDLEY_STATIC_CAST(__typeof__(r_.i8), (a_.i8 > b_.i8));
@@ -1778,7 +1778,7 @@ simde_mm_cmpgt_epi16 (simde__m128i a, simde__m128i b) {
     r_.neon_u16 = vcgtq_s16(a_.neon_i16, b_.neon_i16);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_i16x8_gt(a_.wasm_v128, b_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i16 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed short), vec_cmpgt(a_.altivec_i16, b_.altivec_i16));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i16 = HEDLEY_STATIC_CAST(__typeof__(r_.i16), (a_.i16 > b_.i16));
@@ -1811,7 +1811,7 @@ simde_mm_cmpgt_epi32 (simde__m128i a, simde__m128i b) {
     r_.neon_u32 = vcgtq_s32(a_.neon_i32, b_.neon_i32);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_i32x4_gt(a_.wasm_v128, b_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int), vec_cmpgt(a_.altivec_i32, b_.altivec_i32));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.i32 > b_.i32));
@@ -1844,7 +1844,7 @@ simde_mm_cmpgt_pd (simde__m128d a, simde__m128d b) {
     r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 > b_.f64));
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_f64x2_gt(a_.wasm_v128, b_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_f64 = HEDLEY_STATIC_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmpgt(a_.altivec_f64, b_.altivec_f64));
   #else
     SIMDE_VECTORIZE
@@ -1898,7 +1898,7 @@ simde_mm_cmpge_pd (simde__m128d a, simde__m128d b) {
     r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 >= b_.f64));
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_f64x2_ge(a_.wasm_v128, b_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_f64 = HEDLEY_STATIC_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmpge(a_.altivec_f64, b_.altivec_f64));
   #else
     SIMDE_VECTORIZE
@@ -2174,7 +2174,7 @@ simde_mm_cvtepi32_ps (simde__m128i a) {
 
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   r_.neon_f32 = vcvtq_f32_s32(a_.neon_i32);
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   HEDLEY_DIAGNOSTIC_PUSH
   #if HEDLEY_HAS_WARNING("-Wc11-extensions")
     #pragma clang diagnostic ignored "-Wc11-extensions"
@@ -2317,7 +2317,7 @@ simde_mm_cvtps_epi32 (simde__m128 a) {
     uint32x4_t is_delta_half = vceqq_f32(delta, half); /* delta == +/- 0.5 */
     r_.neon_i32 = vbslq_s32(is_delta_half, r_even, r_normal);
   #endif
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   r_.altivec_i32 = vec_cts(vec_round(a_.altivec_f32), 0);
 #else
   SIMDE_VECTORIZE
@@ -2428,7 +2428,7 @@ simde_mm_cvtsi128_si32 (simde__m128i a) {
 
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       return vgetq_lane_s32(a_.neon_i32, 0);
-    #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
       #if defined(SIMDE_BUG_GCC_95227)
         (void) a_;
       #endif
@@ -2756,7 +2756,7 @@ simde_mm_extract_epi16 (simde__m128i a, const int imm8)
   uint16_t r;
   simde__m128i_private a_ = simde__m128i_to_private(a);
 
-  #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     #if defined(SIMDE_BUG_GCC_95227)
       (void) a_;
       (void) imm8;
@@ -2866,10 +2866,10 @@ simde_mm_load_si128 (simde__m128i const* mem_addr) {
 
   #if defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_load_si128(HEDLEY_REINTERPRET_CAST(__m128i const*, mem_addr));
-  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     simde__m128i_private r_;
 
-    #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
       r_.altivec_i32 = vec_ld(0, HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(int) const*, mem_addr));
     #else
       r_.neon_i32 = vld1q_s32(HEDLEY_REINTERPRET_CAST(int32_t const*, mem_addr));
@@ -3315,7 +3315,7 @@ simde_mm_min_epi16 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_i16 = vminq_s16(a_.neon_i16, b_.neon_i16);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i16 = vec_min(a_.altivec_i16, b_.altivec_i16);
   #else
     SIMDE_VECTORIZE
@@ -3344,7 +3344,7 @@ simde_mm_min_epu8 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_u8 = vminq_u8(a_.neon_u8, b_.neon_u8);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_u8 = vec_min(a_.altivec_u8, b_.altivec_u8);
   #else
     SIMDE_VECTORIZE
@@ -3423,7 +3423,7 @@ simde_mm_max_epi16 (simde__m128i a, simde__m128i b) {
 
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_i16 = vmaxq_s16(a_.neon_i16, b_.neon_i16);
-    #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
       r_.altivec_i16 = vec_max(a_.altivec_i16, b_.altivec_i16);
     #else
       SIMDE_VECTORIZE
@@ -3452,7 +3452,7 @@ simde_mm_max_epu8 (simde__m128i a, simde__m128i b) {
 
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_u8 = vmaxq_u8(a_.neon_u8, b_.neon_u8);
-    #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
       r_.altivec_u8 = vec_max(a_.altivec_u8, b_.altivec_u8);
     #else
       SIMDE_VECTORIZE
@@ -3765,7 +3765,7 @@ simde_mm_mullo_epi16 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_i16 = vmulq_s16(a_.neon_i16, b_.neon_i16);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     (void) a_;
     (void) b_;
     r_.altivec_i16 = vec_mul(a_.altivec_i16, b_.altivec_i16);
@@ -3823,7 +3823,7 @@ simde_mm_or_si128 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_i32 = vorrq_s32(a_.neon_i32, b_.neon_i32);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i32 = vec_or(a_.altivec_i32, b_.altivec_i32);
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i32f = a_.i32f | b_.i32f;
@@ -3882,7 +3882,7 @@ simde_mm_packs_epi32 (simde__m128i a, simde__m128i b) {
 
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   r_.neon_i16 = vcombine_s16(vqmovn_s32(a_.neon_i32), vqmovn_s32(b_.neon_i32));
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   r_.altivec_i16 = vec_packs(a_.altivec_i32, b_.altivec_i32);
 #else
   SIMDE_VECTORIZE
@@ -3912,7 +3912,7 @@ simde_mm_packus_epi16 (simde__m128i a, simde__m128i b) {
 
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   r_.neon_u8 = vcombine_u8(vqmovun_s16(a_.neon_i16), vqmovun_s16(b_.neon_i16));
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   r_.altivec_u8 = vec_packsu(a_.altivec_i16, b_.altivec_i16);
 #else
   SIMDE_VECTORIZE
@@ -5939,7 +5939,7 @@ simde_mm_subs_epu8 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_u8 = vqsubq_u8(a_.neon_u8, b_.neon_u8);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_u8 = vec_subs(a_.altivec_u8, b_.altivec_u8);
   #else
     SIMDE_VECTORIZE
@@ -5975,7 +5975,7 @@ simde_mm_subs_epu16 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_u16 = vqsubq_u16(a_.neon_u16, b_.neon_u16);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_u16 = vec_subs(a_.altivec_u16, b_.altivec_u16);
   #else
     SIMDE_VECTORIZE
@@ -6571,7 +6571,7 @@ simde_mm_xor_si128 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_i32 = veorq_s32(a_.neon_i32, b_.neon_i32);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i32 = vec_xor(a_.altivec_i32, b_.altivec_i32);
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i32f = a_.i32f ^ b_.i32f;

--- a/simde/x86/sse4.1.h
+++ b/simde/x86/sse4.1.h
@@ -72,7 +72,7 @@ simde_mm_blend_epi16 (simde__m128i a, simde__m128i b, const int imm8)
            uint16x8_t _mask_vec = vld1q_u16(_mask);  \
            simde__m128i_from_neon_u16(vbslq_u16(_mask_vec, simde__m128i_to_neon_u16(b), simde__m128i_to_neon_u16(a))); \
        }))
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
 #  define simde_mm_blend_epi16(a, b, imm8)      \
      (__extension__ ({ \
            const vector unsigned short _mask = {      \
@@ -197,7 +197,7 @@ simde_mm_blendv_epi8 (simde__m128i a, simde__m128i b, simde__m128i mask) {
     // Use a signed shift right to create a mask with the sign bit
     mask_.neon_i8 = vshrq_n_s8(mask_.neon_i8, 7);
     r_.neon_i8 = vbslq_s8(mask_.neon_u8, b_.neon_i8, a_.neon_i8);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i8 = vec_sel(a_.altivec_i8, b_.altivec_i8, vec_cmplt(mask_.altivec_i8, vec_splat_s8(0)));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     /* https://software.intel.com/en-us/forums/intel-c-compiler/topic/850087 */
@@ -241,7 +241,7 @@ simde_x_mm_blendv_epi16 (simde__m128i a, simde__m128i b, simde__m128i mask) {
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   mask_ = simde__m128i_to_private(simde_mm_cmplt_epi16(mask, simde_mm_setzero_si128()));
   r_.neon_i16 = vbslq_s16(mask_.neon_u16, b_.neon_i16, a_.neon_i16);
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   r_.altivec_i16 = vec_sel(a_.altivec_i16, b_.altivec_i16, vec_cmplt(mask_.altivec_i16, vec_splat_s16(0)));
 #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
   #if defined(HEDLEY_INTEL_VERSION_CHECK)
@@ -279,7 +279,7 @@ simde_x_mm_blendv_epi32 (simde__m128i a, simde__m128i b, simde__m128i mask) {
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   mask_ = simde__m128i_to_private(simde_mm_cmplt_epi32(mask, simde_mm_setzero_si128()));
   r_.neon_i32 = vbslq_s32(mask_.neon_u32, b_.neon_i32, a_.neon_i32);
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   r_.altivec_i32 = vec_sel(a_.altivec_i32, b_.altivec_i32, vec_cmplt(mask_.altivec_i32, vec_splat_s32(0)));
 #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
   #if defined(HEDLEY_INTEL_VERSION_CHECK)
@@ -378,7 +378,7 @@ simde_mm_round_pd (simde__m128d a, int rounding)
     a_ = simde__m128d_to_private(a);
 
   /* For architectures which lack a current direction SIMD instruction. */
-  #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     if ((rounding & 7) == SIMDE_MM_FROUND_CUR_DIRECTION)
       rounding = HEDLEY_STATIC_CAST(int, SIMDE_MM_GET_ROUNDING_MODE()) << 13;
   #endif
@@ -561,7 +561,7 @@ simde_mm_cmpeq_epi64 (simde__m128i a, simde__m128i b) {
     r_.neon_u32 = vandq_u32(cmp, swapped);
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), a_.i64 == b_.i64);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i64 = (vector signed long long) vec_cmpeq(a_.altivec_i64, b_.altivec_i64);
   #else
     SIMDE_VECTORIZE
@@ -1008,7 +1008,7 @@ simde_mm_extract_epi8 (simde__m128i a, const int imm8)
   simde__m128i_private
     a_ = simde__m128i_to_private(a);
 
-  #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     #if defined(SIMDE_BUG_GCC_95227)
       (void) a_;
       (void) imm8;
@@ -1038,7 +1038,7 @@ simde_mm_extract_epi32 (simde__m128i a, const int imm8)
   simde__m128i_private
     a_ = simde__m128i_to_private(a);
 
-  #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     #if defined(SIMDE_BUG_GCC_95227)
       (void) a_;
       (void) imm8;
@@ -1052,7 +1052,7 @@ simde_mm_extract_epi32 (simde__m128i a, const int imm8)
 #  define simde_mm_extract_epi32(a, imm8) _mm_extract_epi32(a, imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
 #  define simde_mm_extract_epi32(a, imm8) vgetq_lane_s32(simde__m128i_to_private(a).neon_i32, imm8)
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
 #  define simde_mm_extract_epi32(a, imm8) HEDLEY_STATIC_CAST(int32_t, vec_extract(simde__m128i_to_private(a).altivec_i32, imm8))
 #endif
 #if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
@@ -1298,7 +1298,7 @@ simde_mm_max_epi8 (simde__m128i a, simde__m128i b) {
 
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_i8 = vmaxq_s8(a_.neon_i8, b_.neon_i8);
-    #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
       r_.altivec_i8 = vec_max(a_.altivec_i8, b_.altivec_i8);
     #else
       SIMDE_VECTORIZE
@@ -1328,7 +1328,7 @@ simde_mm_max_epi32 (simde__m128i a, simde__m128i b) {
 
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_i32 = vmaxq_s32(a_.neon_i32, b_.neon_i32);
-    #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
       r_.altivec_i32 = vec_max(a_.altivec_i32, b_.altivec_i32);
     #else
       SIMDE_VECTORIZE
@@ -1358,7 +1358,7 @@ simde_mm_max_epu16 (simde__m128i a, simde__m128i b) {
 
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_u16 = vmaxq_u16(a_.neon_u16, b_.neon_u16);
-    #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
       r_.altivec_u16 = vec_max(a_.altivec_u16, b_.altivec_u16);
     #else
       SIMDE_VECTORIZE
@@ -1388,7 +1388,7 @@ simde_mm_max_epu32 (simde__m128i a, simde__m128i b) {
 
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_u32 = vmaxq_u32(a_.neon_u32, b_.neon_u32);
-    #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
       r_.altivec_u32 = vec_max(a_.altivec_u32, b_.altivec_u32);
     #else
       SIMDE_VECTORIZE
@@ -1623,7 +1623,7 @@ simde_mm_mullo_epi32 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_i32 = vmulq_s32(a_.neon_i32, b_.neon_i32);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     (void) a_;
     (void) b_;
     r_.altivec_i32 = vec_mul(a_.altivec_i32, b_.altivec_i32);

--- a/simde/x86/ssse3.h
+++ b/simde/x86/ssse3.h
@@ -45,7 +45,7 @@ simde_mm_abs_epi8 (simde__m128i a) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_i8 = vabsq_s8(a_.neon_i8);
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   r_.altivec_i8 = vec_abs(a_.altivec_i8);
   #else
     SIMDE_VECTORIZE
@@ -73,7 +73,7 @@ simde_mm_abs_epi16 (simde__m128i a) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_i16 = vabsq_s16(a_.neon_i16);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i16 = vec_abs(a_.altivec_i16);
   #else
     SIMDE_VECTORIZE
@@ -101,7 +101,7 @@ simde_mm_abs_epi32 (simde__m128i a) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_i32 = vabsq_s32(a_.neon_i32);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     r_.altivec_i32 = vec_abs(a_.altivec_i32);
   #else
     SIMDE_VECTORIZE
@@ -328,7 +328,7 @@ simde_mm_shuffle_epi8 (simde__m128i a, simde__m128i b) {
       int8x8_t h = vtbl2_s8(i, vget_high_s8(b_.neon_i8));
 
       r_.neon_i8 = vcombine_s8(l, h);
-    #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
       /* This is a bit ugly because of the casts and the awful type
       * macros (SIMDE_POWER_ALTIVEC_VECTOR), but it's really just
        * vec_sel(vec_perm(a, a, b), 0, vec_cmplt(b, 0)) */


### PR DESCRIPTION
POWER6 was the first to have AltiVec.

I left some P5 in simde-features.h, I don't know whether I should remove them.

N.B. in doing this I noticed several problems in sse.h in these lines:
```
  #elif defined(SIMDE_POWER_ALTIVE_P7_NATIVE)
    vec_vsx_st(a_.altivec_32, 0, mem_addr);
  #elif defined(SIMDE_POWER_ALTIVE_P5_NATIVE)
    vec_st(a_.altivec_32, 0, mem_addr);
```
I tried correcting:
- ALTIVE to ALTIVEC (and changing P5 to P6)
- altivec_32 to altivec_u32

but there are still errors so I left it alone :-(
Maybe you can correct it.