### PR TITLE
neon: SSE2 is needed for _mm_castps_si128 in ceq, cge, cgt, cle and clt

### DIFF
--- a/simde/arm/neon/ceq.h
+++ b/simde/arm/neon/ceq.h
@@ -324,7 +324,7 @@ simde_uint32x4_t
 simde_vceqq_f32(simde_float32x4_t a, simde_float32x4_t b) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vceqq_f32(a, b);
-  #elif defined(SIMDE_X86_SSE_NATIVE)
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_castps_si128(_mm_cmpeq_ps(a, b));
   #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmpeq(a, b));

--- a/simde/arm/neon/cge.h
+++ b/simde/arm/neon/cge.h
@@ -39,7 +39,7 @@ simde_uint32x4_t
 simde_vcgeq_f32(simde_float32x4_t a, simde_float32x4_t b) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vcgeq_f32(a, b);
-  #elif defined(SIMDE_X86_SSE_NATIVE)
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_castps_si128(_mm_cmpge_ps(a, b));
   #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmpge(a, b));

--- a/simde/arm/neon/cgt.h
+++ b/simde/arm/neon/cgt.h
@@ -41,7 +41,7 @@ simde_uint32x4_t
 simde_vcgtq_f32(simde_float32x4_t a, simde_float32x4_t b) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vcgtq_f32(a, b);
-  #elif defined(SIMDE_X86_SSE_NATIVE)
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_castps_si128(_mm_cmpgt_ps(a, b));
   #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmpgt(a, b));

--- a/simde/arm/neon/cle.h
+++ b/simde/arm/neon/cle.h
@@ -39,7 +39,7 @@ simde_uint32x4_t
 simde_vcleq_f32(simde_float32x4_t a, simde_float32x4_t b) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vcleq_f32(a, b);
-  #elif defined(SIMDE_X86_SSE_NATIVE)
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_castps_si128(_mm_cmple_ps(a, b));
   #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmple(a, b));

--- a/simde/arm/neon/clt.h
+++ b/simde/arm/neon/clt.h
@@ -41,7 +41,7 @@ simde_uint32x4_t
 simde_vcltq_f32(simde_float32x4_t a, simde_float32x4_t b) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vcltq_f32(a, b);
-  #elif defined(SIMDE_X86_SSE_NATIVE)
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_castps_si128(_mm_cmplt_ps(a, b));
   #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmplt(a, b));


### PR DESCRIPTION
The Intel compare float32 intrinsics only need SSE but the casts to integer require SSE2 :-(
If necessary it would be possible to get round this stupid situation with a memcpy instead of a cast.