### PR TITLE
neon: Fix include guards

### DIFF
--- a/simde/arm/neon/addw.h
+++ b/simde/arm/neon/addw.h
@@ -25,8 +25,8 @@
  *   2020      Sean Maher <seanptmaher@gmail.com>
  */
 
-#if !defined(SIMDE_ARM_NEON_ADD_H)
-#define SIMDE_ARM_NEON_ADD_H
+#if !defined(SIMDE_ARM_NEON_ADDW_H)
+#define SIMDE_ARM_NEON_ADDW_H
 
 #include "types.h"
 
@@ -175,4 +175,4 @@ simde_vaddw_u32(simde_uint64x2_t a, simde_uint32x2_t b) {
 SIMDE_END_DECLS_
 HEDLEY_DIAGNOSTIC_POP
 
-#endif /* !defined(SIMDE_ARM_NEON_ADD_H) */
+#endif /* !defined(SIMDE_ARM_NEON_ADDW_H) */

--- a/simde/arm/neon/cagt.h
+++ b/simde/arm/neon/cagt.h
@@ -25,8 +25,8 @@
  *   2020      Sean Maher <seanptmaher@gmail.com>
  */
 
-#if !defined(SIMDE_ARM_NEON_ADD_H)
-#define SIMDE_ARM_NEON_ADD_H
+#if !defined(SIMDE_ARM_NEON_CAGT_H)
+#define SIMDE_ARM_NEON_CAGT_H
 
 #include "types.h"
 
@@ -137,4 +137,4 @@ simde_vcagtq_f64(simde_float64x2_t a, simde_float64x2_t b) {
 SIMDE_END_DECLS_
 HEDLEY_DIAGNOSTIC_POP
 
-#endif /* !defined(SIMDE_ARM_NEON_ADD_H) */
+#endif /* !defined(SIMDE_ARM_NEON_CAGT_H) */

--- a/simde/arm/neon/padd.h
+++ b/simde/arm/neon/padd.h
@@ -28,10 +28,10 @@
 #if !defined(SIMDE_ARM_NEON_PADD_H)
 #define SIMDE_ARM_NEON_PADD_H
 
-#include "types.h"
 #include "add.h"
 #include "uzp1.h"
 #include "uzp2.h"
+#include "types.h"
 
 HEDLEY_DIAGNOSTIC_PUSH
 SIMDE_DISABLE_UNWANTED_DIAGNOSTICS

--- a/simde/arm/neon/sub.h
+++ b/simde/arm/neon/sub.h
@@ -24,8 +24,8 @@
  *   2020      Evan Nemerson <evan@nemerson.com>
  */
 
-#if !defined(SIMDE_ARM_NEON_ADD_H)
-#define SIMDE_ARM_NEON_ADD_H
+#if !defined(SIMDE_ARM_NEON_SUB_H)
+#define SIMDE_ARM_NEON_SUB_H
 
 #include "types.h"
 


### PR DESCRIPTION
Hi, this is just me cleaning up after doing a s// wrong in my code, sorry about that. It caused a compile error when including paddl.h (I think because of the way the headers are set up it doesn't happen in any other of the files right now, but it could in the future) from other places in the code that didn't already include "add.h" (I just spent longer than I care to admit finding why it wasn't including the file, I've never had to run into this problem before :^) ) 

(CC @ngzhian @tlively)