### PR TITLE
sse/sse2: _mm512_abs_ps introduced in GCC7.1, simde_x_mm_abs_pd does not work before GCC 7.4

### DIFF
--- a/simde/x86/sse.h
+++ b/simde/x86/sse.h
@@ -922,7 +922,8 @@ simde_mm_avg_pu8 (simde__m64 a, simde__m64 b) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128
 simde_x_mm_abs_ps(simde__m128 a) {
-  #if defined(SIMDE_X86_AVX512F_NATIVE)
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && \
+        (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,1,0))
     return _mm512_castps512_ps128(_mm512_abs_ps(_mm512_castps128_ps512(a)));
   #else
     simde__m128_private

--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -404,7 +404,8 @@ simde_mm_set1_pd (simde_float64 a) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128d
 simde_x_mm_abs_pd(simde__m128d a) {
-  #if defined(SIMDE_X86_AVX512F_NATIVE)
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && \
+        (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,4,0))
     return _mm512_castpd512_pd128(_mm512_abs_pd(_mm512_castpd128_pd512(a)));
   #else
     simde__m128d_private


### PR DESCRIPTION
simde_x_mm_abs_ps was breaking MMseqs2 build on GCC 4.9. This should fix compilation on GCC < 7.1.