### PR TITLE
neon: Correct AltiVec versions in max, min and neg

### DIFF
--- a/simde/arm/neon/max.h
+++ b/simde/arm/neon/max.h
@@ -447,7 +447,7 @@ simde_vmaxq_s32(simde_int32x4_t a, simde_int32x4_t b) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde_int64x2_t
 simde_x_vmaxq_s64(simde_int64x2_t a, simde_int64x2_t b) {
-  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
     return vec_max(a, b);
   #elif SIMDE_NATURAL_VECTOR_SIZE > 0
     return simde_vbslq_s64(simde_vcgtq_s64(a, b), a, b);
@@ -565,7 +565,7 @@ simde_vmaxq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde_uint64x2_t
 simde_x_vmaxq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
-  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
     return vec_max(a, b);
   #elif SIMDE_NATURAL_VECTOR_SIZE > 0
     return simde_vbslq_u64(simde_vcgtq_u64(a, b), a, b);

--- a/simde/arm/neon/min.h
+++ b/simde/arm/neon/min.h
@@ -448,7 +448,7 @@ simde_int64x2_t
 simde_x_vminq_s64(simde_int64x2_t a, simde_int64x2_t b) {
   #if defined(SIMDE_X86_AVX512VL_NATIVE)
     return _mm_min_epi64(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
     return vec_min(a, b);
   #elif SIMDE_NATURAL_VECTOR_SIZE > 0
     return simde_vbslq_s64(simde_vcgtq_s64(b, a), a, b);
@@ -566,7 +566,7 @@ simde_vminq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde_uint64x2_t
 simde_x_vminq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
-  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
     return vec_min(a, b);
   #elif SIMDE_NATURAL_VECTOR_SIZE > 0
     return simde_vbslq_u64(simde_vcgtq_u64(b, a), a, b);

--- a/simde/arm/neon/neg.h
+++ b/simde/arm/neon/neg.h
@@ -200,7 +200,7 @@ simde_float32x4_t
 simde_vnegq_f32(simde_float32x4_t a) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vnegq_f32(a);
-  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
     return vec_neg(a);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_f32x4_neg(a);
@@ -231,7 +231,7 @@ simde_float64x2_t
 simde_vnegq_f64(simde_float64x2_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vnegq_f64(a);
-  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
     return vec_neg(a);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_f64x2_neg(a);
@@ -262,7 +262,7 @@ simde_int8x16_t
 simde_vnegq_s8(simde_int8x16_t a) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vnegq_s8(a);
-  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
     return vec_neg(a);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_i8x16_neg(a);
@@ -293,7 +293,7 @@ simde_int16x8_t
 simde_vnegq_s16(simde_int16x8_t a) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vnegq_s16(a);
-  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
     return vec_neg(a);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_i16x8_neg(a);
@@ -324,7 +324,7 @@ simde_int32x4_t
 simde_vnegq_s32(simde_int32x4_t a) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vnegq_s32(a);
-  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
     return vec_neg(a);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_i32x4_neg(a);


### PR DESCRIPTION
Correct some AltiVec versions from P7 to P8.