### PR TITLE
Fix image build error and deprecation warning from apt-key

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,8 +6,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN \
   apt-get update -y && \
-  apt-get install -y apt-utils curl gpg && \
   apt-get upgrade -y && \
+  apt-get install -y curl gpg && \
   curl -s "https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB" | gpg --dearmor > /etc/apt/trusted.gpg.d/intel.gpg && \
   echo "deb [arch=amd64] https://apt.repos.intel.com/oneapi all main" > /etc/apt/sources.list.d/oneAPI.list && \
   for arch in armhf arm64 ppc64el s390x i386 mips64el; do \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,11 +2,13 @@
 
 FROM debian:testing-slim
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN \
   apt-get update -y && \
+  apt-get install -y apt-utils curl gpg && \
   apt-get upgrade -y && \
-  apt-get install -y curl gpg && \
-  curl -s "https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB" | apt-key add - && \
+  curl -s "https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB" | gpg --dearmor > /etc/apt/trusted.gpg.d/intel.gpg && \
   echo "deb [arch=amd64] https://apt.repos.intel.com/oneapi all main" > /etc/apt/sources.list.d/oneAPI.list && \
   for arch in armhf arm64 ppc64el s390x i386 mips64el; do \
     dpkg --add-architecture "$arch"; \

--- a/docker/Dockerfile-unstable
+++ b/docker/Dockerfile-unstable
@@ -2,11 +2,13 @@
 
 FROM debian:unstable-slim
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN \
   apt-get update -y && \
+  apt-get install -y apt-utils curl gpg && \
   apt-get upgrade -y && \
-  apt-get install -y curl gpg && \
-  curl -s "https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB" | apt-key add - && \
+  curl -s "https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB" | gpg --dearmor > /etc/apt/trusted.gpg.d/intel.gpg && \
   echo "deb [arch=amd64] https://apt.repos.intel.com/oneapi all main" > /etc/apt/sources.list.d/oneAPI.list && \
   for arch in armhf arm64 ppc64el s390x i386 mips64el; do \
     dpkg --add-architecture "$arch"; \

--- a/docker/Dockerfile-unstable
+++ b/docker/Dockerfile-unstable
@@ -6,8 +6,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN \
   apt-get update -y && \
-  apt-get install -y apt-utils curl gpg && \
   apt-get upgrade -y && \
+  apt-get install -y curl gpg && \
   curl -s "https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB" | gpg --dearmor > /etc/apt/trusted.gpg.d/intel.gpg && \
   echo "deb [arch=amd64] https://apt.repos.intel.com/oneapi all main" > /etc/apt/sources.list.d/oneAPI.list && \
   for arch in armhf arm64 ppc64el s390x i386 mips64el; do \


### PR DESCRIPTION
This fixes #633.

I have tested the image build with this change and it now finishes successfully.

I also noticed a deprecation warning from apt-key so I updated it to use `gpg --dearmor` and place the keys directly into `/etc/apt/trusted.gpg.d/intel.gpg`. It doesn't look like Debain are going to remove `apt-key` for a couple of years (https://manpages.debian.org/testing/apt/apt-key.8.en.html) but might as well fix it now.