### PR TITLE
Add .dir-locals.el

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,4 @@
+((nil . ((indent-tabs-mode . nil)
+         (show-trailing-whitespace . t)))
+ (c-mode . ((c-basic-offset . 2)))
+ (c++-mode . ((c-basic-offset . 2))))


### PR DESCRIPTION
This is pretty useful, makes sure the offset is 2, shows trailing whitespace, should stop me (and anyone else using emacs) from failing the formatting bot, indent with spaces, etc.

It's not really super necessary, but it's helpful, a "convenience merge," if you will. 