### PR TITLE
avx2: added impl for mm{,256}_{,mask}_i{32,64}gather_epi32 and small bug fix

### DIFF
--- a/simde/x86/avx2.h
+++ b/simde/x86/avx2.h
@@ -1566,7 +1566,7 @@ simde_mm256_extract_epi8 (simde__m256i a, const int index)
   simde__m256i_private a_ = simde__m256i_to_private(a);
   return a_.i8[index];
 }
-#if defined(SIMDE_X86_AVX_NATIVE)
+#if defined(SIMDE_X86_AVX2_NATIVE)
   #define simde_mm256_extract_epi8(a, index) _mm256_extract_epi8(a, index)
 #endif
 #if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
@@ -1581,7 +1581,7 @@ simde_mm256_extract_epi16 (simde__m256i a, const int index)
   simde__m256i_private a_ = simde__m256i_to_private(a);
   return a_.i16[index];
 }
-#if defined(SIMDE_X86_AVX_NATIVE)
+#if defined(SIMDE_X86_AVX2_NATIVE)
   #define simde_mm256_extract_epi16(a, index) _mm256_extract_epi16(a, index)
 #endif
 #if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
@@ -1602,6 +1602,260 @@ simde_mm256_extracti128_si256 (simde__m256i a, const int imm8)
 #if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
   #undef _mm256_extracti128_si256
   #define _mm256_extracti128_si256(a, imm8) simde_mm256_extracti128_si256(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_i32gather_epi32(const int32_t* base_addr, simde__m128i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex),
