### PR TITLE
Wunused-but-set-variable is a problem until GCC 6.4 (#277)

### DIFF
--- a/simde/simde-diagnostic.h
+++ b/simde/simde-diagnostic.h
@@ -274,7 +274,7 @@
 #endif
 
 /* https://github.com/simd-everywhere/simde/issues/277 */
-#if defined(HEDLEY_GCC_VERSION) && HEDLEY_GCC_VERSION_CHECK(4,6,0) && !HEDLEY_GCC_VERSION_CHECK(6,0,0) && defined(__cplusplus)
+#if defined(HEDLEY_GCC_VERSION) && HEDLEY_GCC_VERSION_CHECK(4,6,0) && !HEDLEY_GCC_VERSION_CHECK(6,4,0) && defined(__cplusplus)
   #define SIMDE_DIAGNOSTIC_DISABLE_BUGGY_UNUSED_BUT_SET_VARIBALE_ _Pragma("GCC diagnostic ignored \"-Wunused-but-set-variable\"")
 #else
   #define SIMDE_DIAGNOSTIC_DISABLE_BUGGY_UNUSED_BUT_SET_VARIBALE_


### PR DESCRIPTION
Tested on godbolt with the following snippet:
```
int test() {
    struct simde__m128i_private {
        int  i32f __attribute__((__vector_size__(16)));
    };
  simde__m128i_private r_, a_;
  r_.i32f = ~(a_.i32f);
  return r_.i32f[0];
}
```
GCC 6.4 is the version that does not emit the warning.