### PR TITLE
allow skipping the inclusion of the complex header

### DIFF
--- a/simde/simde-math.h
+++ b/simde/simde-math.h
@@ -123,6 +123,7 @@
   #endif
 #endif
 
+#ifndef SIMDE_NO_COMPLEX
 #if !defined(__cplusplus)
   /* If this is a problem we *might* be able to avoid including
    * <complex.h> on some compilers (gcc, clang, and others which
@@ -213,6 +214,7 @@
   #if !defined(simde_math_cimagf)
     #define simde_math_cimagf(z) ((z).imag())
   #endif
+#endif
 #endif
 
 #if !defined(SIMDE_MATH_INFINITY)

--- a/simde/x86/svml.h
+++ b/simde/x86/svml.h
@@ -1577,6 +1577,7 @@ simde_mm512_mask_cbrt_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
   #define _mm512_mask_cbrt_pd(src, k, a) simde_mm512_mask_cbrt_pd(src, k, a)
 #endif
 
+#if !defined(SIMDE_NO_COMPLEX)
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128
 simde_mm_cexp_ps (simde__m128 a) {
@@ -1601,7 +1602,9 @@ simde_mm_cexp_ps (simde__m128 a) {
   #undef _mm_cexp_ps
   #define _mm_cexp_ps(a) simde_mm_cexp_ps(a)
 #endif
+#endif
 
+#if !defined(SIMDE_NO_COMPLEX)
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m256
 simde_mm256_cexp_ps (simde__m256 a) {
@@ -1625,6 +1628,7 @@ simde_mm256_cexp_ps (simde__m256 a) {
 #if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
   #undef _mm256_cexp_ps
   #define _mm256_cexp_ps(a) simde_mm256_cexp_ps(a)
+#endif
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES


### PR DESCRIPTION
the c++ `<complex>` header can add quite a bit of compilation overhead, since it includes the `io` headers to define serializing operations.  
this PR allows the user to define a macro `SIMDE_NO_COMPLEX` to skip that header, which reduces the compilation time of a trivial c++ program from ~0.46s to ~0.28s on my machine. not a massive gain by any means, but i thought it'd be nice to give this option.

```cpp
#define SIMDE_NO_COMPLEX
#include "simde/x86/avx2.h"
int main() {}
```