+    r_;
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i32) / sizeof(vindex_.i32[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    int32_t dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.i32[i] = dst;
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_i32gather_epi32(base_addr, vindex, scale) _mm_i32gather_epi32(HEDLEY_REINTERPRET_CAST(int32_t const*, base_addr), vindex, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_i32_gather_epi32
+  #define _mm_i32gather_epi32(base_addr, vindex, scale) simde_mm_i32gather_epi32(HEDLEY_REINTERPRET_CAST(int32_t const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_i32gather_epi32(simde__m128i src, const int32_t* base_addr, simde__m128i vindex, simde__m128i mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex),
+    src_ = simde__m128i_to_private(src),
+    mask_ = simde__m128i_to_private(mask),
+    r_;
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i32) / sizeof(vindex_.i32[0])) ; i++) {
+    if( (mask_.i32[i] >> 31) & 1 ) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+      int32_t dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.i32[i] = dst;
+    }
+    else {
+      r_.i32[i] = src_.i32[i];
+    }
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_mask_i32gather_epi32(src, base_addr, vindex, mask, scale) _mm_mask_i32gather_epi32(src, HEDLEY_REINTERPRET_CAST(int32_t const*, base_addr), vindex, mask, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_i32gather_epi32
+  #define _mm_mask_i32gather_epi32(src, base_addr, vindex, mask, scale) simde_mm_mask_i32gather_epi32(src, HEDLEY_REINTERPRET_CAST(int32_t const*, base_addr), vindex, mask, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_i32gather_epi32(const int32_t* base_addr, simde__m256i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m256i_private
+    vindex_ = simde__m256i_to_private(vindex),
+    r_;
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i32) / sizeof(vindex_.i32[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    int32_t dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.i32[i] = dst;
+  }
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_i32gather_epi32(base_addr, vindex, scale) _mm256_i32gather_epi32(HEDLEY_REINTERPRET_CAST(int32_t const*, base_addr), vindex, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_i32_gather_epi32
+  #define _mm256_i32gather_epi32(base_addr, vindex, scale) simde_mm256_i32gather_epi32(HEDLEY_REINTERPRET_CAST(int32_t const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_i32gather_epi32(simde__m256i src, const int32_t* base_addr, simde__m256i vindex, simde__m256i mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m256i_private
+    vindex_ = simde__m256i_to_private(vindex),
+    src_ = simde__m256i_to_private(src),
+    mask_ = simde__m256i_to_private(mask),
+    r_;
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i32) / sizeof(vindex_.i32[0])) ; i++) {
+    if( (mask_.i32[i] >> 31) & 1 ) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+      int32_t dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.i32[i] = dst;
+    }
+    else {
+      r_.i32[i] = src_.i32[i];
+    }
+  }
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_mask_i32gather_epi32(src, base_addr, vindex, mask, scale) _mm256_mask_i32gather_epi32(src, HEDLEY_REINTERPRET_CAST(int32_t const*, base_addr), vindex, mask, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_i32gather_epi32
+  #define _mm256_mask_i32gather_epi32(src, base_addr, vindex, mask, scale) simde_mm256_mask_i32gather_epi32(src, HEDLEY_REINTERPRET_CAST(int32_t const*, base_addr), vindex, mask, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_i64gather_epi32(const int32_t* base_addr, simde__m128i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex),
+    r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    int32_t dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.i32[i] = dst;
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_i64gather_epi32(base_addr, vindex, scale) _mm_i64gather_epi32(HEDLEY_REINTERPRET_CAST(int32_t const*, base_addr), vindex, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_i64_gather_epi32
+  #define _mm_i64gather_epi32(base_addr, vindex, scale) simde_mm_i64gather_epi32(HEDLEY_REINTERPRET_CAST(int32_t const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_i64gather_epi32(simde__m128i src, const int32_t* base_addr, simde__m128i vindex, simde__m128i mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex),
+    src_ = simde__m128i_to_private(src),
+    mask_ = simde__m128i_to_private(mask),
+    r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    if( (mask_.i32[i] >> 31) & 1 ) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+      int32_t dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.i32[i] = dst;
+    }
+    else {
+      r_.i32[i] = src_.i32[i];
+    }
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_mask_i64gather_epi32(src, base_addr, vindex, mask, scale) _mm_mask_i64gather_epi32(src, HEDLEY_REINTERPRET_CAST(int32_t const*, base_addr), vindex, mask, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_i64gather_epi32
+  #define _mm_mask_i64gather_epi32(src, base_addr, vindex, mask, scale) simde_mm_mask_i64gather_epi32(src, HEDLEY_REINTERPRET_CAST(int32_t const*, base_addr), vindex, mask, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm256_i64gather_epi32(const int32_t* base_addr, simde__m256i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m256i_private
+    vindex_ = simde__m256i_to_private(vindex);
+  simde__m128i_private
+    r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    int32_t dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.i32[i] = dst;
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_i64gather_epi32(base_addr, vindex, scale) _mm256_i64gather_epi32(HEDLEY_REINTERPRET_CAST(int32_t const*, base_addr), vindex, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_i64_gather_epi32
+  #define _mm256_i64gather_epi32(base_addr, vindex, scale) simde_mm256_i64gather_epi32(HEDLEY_REINTERPRET_CAST(int32_t const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm256_mask_i64gather_epi32(simde__m128i src, const int32_t* base_addr, simde__m256i vindex, simde__m128i mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m256i_private
+    vindex_ = simde__m256i_to_private(vindex);
+  simde__m128i_private
+    src_ = simde__m128i_to_private(src),
+    mask_ = simde__m128i_to_private(mask),
+    r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    if( (mask_.i32[i] >> 31) & 1 ) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+      int32_t dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.i32[i] = dst;
+    }
+    else {
+      r_.i32[i] = src_.i32[i];
+    }
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_mask_i64gather_epi32(src, base_addr, vindex, mask, scale) _mm256_mask_i64gather_epi32(src, HEDLEY_REINTERPRET_CAST(int32_t const*, base_addr), vindex, mask, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_i64gather_epi32
+  #define _mm256_mask_i64gather_epi32(src, base_addr, vindex, mask, scale) simde_mm256_mask_i64gather_epi32(src, HEDLEY_REINTERPRET_CAST(int32_t const*, base_addr), vindex, mask, scale)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES

--- a/test/x86/avx2.c
+++ b/test/x86/avx2.c
@@ -6029,6 +6029,364 @@ test_simde_mm256_hsubs_epi16 (SIMDE_MUNIT_TEST_ARGS) {
   return 0;
 }
 
+static int32_t gather_buffer[4096];
+
+static int
+test_simde_mm_i32gather_epi32 (SIMDE_MUNIT_TEST_ARGS) {
+  static const struct {
+    const int32_t vindex[4];
+    const int32_t r[4];
+  } test_vec[] = {
+    { {  INT32_C(         141),  INT32_C(          78),  INT32_C(         249),  INT32_C(          88) },
+      {  INT32_C(         141),  INT32_C(          78),  INT32_C(         249),  INT32_C(          88) } },
+    { {  INT32_C(         189),  INT32_C(         204),  INT32_C(          14),  INT32_C(         231) },
+      {  INT32_C(         189),  INT32_C(         204),  INT32_C(          14),  INT32_C(         231) } },
+    { {  INT32_C(         199),  INT32_C(          52),  INT32_C(         133),  INT32_C(         101) },
+      {  INT32_C(         199),  INT32_C(          52),  INT32_C(         133),  INT32_C(         101) } },
+    { {  INT32_C(         239),  INT32_C(          12),  INT32_C(         121),  INT32_C(         226) },
+      {  INT32_C(         239),  INT32_C(          12),  INT32_C(         121),  INT32_C(         226) } },
+    { {  INT32_C(         197),  INT32_C(         167),  INT32_C(         235),  INT32_C(          15) },
+      {  INT32_C(         197),  INT32_C(         167),  INT32_C(         235),  INT32_C(          15) } },
+    { {  INT32_C(         239),  INT32_C(         157),  INT32_C(         219),  INT32_C(          83) },
+      {  INT32_C(         239),  INT32_C(         157),  INT32_C(         219),  INT32_C(          83) } },
+    { {  INT32_C(         230),  INT32_C(          67),  INT32_C(         195),  INT32_C(          27) },
+      {  INT32_C(         230),  INT32_C(          67),  INT32_C(         195),  INT32_C(          27) } },
+    { {  INT32_C(         203),  INT32_C(         150),  INT32_C(         133),  INT32_C(          68) },
+      {  INT32_C(         203),  INT32_C(         150),  INT32_C(         133),  INT32_C(          68) } }
+  };
+  for (size_t i = 0 ; i < (sizeof(gather_buffer) / sizeof(gather_buffer[0])) ; i++) { gather_buffer[i] = HEDLEY_STATIC_CAST(int32_t, i); }
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m128i vindex = simde_x_mm_loadu_epi32(test_vec[i].vindex);
+    simde__m128i r = simde_mm_i32gather_epi32(gather_buffer, vindex, 4);
+    simde_test_x86_assert_equal_i32x4(r, simde_x_mm_loadu_epi32(test_vec[i].r));
+  }
+
+  return 0;
+}
+
+static int
+test_simde_mm_mask_i32gather_epi32 (SIMDE_MUNIT_TEST_ARGS) {
+  static const struct {
+    const int32_t src[4];
+    const int32_t vindex[4];
+    const int32_t mask[4];
+    const int32_t r[4];
+  } test_vec[] = {
+    { { -INT32_C(   685361840), -INT32_C(  1057547638), -INT32_C(  1601608401), -INT32_C(  2110383967) },
+      {  INT32_C(          85),  INT32_C(          81),  INT32_C(         250),  INT32_C(         146) },
+      {            INT32_MIN,            INT32_MIN,            INT32_MIN,            INT32_MIN },
+      {  INT32_C(          85),  INT32_C(          81),  INT32_C(         250),  INT32_C(         146) } },
+    { { -INT32_C(   612533238), -INT32_C(  2144538583), -INT32_C(  1518687133),  INT32_C(  1765241328) },
+      {  INT32_C(         198),  INT32_C(         202),  INT32_C(         225),  INT32_C(         124) },
+      {  INT32_C(           0),  INT32_C(           0),            INT32_MIN,            INT32_MIN },
+      { -INT32_C(   612533238), -INT32_C(  2144538583),  INT32_C(         225),  INT32_C(         124) } },
+    { {  INT32_C(  1518663255), -INT32_C(  1557876442),  INT32_C(  1485068261),  INT32_C(   248810868) },
+      {  INT32_C(         138),  INT32_C(         226),  INT32_C(           2),  INT32_C(         239) },
+      {            INT32_MIN,            INT32_MIN,            INT32_MIN,            INT32_MIN },
+      {  INT32_C(         138),  INT32_C(         226),  INT32_C(           2),  INT32_C(         239) } },
+    { { -INT32_C(   436463052),  INT32_C(    46620719), -INT32_C(   637220286), -INT32_C(   624310953) },
+      {  INT32_C(         255),  INT32_C(          71),  INT32_C(           2),  INT32_C(          72) },
+      {  INT32_C(           0),            INT32_MIN,  INT32_C(           0),  INT32_C(           0) },
+      { -INT32_C(   436463052),  INT32_C(          71), -INT32_C(   637220286), -INT32_C(   624310953) } },
+    { {  INT32_C(  1290237130), -INT32_C(   376192698), -INT32_C(   487909938), -INT32_C(  1020567585) },
+      {  INT32_C(         161),  INT32_C(          11),  INT32_C(         227),  INT32_C(          34) },
+      {            INT32_MIN,            INT32_MIN,  INT32_C(           0),            INT32_MIN },
+      {  INT32_C(         161),  INT32_C(          11), -INT32_C(   487909938),  INT32_C(          34) } },
+    { { -INT32_C(   193884505),  INT32_C(  2130650489),  INT32_C(   526459079), -INT32_C(  1220465615) },
+      {  INT32_C(          81),  INT32_C(         199),  INT32_C(         213),  INT32_C(         171) },
+      {            INT32_MIN,            INT32_MIN,            INT32_MIN,  INT32_C(           0) },
+      {  INT32_C(          81),  INT32_C(         199),  INT32_C(         213), -INT32_C(  1220465615) } },
+    { { -INT32_C(  1028183535),  INT32_C(   931744097),  INT32_C(    34424318), -INT32_C(  1095912774) },
+      {  INT32_C(           3),  INT32_C(         170),  INT32_C(          26),  INT32_C(         155) },
+      {  INT32_C(           0),  INT32_C(           0),  INT32_C(           0),            INT32_MIN },
+      { -INT32_C(  1028183535),  INT32_C(   931744097),  INT32_C(    34424318),  INT32_C(         155) } },
+    { {  INT32_C(  1720704891), -INT32_C(  1492085483),  INT32_C(  1187097276),  INT32_C(  1491223020) },
+      {  INT32_C(         248),  INT32_C(          82),  INT32_C(         255),  INT32_C(         161) },
+      {  INT32_C(           0),  INT32_C(           0),  INT32_C(           0),  INT32_C(           0) },
+      {  INT32_C(  1720704891), -INT32_C(  1492085483),  INT32_C(  1187097276),  INT32_C(  1491223020) } }
+  };
+
+  for (size_t i = 0 ; i < (sizeof(gather_buffer) / sizeof(gather_buffer[0])) ; i++) { gather_buffer[i] = HEDLEY_STATIC_CAST(int32_t, i); }
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m128i src = simde_x_mm_loadu_epi32(test_vec[i].src);
+    simde__m128i vindex = simde_x_mm_loadu_epi32(test_vec[i].vindex);
+    simde__m128i mask = simde_x_mm_loadu_epi32(test_vec[i].mask);
+    simde__m128i r = simde_mm_mask_i32gather_epi32(src, gather_buffer, vindex, mask, 4);
+    simde_test_x86_assert_equal_i32x4(r, simde_x_mm_loadu_epi32(test_vec[i].r));
+  }
+
+  return 0;
+
+}
+
+static int
+test_simde_mm256_i32gather_epi32 (SIMDE_MUNIT_TEST_ARGS) {
+  static const struct {
+    const int32_t vindex[8];
+    const int32_t r[8];
+  } test_vec[] = {
+    { {  INT32_C(          27),  INT32_C(         135),  INT32_C(         222),  INT32_C(          60),  INT32_C(         120),  INT32_C(         248),  INT32_C(         252),  INT32_C(          33) },
+      {  INT32_C(          27),  INT32_C(         135),  INT32_C(         222),  INT32_C(          60),  INT32_C(         120),  INT32_C(         248),  INT32_C(         252),  INT32_C(          33) } },
+    { {  INT32_C(          94),  INT32_C(         185),  INT32_C(         221),  INT32_C(         160),  INT32_C(          28),  INT32_C(         199),  INT32_C(         216),  INT32_C(          91) },
+      {  INT32_C(          94),  INT32_C(         185),  INT32_C(         221),  INT32_C(         160),  INT32_C(          28),  INT32_C(         199),  INT32_C(         216),  INT32_C(          91) } },
+    { {  INT32_C(         198),  INT32_C(          71),  INT32_C(         176),  INT32_C(          54),  INT32_C(         235),  INT32_C(         249),  INT32_C(           5),  INT32_C(         236) },
+      {  INT32_C(         198),  INT32_C(          71),  INT32_C(         176),  INT32_C(          54),  INT32_C(         235),  INT32_C(         249),  INT32_C(           5),  INT32_C(         236) } },
+    { {  INT32_C(         152),  INT32_C(         161),  INT32_C(         168),  INT32_C(         209),  INT32_C(         201),  INT32_C(         153),  INT32_C(           8),  INT32_C(          97) },
+      {  INT32_C(         152),  INT32_C(         161),  INT32_C(         168),  INT32_C(         209),  INT32_C(         201),  INT32_C(         153),  INT32_C(           8),  INT32_C(          97) } },
+    { {  INT32_C(         210),  INT32_C(          35),  INT32_C(          29),  INT32_C(         112),  INT32_C(         115),  INT32_C(           2),  INT32_C(         240),  INT32_C(         195) },
+      {  INT32_C(         210),  INT32_C(          35),  INT32_C(          29),  INT32_C(         112),  INT32_C(         115),  INT32_C(           2),  INT32_C(         240),  INT32_C(         195) } },
+    { {  INT32_C(         126),  INT32_C(           0),  INT32_C(          49),  INT32_C(         241),  INT32_C(         211),  INT32_C(         104),  INT32_C(         198),  INT32_C(         131) },
+      {  INT32_C(         126),  INT32_C(           0),  INT32_C(          49),  INT32_C(         241),  INT32_C(         211),  INT32_C(         104),  INT32_C(         198),  INT32_C(         131) } },
+    { {  INT32_C(          25),  INT32_C(         242),  INT32_C(          37),  INT32_C(         251),  INT32_C(         120),  INT32_C(          10),  INT32_C(          98),  INT32_C(         217) },
+      {  INT32_C(          25),  INT32_C(         242),  INT32_C(          37),  INT32_C(         251),  INT32_C(         120),  INT32_C(          10),  INT32_C(          98),  INT32_C(         217) } },
+    { {  INT32_C(         159),  INT32_C(         152),  INT32_C(         136),  INT32_C(          27),  INT32_C(          62),  INT32_C(         120),  INT32_C(         145),  INT32_C(         235) },
+      {  INT32_C(         159),  INT32_C(         152),  INT32_C(         136),  INT32_C(          27),  INT32_C(          62),  INT32_C(         120),  INT32_C(         145),  INT32_C(         235) } }
+  };
+  for (size_t i = 0 ; i < (sizeof(gather_buffer) / sizeof(gather_buffer[0])) ; i++) { gather_buffer[i] = HEDLEY_STATIC_CAST(int32_t, i); }
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256i vindex = simde_x_mm256_loadu_epi32(test_vec[i].vindex);
+    simde__m256i r = simde_mm256_i32gather_epi32(gather_buffer, vindex, 4);
+    simde_test_x86_assert_equal_i32x8(r, simde_x_mm256_loadu_epi32(test_vec[i].r));
+  }
+
+  return 0;
+}
+
+static int
+test_simde_mm256_mask_i32gather_epi32 (SIMDE_MUNIT_TEST_ARGS) {
+  static const struct {
+    const int32_t src[8];
+    const int32_t vindex[8];
+    const int32_t mask[8];
+    const int32_t r[8];
+  } test_vec[] = {
+    { { -INT32_C(  1086860273), -INT32_C(   849127954), -INT32_C(   348023026), -INT32_C(  1484367608),  INT32_C(   287657063), -INT32_C(   380909789),  INT32_C(  1004087424), -INT32_C(  1260891740) },
+      {  INT32_C(          19),  INT32_C(         114),  INT32_C(         118),  INT32_C(         226),  INT32_C(          83),  INT32_C(         138),  INT32_C(          11),  INT32_C(         140) },
+      {  INT32_C(           0),            INT32_MIN,            INT32_MIN,            INT32_MIN,            INT32_MIN,  INT32_C(           0),  INT32_C(           0),            INT32_MIN },
+      { -INT32_C(  1086860273),  INT32_C(         114),  INT32_C(         118),  INT32_C(         226),  INT32_C(          83), -INT32_C(   380909789),  INT32_C(  1004087424),  INT32_C(         140) } },
+    { { -INT32_C(  1577111400),  INT32_C(  1410892465),  INT32_C(   678561379),  INT32_C(  1578988305), -INT32_C(  1665833368), -INT32_C(  2026400021),  INT32_C(  2139872828), -INT32_C(   596763836) },
+      {  INT32_C(         252),  INT32_C(          84),  INT32_C(         173),  INT32_C(         158),  INT32_C(         235),  INT32_C(         148),  INT32_C(         148),  INT32_C(         100) },
+      {  INT32_C(           0),            INT32_MIN,  INT32_C(           0),            INT32_MIN,            INT32_MIN,  INT32_C(           0),  INT32_C(           0),  INT32_C(           0) },
+      { -INT32_C(  1577111400),  INT32_C(          84),  INT32_C(   678561379),  INT32_C(         158),  INT32_C(         235), -INT32_C(  2026400021),  INT32_C(  2139872828), -INT32_C(   596763836) } },
+    { { -INT32_C(  1074690759), -INT32_C(  1478416843),  INT32_C(   592490712),  INT32_C(   695179148),  INT32_C(   220112409), -INT32_C(   128800944),  INT32_C(  1706634309), -INT32_C(  1334452618) },
+      {  INT32_C(         152),  INT32_C(         101),  INT32_C(         140),  INT32_C(          63),  INT32_C(         238),  INT32_C(         192),  INT32_C(          66),  INT32_C(         224) },
+      {            INT32_MIN,            INT32_MIN,            INT32_MIN,            INT32_MIN,            INT32_MIN,            INT32_MIN,  INT32_C(           0),            INT32_MIN },
+      {  INT32_C(         152),  INT32_C(         101),  INT32_C(         140),  INT32_C(          63),  INT32_C(         238),  INT32_C(         192),  INT32_C(  1706634309),  INT32_C(         224) } },
+    { { -INT32_C(  1420665862),  INT32_C(  1515996691),  INT32_C(   969382596),  INT32_C(  1431139470),  INT32_C(   144133742), -INT32_C(  1133668042), -INT32_C(  2118118208), -INT32_C(  1488673875) },
+      {  INT32_C(          18),  INT32_C(         161),  INT32_C(         215),  INT32_C(          22),  INT32_C(         172),  INT32_C(          28),  INT32_C(          76),  INT32_C(         203) },
+      {  INT32_C(           0),  INT32_C(           0),  INT32_C(           0),  INT32_C(           0),            INT32_MIN,            INT32_MIN,            INT32_MIN,  INT32_C(           0) },
+      { -INT32_C(  1420665862),  INT32_C(  1515996691),  INT32_C(   969382596),  INT32_C(  1431139470),  INT32_C(         172),  INT32_C(          28),  INT32_C(          76), -INT32_C(  1488673875) } },
+    { { -INT32_C(    20439286), -INT32_C(   449069208), -INT32_C(  2012655728), -INT32_C(  1829288817), -INT32_C(  2081353314),  INT32_C(  1074228372),  INT32_C(  2142754948), -INT32_C(  1477248355) },
+      {  INT32_C(         130),  INT32_C(           9),  INT32_C(         190),  INT32_C(          83),  INT32_C(          47),  INT32_C(          49),  INT32_C(          83),  INT32_C(          58) },
+      {            INT32_MIN,            INT32_MIN,            INT32_MIN,            INT32_MIN,            INT32_MIN,            INT32_MIN,  INT32_C(           0),  INT32_C(           0) },
+      {  INT32_C(         130),  INT32_C(           9),  INT32_C(         190),  INT32_C(          83),  INT32_C(          47),  INT32_C(          49),  INT32_C(  2142754948), -INT32_C(  1477248355) } },
+    { {  INT32_C(  1885499633),  INT32_C(   656294547), -INT32_C(  1351644492),  INT32_C(  1128532806), -INT32_C(   873657988), -INT32_C(  1764702148), -INT32_C(  2096027564),  INT32_C(  1796130170) },
+      {  INT32_C(         201),  INT32_C(         102),  INT32_C(         201),  INT32_C(         231),  INT32_C(         159),  INT32_C(          22),  INT32_C(          38),  INT32_C(          66) },
+      {  INT32_C(           0),            INT32_MIN,  INT32_C(           0),            INT32_MIN,  INT32_C(           0),            INT32_MIN,  INT32_C(           0),  INT32_C(           0) },
+      {  INT32_C(  1885499633),  INT32_C(         102), -INT32_C(  1351644492),  INT32_C(         231), -INT32_C(   873657988),  INT32_C(          22), -INT32_C(  2096027564),  INT32_C(  1796130170) } },
+    { {  INT32_C(   515341239), -INT32_C(   737547912), -INT32_C(   778257104),  INT32_C(   936725373), -INT32_C(  1833731923),  INT32_C(  1914979922),  INT32_C(  1184881778), -INT32_C(   583921882) },
+      {  INT32_C(           2),  INT32_C(           3),  INT32_C(          63),  INT32_C(         107),  INT32_C(         115),  INT32_C(         226),  INT32_C(          35),  INT32_C(          31) },
+      {            INT32_MIN,  INT32_C(           0),            INT32_MIN,  INT32_C(           0),            INT32_MIN,            INT32_MIN,  INT32_C(           0),            INT32_MIN },
+      {  INT32_C(           2), -INT32_C(   737547912),  INT32_C(          63),  INT32_C(   936725373),  INT32_C(         115),  INT32_C(         226),  INT32_C(  1184881778),  INT32_C(          31) } },
+    { { -INT32_C(   724013614), -INT32_C(   778505370),  INT32_C(  2063310050), -INT32_C(  1154183402), -INT32_C(   707698399),  INT32_C(   210159988),  INT32_C(  1698257641),  INT32_C(    36013360) },
+      {  INT32_C(          89),  INT32_C(         212),  INT32_C(          34),  INT32_C(         214),  INT32_C(          87),  INT32_C(          97),  INT32_C(         188),  INT32_C(          22) },
+      {            INT32_MIN,            INT32_MIN,            INT32_MIN,  INT32_C(           0),  INT32_C(           0),            INT32_MIN,  INT32_C(           0),  INT32_C(           0) },
+      {  INT32_C(          89),  INT32_C(         212),  INT32_C(          34), -INT32_C(  1154183402), -INT32_C(   707698399),  INT32_C(          97),  INT32_C(  1698257641),  INT32_C(    36013360) } }
+  };
+  for (size_t i = 0 ; i < (sizeof(gather_buffer) / sizeof(gather_buffer[0])) ; i++) { gather_buffer[i] = HEDLEY_STATIC_CAST(int32_t, i); }
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256i src = simde_x_mm256_loadu_epi32(test_vec[i].src);
+    simde__m256i vindex = simde_x_mm256_loadu_epi32(test_vec[i].vindex);
+    simde__m256i mask = simde_x_mm256_loadu_epi32(test_vec[i].mask);
+    simde__m256i r = simde_mm256_mask_i32gather_epi32(src, gather_buffer, vindex, mask, 4);
+    simde_test_x86_assert_equal_i32x8(r, simde_x_mm256_loadu_epi32(test_vec[i].r));
+  }
+
+  return 0;
+}
+
+static int
+test_simde_mm_i64gather_epi32 (SIMDE_MUNIT_TEST_ARGS) {
+  static const struct {
+    const int64_t vindex[2];
+    const int32_t r[4];
+  } test_vec[] = {
+    { {  INT64_C(                 136),  INT64_C(                  22) },
+      {  INT32_C(         136),  INT32_C(          22),  INT32_C(           0),  INT32_C(           0) } },
+    { {  INT64_C(                 173),  INT64_C(                  86) },
+      {  INT32_C(         173),  INT32_C(          86),  INT32_C(           0),  INT32_C(           0) } },
+    { {  INT64_C(                 157),  INT64_C(                 106) },
+      {  INT32_C(         157),  INT32_C(         106),  INT32_C(           0),  INT32_C(           0) } },
+    { {  INT64_C(                  81),  INT64_C(                 112) },
+      {  INT32_C(          81),  INT32_C(         112),  INT32_C(           0),  INT32_C(           0) } },
+    { {  INT64_C(                  42),  INT64_C(                  54) },
+      {  INT32_C(          42),  INT32_C(          54),  INT32_C(           0),  INT32_C(           0) } },
+    { {  INT64_C(                  75),  INT64_C(                 158) },
+      {  INT32_C(          75),  INT32_C(         158),  INT32_C(           0),  INT32_C(           0) } },
+    { {  INT64_C(                   9),  INT64_C(                  95) },
+      {  INT32_C(           9),  INT32_C(          95),  INT32_C(           0),  INT32_C(           0) } },
+    { {  INT64_C(                 192),  INT64_C(                 148) },
+      {  INT32_C(         192),  INT32_C(         148),  INT32_C(           0),  INT32_C(           0) } }
+  };
+  for (size_t i = 0 ; i < (sizeof(gather_buffer) / sizeof(gather_buffer[0])) ; i++) { gather_buffer[i] = HEDLEY_STATIC_CAST(int32_t, i); }
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m128i vindex = simde_x_mm_loadu_epi64(test_vec[i].vindex);
+    simde__m128i r = simde_mm_i64gather_epi32(gather_buffer, vindex, 4);
+    simde_test_x86_assert_equal_i32x4(r, simde_x_mm_loadu_epi32(test_vec[i].r));
+  }
+
+  return 0;
+}
+
+static int
+test_simde_mm_mask_i64gather_epi32 (SIMDE_MUNIT_TEST_ARGS) {
+  static const struct {
+    const int32_t src[4];
+    const int64_t vindex[2];
+    const int32_t mask[4];
+    const int32_t r[4];
+  } test_vec[] = {
+    { {  INT32_C(  1478898212),  INT32_C(   916774907), -INT32_C(  1556893248),  INT32_C(  1777183058) },
+      {  INT64_C(                 141),  INT64_C(                 139) },
+      {            INT32_MIN,            INT32_MIN,  INT32_C(           0),  INT32_C(           0) },
+      {  INT32_C(         141),  INT32_C(         139),  INT32_C(           0),  INT32_C(           0) } },
+    { { -INT32_C(   632300097), -INT32_C(   462958966),  INT32_C(  1851006215),  INT32_C(   721091466) },
+      {  INT64_C(                 157),  INT64_C(                 177) },
+      {            INT32_MIN,            INT32_MIN,            INT32_MIN,            INT32_MIN },
+      {  INT32_C(         157),  INT32_C(         177),  INT32_C(           0),  INT32_C(           0) } },
+    { {  INT32_C(  1526041333), -INT32_C(  1124607967), -INT32_C(  1106894900),  INT32_C(   879726651) },
+      {  INT64_C(                   0),  INT64_C(                 233) },
+      {            INT32_MIN,            INT32_MIN,  INT32_C(           0),            INT32_MIN },
+      {  INT32_C(           0),  INT32_C(         233),  INT32_C(           0),  INT32_C(           0) } },
+    { { -INT32_C(  1009155372),  INT32_C(  2126747810),  INT32_C(  1779523445), -INT32_C(  1420614464) },
+      {  INT64_C(                  44),  INT64_C(                 205) },
+      {            INT32_MIN,  INT32_C(           0),            INT32_MIN,  INT32_C(           0) },
+      {  INT32_C(          44),  INT32_C(  2126747810),  INT32_C(           0),  INT32_C(           0) } },
+    { { -INT32_C(  2036541516), -INT32_C(  1464708264),  INT32_C(  1817736563),  INT32_C(   289001730) },
+      {  INT64_C(                 210),  INT64_C(                   6) },
+      {  INT32_C(           0),            INT32_MIN,  INT32_C(           0),  INT32_C(           0) },
+      { -INT32_C(  2036541516),  INT32_C(           6),  INT32_C(           0),  INT32_C(           0) } },
+    { {  INT32_C(   529894144), -INT32_C(  1242496641), -INT32_C(  1991166154), -INT32_C(   661684580) },
+      {  INT64_C(                  15),  INT64_C(                  39) },
+      {            INT32_MIN,  INT32_C(           0),            INT32_MIN,            INT32_MIN },
+      {  INT32_C(          15), -INT32_C(  1242496641),  INT32_C(           0),  INT32_C(           0) } },
+    { { -INT32_C(  2000072659),  INT32_C(   932691705), -INT32_C(   673489744),  INT32_C(    16648425) },
+      {  INT64_C(                 234),  INT64_C(                  70) },
+      {  INT32_C(           0),            INT32_MIN,  INT32_C(           0),            INT32_MIN },
+      { -INT32_C(  2000072659),  INT32_C(          70),  INT32_C(           0),  INT32_C(           0) } },
+    { { -INT32_C(   913030322), -INT32_C(  1531700955),  INT32_C(   960408096), -INT32_C(  1367393148) },
+      {  INT64_C(                 118),  INT64_C(                  32) },
+      {  INT32_C(           0),  INT32_C(           0),  INT32_C(           0),            INT32_MIN },
+      { -INT32_C(   913030322), -INT32_C(  1531700955),  INT32_C(           0),  INT32_C(           0) } }
+  };
+
+  for (size_t i = 0 ; i < (sizeof(gather_buffer) / sizeof(gather_buffer[0])) ; i++) { gather_buffer[i] = HEDLEY_STATIC_CAST(int32_t, i); }
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m128i src = simde_x_mm_loadu_epi32(test_vec[i].src);
+    simde__m128i vindex = simde_x_mm_loadu_epi64(test_vec[i].vindex);
+    simde__m128i mask = simde_x_mm_loadu_epi32(test_vec[i].mask);
+    simde__m128i r = simde_mm_mask_i64gather_epi32(src, gather_buffer, vindex, mask, 4);
+    simde_test_x86_assert_equal_i32x4(r, simde_x_mm_loadu_epi32(test_vec[i].r));
+  }
+
+  return 0;
+}
+
+static int
+test_simde_mm256_i64gather_epi32 (SIMDE_MUNIT_TEST_ARGS) {
+  static const struct {
+    const int64_t vindex[4];
+    const int32_t r[4];
+  } test_vec[] = {
+    { {  INT64_C(                 164),  INT64_C(                 255),  INT64_C(                  34),  INT64_C(                 127) },
+      {  INT32_C(         164),  INT32_C(         255),  INT32_C(          34),  INT32_C(         127) } },
+    { {  INT64_C(                  52),  INT64_C(                  61),  INT64_C(                  40),  INT64_C(                  26) },
+      {  INT32_C(          52),  INT32_C(          61),  INT32_C(          40),  INT32_C(          26) } },
+    { {  INT64_C(                 166),  INT64_C(                 126),  INT64_C(                 130),  INT64_C(                  24) },
+      {  INT32_C(         166),  INT32_C(         126),  INT32_C(         130),  INT32_C(          24) } },
+    { {  INT64_C(                 246),  INT64_C(                  51),  INT64_C(                  78),  INT64_C(                 212) },
+      {  INT32_C(         246),  INT32_C(          51),  INT32_C(          78),  INT32_C(         212) } },
+    { {  INT64_C(                 104),  INT64_C(                 184),  INT64_C(                  15),  INT64_C(                 222) },
+      {  INT32_C(         104),  INT32_C(         184),  INT32_C(          15),  INT32_C(         222) } },
+    { {  INT64_C(                 136),  INT64_C(                  54),  INT64_C(                 141),  INT64_C(                  30) },
+      {  INT32_C(         136),  INT32_C(          54),  INT32_C(         141),  INT32_C(          30) } },
+    { {  INT64_C(                 103),  INT64_C(                 148),  INT64_C(                 191),  INT64_C(                 239) },
+      {  INT32_C(         103),  INT32_C(         148),  INT32_C(         191),  INT32_C(         239) } },
+    { {  INT64_C(                 123),  INT64_C(                 179),  INT64_C(                  92),  INT64_C(                 156) },
+      {  INT32_C(         123),  INT32_C(         179),  INT32_C(          92),  INT32_C(         156) } }
+  };
+  for (size_t i = 0 ; i < (sizeof(gather_buffer) / sizeof(gather_buffer[0])) ; i++) { gather_buffer[i] = HEDLEY_STATIC_CAST(int32_t, i); }
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256i vindex = simde_x_mm256_loadu_epi64(test_vec[i].vindex);
+    simde__m128i r = simde_mm256_i64gather_epi32(gather_buffer, vindex, 4);
+    simde_test_x86_assert_equal_i32x4(r, simde_x_mm_loadu_epi32(test_vec[i].r));
+  }
+
+  return 0;
+}
+
+static int
+test_simde_mm256_mask_i64gather_epi32 (SIMDE_MUNIT_TEST_ARGS) {
+  static const struct {
+    const int32_t src[4];
+    const int64_t vindex[4];
+    const int32_t mask[4];
+    const int32_t r[4];
+  } test_vec[] = {
+    { { -INT32_C(  1914974857), -INT32_C(   268305992),  INT32_C(  1600826892),  INT32_C(    91051765) },
+      {  INT64_C(                  21),  INT64_C(                 250),  INT64_C(                  89),  INT64_C(                  48) },
+      {  INT32_C(           0),  INT32_C(           0),            INT32_MIN,  INT32_C(           0) },
+      { -INT32_C(  1914974857), -INT32_C(   268305992),  INT32_C(          89),  INT32_C(    91051765) } },
+    { { -INT32_C(   807128191), -INT32_C(   215463748),  INT32_C(   975167766),  INT32_C(   627724550) },
+      {  INT64_C(                  89),  INT64_C(                  70),  INT64_C(                 162),  INT64_C(                 179) },
+      {  INT32_C(           0),  INT32_C(           0),            INT32_MIN,            INT32_MIN },
+      { -INT32_C(   807128191), -INT32_C(   215463748),  INT32_C(         162),  INT32_C(         179) } },
+    { { -INT32_C(   569972142),  INT32_C(  1199611944),  INT32_C(  1668045913), -INT32_C(   770263134) },
+      {  INT64_C(                  96),  INT64_C(                  18),  INT64_C(                 116),  INT64_C(                   3) },
+      {            INT32_MIN,  INT32_C(           0),  INT32_C(           0),  INT32_C(           0) },
+      {  INT32_C(          96),  INT32_C(  1199611944),  INT32_C(  1668045913), -INT32_C(   770263134) } },
+    { {  INT32_C(   209437937),  INT32_C(    25204532),  INT32_C(  1584355103), -INT32_C(  1738428347) },
+      {  INT64_C(                 249),  INT64_C(                 196),  INT64_C(                 215),  INT64_C(                 197) },
+      {  INT32_C(           0),  INT32_C(           0),            INT32_MIN,            INT32_MIN },
+      {  INT32_C(   209437937),  INT32_C(    25204532),  INT32_C(         215),  INT32_C(         197) } },
+    { {  INT32_C(  1431392925),  INT32_C(  1278007459),  INT32_C(  1966760398),  INT32_C(   926662903) },
+      {  INT64_C(                 228),  INT64_C(                 100),  INT64_C(                 202),  INT64_C(                  39) },
+      {  INT32_C(           0),            INT32_MIN,            INT32_MIN,            INT32_MIN },
+      {  INT32_C(  1431392925),  INT32_C(         100),  INT32_C(         202),  INT32_C(          39) } },
+    { {  INT32_C(   286484245), -INT32_C(  1831110836),  INT32_C(  1942952725),  INT32_C(  2140816278) },
+      {  INT64_C(                  25),  INT64_C(                 234),  INT64_C(                 181),  INT64_C(                 145) },
+      {            INT32_MIN,  INT32_C(           0),            INT32_MIN,  INT32_C(           0) },
+      {  INT32_C(          25), -INT32_C(  1831110836),  INT32_C(         181),  INT32_C(  2140816278) } },
+    { {  INT32_C(   478193020),  INT32_C(  1842534011),  INT32_C(  1693907963), -INT32_C(   520749634) },
+      {  INT64_C(                  40),  INT64_C(                  39),  INT64_C(                 239),  INT64_C(                 122) },
+      {  INT32_C(           0),            INT32_MIN,            INT32_MIN,            INT32_MIN },
+      {  INT32_C(   478193020),  INT32_C(          39),  INT32_C(         239),  INT32_C(         122) } },
+    { { -INT32_C(   683278108),  INT32_C(   667313686), -INT32_C(  1862854276), -INT32_C(   552950175) },
+      {  INT64_C(                 248),  INT64_C(                 188),  INT64_C(                  99),  INT64_C(                  19) },
+      {  INT32_C(           0),            INT32_MIN,  INT32_C(           0),            INT32_MIN },
+      { -INT32_C(   683278108),  INT32_C(         188), -INT32_C(  1862854276),  INT32_C(          19) } }
+  };
+
+  for (size_t i = 0 ; i < (sizeof(gather_buffer) / sizeof(gather_buffer[0])) ; i++) { gather_buffer[i] = HEDLEY_STATIC_CAST(int32_t, i); }
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m128i src = simde_x_mm_loadu_epi32(test_vec[i].src);
+    simde__m256i vindex = simde_x_mm256_loadu_epi64(test_vec[i].vindex);
+    simde__m128i mask = simde_x_mm_loadu_epi32(test_vec[i].mask);
+    simde__m128i r = simde_mm256_mask_i64gather_epi32(src, gather_buffer, vindex, mask, 4);
+    simde_test_x86_assert_equal_i32x4(r, simde_x_mm_loadu_epi32(test_vec[i].r));
+  }
+
+  return 0;
+}
+
 static int
 test_simde_mm256_inserti128_si256 (SIMDE_MUNIT_TEST_ARGS) {
   static const struct {
@@ -14892,6 +15250,15 @@ SIMDE_TEST_FUNC_LIST_BEGIN
   SIMDE_TEST_FUNC_LIST_ENTRY(mm256_hsub_epi16)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm256_hsub_epi32)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm256_hsubs_epi16)
+
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_i32gather_epi32)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_mask_i32gather_epi32)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_i32gather_epi32)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_mask_i32gather_epi32)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_i64gather_epi32)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_mask_i64gather_epi32)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_i64gather_epi32)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_mask_i64gather_epi32)
 
   SIMDE_TEST_FUNC_LIST_ENTRY(mm256_inserti128_si256)
 


### PR DESCRIPTION
I was using the wrong scale factor, scale factor should have been 4 instead of 1 to test with int32_t buffer array and I didn't understand at first that this instruction uses byte addressing.