### PR TITLE
avx512: add 128- and 256-bit intrinsics and translations to permutexvar

### DIFF
--- a/simde/x86/avx512/permutexvar.h
+++ b/simde/x86/avx512/permutexvar.h
@@ -534,7 +534,7 @@ simde_mm256_permutexvar_pd (simde__m256i idx, simde__m256d a) {
   #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
     return _mm256_permutexvar_pd(idx, a);
   #else
-    return HEDLEY_REINTERPRET_CAST(simde__m256d, simde_mm256_permutexvar_epi64(idx, HEDLEY_REINTERPRET_CAST(simde__m256i, a)));
+    return simde_mm256_castsi256_pd(simde_mm256_permutexvar_epi64(idx, simde_mm256_castpd_si256(a)));
   #endif
 }
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
@@ -578,7 +578,7 @@ simde_mm256_permutexvar_ps (simde__m256i idx, simde__m256 a) {
   #elif defined(SIMDE_X86_AVX2_NATIVE)
     return simde_mm256_permutevar8x32_ps(a, idx);
   #else
-    return HEDLEY_REINTERPRET_CAST(simde__m256, simde_mm256_permutexvar_epi32(idx, HEDLEY_REINTERPRET_CAST(simde__m256i, a)));
+    return simde_mm256_castsi256_ps(simde_mm256_permutexvar_epi32(idx, simde_mm256_castps_si256(a)));
   #endif
 }
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
@@ -775,9 +775,9 @@ simde_mm512_permutexvar_epi32 (simde__m512i idx, simde__m512i a) {
         r0 = simde_mm256_permutevar8x32_epi32(a_.m256i[0], index);
         r1 = simde_mm256_permutevar8x32_epi32(a_.m256i[1], index);
         select = simde_mm256_slli_epi32(index, 28);
-        r_.m256i[i] = HEDLEY_REINTERPRET_CAST(simde__m256i, simde_mm256_blendv_ps(HEDLEY_REINTERPRET_CAST(simde__m256, r0),
-                                                                                  HEDLEY_REINTERPRET_CAST(simde__m256, r1),
-                                                                                  HEDLEY_REINTERPRET_CAST(simde__m256, select)));
+        r_.m256i[i] = simde_mm256_castps_si256(simde_mm256_blendv_ps(simde_mm256_castsi256_ps(r0),
+                                                                     simde_mm256_castsi256_ps(r1),
+                                                                     simde_mm256_castsi256_ps(select)));
       }
     #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
       uint8x16x4_t table = { { a_.m128i_private[0].neon_u8,
@@ -1095,7 +1095,7 @@ simde_mm512_permutexvar_pd (simde__m512i idx, simde__m512d a) {
   #if defined(SIMDE_X86_AVX512F_NATIVE)
     return _mm512_permutexvar_pd(idx, a);
   #else
-    return HEDLEY_REINTERPRET_CAST(simde__m512d, simde_mm512_permutexvar_epi64(idx, HEDLEY_REINTERPRET_CAST(simde__m512i, a)));
+    return simde_mm512_castsi512_pd(simde_mm512_permutexvar_epi64(idx, simde_mm512_castpd_si512(a)));
   #endif
 }
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
@@ -1137,7 +1137,7 @@ simde_mm512_permutexvar_ps (simde__m512i idx, simde__m512 a) {
   #if defined(SIMDE_X86_AVX512F_NATIVE)
     return _mm512_permutexvar_ps(idx, a);
   #else
-    return HEDLEY_REINTERPRET_CAST(simde__m512, simde_mm512_permutexvar_epi32(idx, HEDLEY_REINTERPRET_CAST(simde__m512i, a)));
+    return simde_mm512_castsi512_ps(simde_mm512_permutexvar_epi32(idx, simde_mm512_castps_si512(a)));
   #endif
 }
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)

--- a/simde/x86/avx512/permutexvar.h
+++ b/simde/x86/avx512/permutexvar.h
@@ -28,6 +28,10 @@
 #if !defined(SIMDE_X86_AVX512_PERMUTEXVAR_H)
 #define SIMDE_X86_AVX512_PERMUTEXVAR_H
 
+/* Currently (18th December 2020) using emsdk tot many tests fail on wasm with -O0, -O2 and -O3 */
+/* Only -O1 passes all tests */
+#define SIMDE_BUG_EMSCRIPTEN_OPTIMIZATION_FAILURES 1
+
 #include "types.h"
 #include "and.h"
 #include "andnot.h"
@@ -44,6 +48,573 @@ SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
 SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_permutexvar_epi16 (simde__m128i idx, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_permutexvar_epi16(idx, a);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE)
+    simde__m128i mask16 = simde_mm_set1_epi16(0x0007);
+    simde__m128i shift16 = simde_mm_set1_epi16(0x0202);
+    simde__m128i byte_index16 = simde_mm_set1_epi16(0x0100);
+    simde__m128i index16 = simde_mm_and_si128(idx, mask16);
+    index16 = simde_mm_mullo_epi16(index16, shift16);
+    index16 = simde_mm_add_epi16(index16, byte_index16);
+    return simde_mm_shuffle_epi8(a, index16);
+  #else
+    simde__m128i_private
+      idx_ = simde__m128i_to_private(idx),
+      a_ = simde__m128i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint16x8_t mask16 = vdupq_n_u16(0x0007);
+      uint16x8_t byte_index16 = vdupq_n_u16(0x0100);
+      uint16x8_t index16 = vandq_u16(idx_.neon_u16, mask16);
+      index16 = vmulq_n_u16(index16, 0x0202);
+      index16 = vaddq_u16(index16, byte_index16);
+      r_.neon_u8 = vqtbl1q_u8(a_.neon_u8, vreinterpretq_u8_u16(index16));
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) index16;
+      index16 = vec_and(idx_.altivec_u16, vec_splat_u16(7));
+      index16 = vec_mladd(index16, vec_splats(HEDLEY_STATIC_CAST(unsigned short, 0x0202)), vec_splats(HEDLEY_STATIC_CAST(unsigned short, 0x0100)));
+      r_.altivec_u8 = vec_perm(a_.altivec_u8, a_.altivec_u8, HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), index16));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      const v128_t mask16 = wasm_i16x8_splat(0x0007);
+      const v128_t shift16 = wasm_i16x8_splat(0x0202);
+      const v128_t byte_index16 = wasm_i16x8_splat(0x0100);
+      v128_t index16 = wasm_v128_and(idx_.wasm_v128, mask16);
+      index16 = wasm_i16x8_mul(index16, shift16);
+      index16 = wasm_i16x8_add(index16, byte_index16);
+      r_.wasm_v128 = wasm_v8x16_swizzle(a_.wasm_v128, index16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i16[idx_.i16[i] & 0x07];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_permutexvar_epi16
+  #define _mm_permutexvar_epi16(idx, a) simde_mm_permutexvar_epi16(idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_permutexvar_epi16 (simde__m128i src, simde__mmask8 k, simde__m128i idx, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_mask_permutexvar_epi16(src, k, idx, a);
+  #else
+    return simde_mm_mask_mov_epi16(src, k, simde_mm_permutexvar_epi16(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_permutexvar_epi16
+  #define _mm_mask_permutexvar_epi16(src, k, idx, a) simde_mm_mask_permutexvar_epi16(src, k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_permutexvar_epi16 (simde__mmask8 k, simde__m128i idx, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_maskz_permutexvar_epi16(k, idx, a);
+  #else
+    return simde_mm_maskz_mov_epi16(k, simde_mm_permutexvar_epi16(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_permutexvar_epi16
+  #define _mm_maskz_permutexvar_epi16(k, idx, a) simde_mm_maskz_permutexvar_epi16(k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_permutexvar_epi8 (simde__m128i idx, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VBMI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_permutexvar_epi8(idx, a);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE)
+    simde__m128i mask = simde_mm_set1_epi8(0x0F);
+    simde__m128i index = simde_mm_and_si128(idx, mask);
+    return simde_mm_shuffle_epi8(a, index);
+  #else
+    simde__m128i_private
+      idx_ = simde__m128i_to_private(idx),
+      a_ = simde__m128i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint8x16_t mask = vdupq_n_u8(0x0F);
+      uint8x16_t index = vandq_u8(idx_.neon_u8, mask);
+      r_.neon_u8 = vqtbl1q_u8(a_.neon_u8, index);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_u8 = vec_perm(a_.altivec_u8, a_.altivec_u8, idx_.altivec_u8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      const v128_t mask = wasm_i8x16_splat(0x0F);
+      v128_t index = wasm_v128_and(idx_.wasm_v128, mask);
+      r_.wasm_v128 = wasm_v8x16_swizzle(a_.wasm_v128, index);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a_.i8[idx_.i8[i] & 0x0F];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VBMI_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_permutexvar_epi8
+  #define _mm_permutexvar_epi8(idx, a) simde_mm_permutexvar_epi8(idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_permutexvar_epi8 (simde__m128i src, simde__mmask16 k, simde__m128i idx, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VBMI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_mask_permutexvar_epi8(src, k, idx, a);
+  #else
+    return simde_mm_mask_mov_epi8(src, k, simde_mm_permutexvar_epi8(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VBMI_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_permutexvar_epi8
+  #define _mm_mask_permutexvar_epi8(src, k, idx, a) simde_mm_mask_permutexvar_epi8(src, k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_permutexvar_epi8 (simde__mmask16 k, simde__m128i idx, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VBMI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_maskz_permutexvar_epi8(k, idx, a);
+  #else
+    return simde_mm_maskz_mov_epi8(k, simde_mm_permutexvar_epi8(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VBMI_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_permutexvar_epi8
+  #define _mm_maskz_permutexvar_epi8(k, idx, a) simde_mm_maskz_permutexvar_epi8(k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_permutexvar_epi16 (simde__m256i idx, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_permutexvar_epi16(idx, a);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    simde__m256i mask16 = simde_mm256_set1_epi16(0x001F);
+    simde__m256i shift16 = simde_mm256_set1_epi16(0x0202);
+    simde__m256i byte_index16 = simde_mm256_set1_epi16(0x0100);
+    simde__m256i index16 = simde_mm256_and_si256(idx, mask16);
+    index16 = simde_mm256_mullo_epi16(index16, shift16);
+    simde__m256i lo = simde_mm256_permute4x64_epi64(a, (1 << 6) + (0 << 4) + (1 << 2) + (0 << 0));
+    simde__m256i hi = simde_mm256_permute4x64_epi64(a, (3 << 6) + (2 << 4) + (3 << 2) + (2 << 0));
+    simde__m256i select = simde_mm256_slli_epi64(index16, 3);
+    index16 = simde_mm256_add_epi16(index16, byte_index16);
+    lo = simde_mm256_shuffle_epi8(lo, index16);
+    hi = simde_mm256_shuffle_epi8(hi, index16);
+    return simde_mm256_blendv_epi8(lo, hi, select);
+  #else
+    simde__m256i_private
+      idx_ = simde__m256i_to_private(idx),
+      a_ = simde__m256i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint8x16x2_t table = { { a_.m128i_private[0].neon_u8,
+                               a_.m128i_private[1].neon_u8 } };
+      uint16x8_t mask16 = vdupq_n_u16(0x000F);
+      uint16x8_t byte_index16 = vdupq_n_u16(0x0100);
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m128i_private) / sizeof(r_.m128i_private[0])) ; i++) {
+        uint16x8_t index16 = vandq_u16(idx_.m128i_private[i].neon_u16, mask16);
+        index16 = vmulq_n_u16(index16, 0x0202);
+        index16 = vaddq_u16(index16, byte_index16);
+        r_.m128i_private[i].neon_u8 = vqtbl2q_u8(table, vreinterpretq_u8_u16(index16));
+      }
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) index16, mask16, shift16, byte_index16;
+      mask16 = vec_splat_u16(0x000F);
+      shift16 = vec_splats(HEDLEY_STATIC_CAST(unsigned short, 0x0202));
+      byte_index16 = vec_splats(HEDLEY_STATIC_CAST(unsigned short, 0x0100));
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m128i_private) / sizeof(r_.m128i_private[0])) ; i++) {
+        index16 = vec_and(idx_.m128i_private[i].altivec_u16, mask16);
+        index16 = vec_mladd(index16, shift16, byte_index16);
+        r_.m128i_private[i].altivec_u8 = vec_perm(a_.m128i_private[0].altivec_u8,
+                                                  a_.m128i_private[1].altivec_u8,
+                                                  HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), index16));
+      }
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE) && !SIMDE_BUG_EMSCRIPTEN_OPTIMIZATION_FAILURES
+      v128_t index, index16, r, t;
+      const v128_t mask16 = wasm_i16x8_splat(0x000F);
+      const v128_t shift16 = wasm_i16x8_splat(0x0202);
+      const v128_t byte_index16 = wasm_i16x8_splat(0x0100);
+      const v128_t sixteen = wasm_i8x16_splat(16);
+      const v128_t a0 = a_.m128i_private[0].wasm_v128;
+      const v128_t a1 = a_.m128i_private[1].wasm_v128;
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m128i_private) / sizeof(r_.m128i_private[0])) ; i++) {
+        index16 = wasm_v128_and(idx_.m128i_private[i].wasm_v128, mask16);
+        index16 = wasm_i16x8_mul(index16, shift16);
+        index = wasm_i16x8_add(index16, byte_index16);
+        r = wasm_v8x16_swizzle(a0, index);
+
+        index = wasm_i8x16_sub(index, sixteen);
+        t = wasm_v8x16_swizzle(a1, index);
+        r_.m128i_private[i].wasm_v128 = wasm_v128_or(r, t);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i16[idx_.i16[i] & 0x0F];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_permutexvar_epi16
+  #define _mm256_permutexvar_epi16(idx, a) simde_mm256_permutexvar_epi16(idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_permutexvar_epi16 (simde__m256i src, simde__mmask16 k, simde__m256i idx, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_permutexvar_epi16(src, k, idx, a);
+  #else
+    return simde_mm256_mask_mov_epi16(src, k, simde_mm256_permutexvar_epi16(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_permutexvar_epi16
+  #define _mm256_mask_permutexvar_epi16(src, k, idx, a) simde_mm256_mask_permutexvar_epi16(src, k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskz_permutexvar_epi16 (simde__mmask16 k, simde__m256i idx, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_permutexvar_epi16(k, idx, a);
+  #else
+    return simde_mm256_maskz_mov_epi16(k, simde_mm256_permutexvar_epi16(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_permutexvar_epi16
+  #define _mm256_maskz_permutexvar_epi16(k, idx, a) simde_mm256_maskz_permutexvar_epi16(k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_permutexvar_epi32 (simde__m256i idx, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_permutexvar_epi32(idx, a);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    return simde_mm256_permutevar8x32_epi32(a, idx);
+  #else
+    simde__m256i_private
+      idx_ = simde__m256i_to_private(idx),
+      a_ = simde__m256i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint8x16x2_t table = { { a_.m128i_private[0].neon_u8,
+                               a_.m128i_private[1].neon_u8 } };
+      uint32x4_t mask32 = vdupq_n_u32(0x00000007);
+      uint32x4_t byte_index32 = vdupq_n_u32(0x03020100);
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m128i_private) / sizeof(r_.m128i_private[0])) ; i++) {
+        uint32x4_t index32 = vandq_u32(idx_.m128i_private[i].neon_u32, mask32);
+        index32 = vmulq_n_u32(index32, 0x04040404);
+        index32 = vaddq_u32(index32, byte_index32);
+        r_.m128i_private[i].neon_u8 = vqtbl2q_u8(table, vreinterpretq_u8_u32(index32));
+      }
+    #else
+      #if !defined(__INTEL_COMPILER)
+        SIMDE_VECTORIZE
+      #endif
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[idx_.i32[i] & 0x07];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_permutexvar_epi32
+  #define _mm256_permutexvar_epi32(idx, a) simde_mm256_permutexvar_epi32(idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_permutexvar_epi32 (simde__m256i src, simde__mmask8 k, simde__m256i idx, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_permutexvar_epi32(src, k, idx, a);
+  #else
+    return simde_mm256_mask_mov_epi32(src, k, simde_mm256_permutexvar_epi32(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_permutexvar_epi32
+  #define _mm256_mask_permutexvar_epi32(src, k, idx, a) simde_mm256_mask_permutexvar_epi32(src, k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskz_permutexvar_epi32 (simde__mmask8 k, simde__m256i idx, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_permutexvar_epi32(k, idx, a);
+  #else
+    return simde_mm256_maskz_mov_epi32(k, simde_mm256_permutexvar_epi32(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_permutexvar_epi32
+  #define _mm256_maskz_permutexvar_epi32(k, idx, a) simde_mm256_maskz_permutexvar_epi32(k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_permutexvar_epi64 (simde__m256i idx, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_permutexvar_epi64(idx, a);
+  #else
+    simde__m256i_private
+      idx_ = simde__m256i_to_private(idx),
+      a_ = simde__m256i_to_private(a),
+      r_;
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = a_.i64[idx_.i64[i] & 3];
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_permutexvar_epi64
+  #define _mm256_permutexvar_epi64(idx, a) simde_mm256_permutexvar_epi64(idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_permutexvar_epi64 (simde__m256i src, simde__mmask8 k, simde__m256i idx, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_permutexvar_epi64(src, k, idx, a);
+  #else
+    return simde_mm256_mask_mov_epi64(src, k, simde_mm256_permutexvar_epi64(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_permutexvar_epi64
+  #define _mm256_mask_permutexvar_epi64(src, k, idx, a) simde_mm256_mask_permutexvar_epi64(src, k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskz_permutexvar_epi64 (simde__mmask8 k, simde__m256i idx, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_permutexvar_epi64(k, idx, a);
+  #else
+    return simde_mm256_maskz_mov_epi64(k, simde_mm256_permutexvar_epi64(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_permutexvar_epi64
+  #define _mm256_maskz_permutexvar_epi64(k, idx, a) simde_mm256_maskz_permutexvar_epi64(k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_permutexvar_epi8 (simde__m256i idx, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512VBMI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_permutexvar_epi8(idx, a);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    simde__m256i mask = simde_mm256_set1_epi8(0x0F);
+    simde__m256i lo = simde_mm256_permute4x64_epi64(a, (1 << 6) + (0 << 4) + (1 << 2) + (0 << 0));
+    simde__m256i hi = simde_mm256_permute4x64_epi64(a, (3 << 6) + (2 << 4) + (3 << 2) + (2 << 0));
+    simde__m256i index = simde_mm256_and_si256(idx, mask);
+    simde__m256i select = simde_mm256_slli_epi64(idx, 3);
+    lo = simde_mm256_shuffle_epi8(lo, index);
+    hi = simde_mm256_shuffle_epi8(hi, index);
+    return simde_mm256_blendv_epi8(lo, hi, select);
+  #else
+    simde__m256i_private
+      idx_ = simde__m256i_to_private(idx),
+      a_ = simde__m256i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint8x16x2_t table = { { a_.m128i_private[0].neon_u8,
+                               a_.m128i_private[1].neon_u8 } };
+      uint8x16_t mask = vdupq_n_u8(0x1F);
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m128i_private) / sizeof(r_.m128i_private[0])) ; i++) {
+        r_.m128i_private[i].neon_u8 = vqtbl2q_u8(table, vandq_u8(idx_.m128i_private[i].neon_u8, mask));
+      }
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m128i_private) / sizeof(r_.m128i_private[0])) ; i++) {
+        r_.m128i_private[i].altivec_u8 = vec_perm(a_.m128i_private[0].altivec_u8, a_.m128i_private[1].altivec_u8, idx_.m128i_private[i].altivec_u8);
+      }
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE) && !SIMDE_BUG_EMSCRIPTEN_OPTIMIZATION_FAILURES
+      v128_t index, r, t;
+      const v128_t mask = wasm_i8x16_splat(0x1F);
+      const v128_t sixteen = wasm_i8x16_splat(16);
+      const v128_t a0 = a_.m128i_private[0].wasm_v128;
+      const v128_t a1 = a_.m128i_private[1].wasm_v128;
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m128i_private) / sizeof(r_.m128i_private[0])) ; i++) {
+        index = wasm_v128_and(idx_.m128i_private[i].wasm_v128, mask);
+        r = wasm_v8x16_swizzle(a0, index);
+        index = wasm_i8x16_sub(index, sixteen);
+        t = wasm_v8x16_swizzle(a1, index);
+        r_.m128i_private[i].wasm_v128 = wasm_v128_or(r, t);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a_.i8[idx_.i8[i] & 0x1F];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VBMI_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_permutexvar_epi8
+  #define _mm256_permutexvar_epi8(idx, a) simde_mm256_permutexvar_epi8(idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_permutexvar_epi8 (simde__m256i src, simde__mmask32 k, simde__m256i idx, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512VBMI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_permutexvar_epi8(src, k, idx, a);
+  #else
+    return simde_mm256_mask_mov_epi8(src, k, simde_mm256_permutexvar_epi8(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VBMI_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_permutexvar_epi8
+  #define _mm256_mask_permutexvar_epi8(src, k, idx, a) simde_mm256_mask_permutexvar_epi8(src, k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskz_permutexvar_epi8 (simde__mmask32 k, simde__m256i idx, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512VBMI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_permutexvar_epi8(k, idx, a);
+  #else
+    return simde_mm256_maskz_mov_epi8(k, simde_mm256_permutexvar_epi8(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VBMI_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_permutexvar_epi8
+  #define _mm256_maskz_permutexvar_epi8(k, idx, a) simde_mm256_maskz_permutexvar_epi8(k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_permutexvar_pd (simde__m256i idx, simde__m256d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_permutexvar_pd(idx, a);
+  #else
+    return HEDLEY_REINTERPRET_CAST(simde__m256d, simde_mm256_permutexvar_epi64(idx, HEDLEY_REINTERPRET_CAST(simde__m256i, a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_permutexvar_pd
+  #define _mm256_permutexvar_pd(idx, a) simde_mm256_permutexvar_pd(idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_mask_permutexvar_pd (simde__m256d src, simde__mmask8 k, simde__m256i idx, simde__m256d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_permutexvar_pd(src, k, idx, a);
+  #else
+    return simde_mm256_mask_mov_pd(src, k, simde_mm256_permutexvar_pd(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_permutexvar_pd
+  #define _mm256_mask_permutexvar_pd(src, k, idx, a) simde_mm256_mask_permutexvar_pd(src, k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_maskz_permutexvar_pd (simde__mmask8 k, simde__m256i idx, simde__m256d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_permutexvar_pd(k, idx, a);
+  #else
+    return simde_mm256_maskz_mov_pd(k, simde_mm256_permutexvar_pd(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_permutexvar_pd
+  #define _mm256_maskz_permutexvar_pd(k, idx, a) simde_mm256_maskz_permutexvar_pd(k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_permutexvar_ps (simde__m256i idx, simde__m256 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_permutexvar_ps(idx, a);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    return simde_mm256_permutevar8x32_ps(a, idx);
+  #else
+    return HEDLEY_REINTERPRET_CAST(simde__m256, simde_mm256_permutexvar_epi32(idx, HEDLEY_REINTERPRET_CAST(simde__m256i, a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_permutexvar_ps
+  #define _mm256_permutexvar_ps(idx, a) simde_mm256_permutexvar_ps(idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_mask_permutexvar_ps (simde__m256 src, simde__mmask8 k, simde__m256i idx, simde__m256 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_permutexvar_ps(src, k, idx, a);
+  #else
+    return simde_mm256_mask_mov_ps(src, k, simde_mm256_permutexvar_ps(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_permutexvar_ps
+  #define _mm256_mask_permutexvar_ps(src, k, idx, a) simde_mm256_mask_permutexvar_ps(src, k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_maskz_permutexvar_ps (simde__mmask8 k, simde__m256i idx, simde__m256 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_permutexvar_ps(k, idx, a);
+  #else
+    return simde_mm256_maskz_mov_ps(k, simde_mm256_permutexvar_ps(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_permutexvar_ps
+  #define _mm256_maskz_permutexvar_ps(k, idx, a) simde_mm256_maskz_permutexvar_ps(k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
 simde__m512i
 simde_mm512_permutexvar_epi16 (simde__m512i idx, simde__m512i a) {
   #if defined(SIMDE_X86_AVX512BW_NATIVE)
@@ -54,7 +625,33 @@ simde_mm512_permutexvar_epi16 (simde__m512i idx, simde__m512i a) {
       a_ = simde__m512i_to_private(a),
       r_;
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    #if defined(SIMDE_X86_AVX2_NATIVE)
+      simde__m256i t0, t1, index, select, a01, a23;
+      simde__m256i mask = simde_mm256_set1_epi16(0x001F);
+      simde__m256i shift = simde_mm256_set1_epi16(0x0202);
+      simde__m256i byte_index = simde_mm256_set1_epi16(0x0100);
+      simde__m256i a0 = simde_mm256_broadcastsi128_si256(a_.m128i[0]);
+      simde__m256i a1 = simde_mm256_broadcastsi128_si256(a_.m128i[1]);
+      simde__m256i a2 = simde_mm256_broadcastsi128_si256(a_.m128i[2]);
+      simde__m256i a3 = simde_mm256_broadcastsi128_si256(a_.m128i[3]);
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256i_private) / sizeof(r_.m256i_private[0])) ; i++) {
+        index = idx_.m256i[i];
+        index = simde_mm256_and_si256(index, mask);
+        index = simde_mm256_mullo_epi16(index, shift);
+        index = simde_mm256_add_epi16(index, byte_index);
+        t0 = simde_mm256_shuffle_epi8(a0, index);
+        t1 = simde_mm256_shuffle_epi8(a1, index);
+        select = simde_mm256_slli_epi64(index, 3);
+        a01 = simde_mm256_blendv_epi8(t0, t1, select);
+        t0 = simde_mm256_shuffle_epi8(a2, index);
+        t1 = simde_mm256_shuffle_epi8(a3, index);
+        a23 = simde_mm256_blendv_epi8(t0, t1, select);
+        select = simde_mm256_slli_epi64(index, 2);
+        r_.m256i[i] = simde_mm256_blendv_epi8(a01, a23, select);
+      }
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
       uint8x16x4_t table = { { a_.m128i_private[0].neon_u8,
                                a_.m128i_private[1].neon_u8,
                                a_.m128i_private[2].neon_u8,
@@ -68,6 +665,53 @@ simde_mm512_permutexvar_epi16 (simde__m512i idx, simde__m512i a) {
         index16 = vmulq_n_u16(index16, 0x0202);
         index16 = vaddq_u16(index16, byte_index16);
         r_.m128i_private[i].neon_u8 = vqtbl4q_u8(table, vreinterpretq_u8_u16(index16));
+      }
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) index16, mask16, shift16, byte_index16;
+      SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) index, test, r01, r23;
+      mask16 = vec_splats(HEDLEY_STATIC_CAST(unsigned short, 0x001F));
+      shift16 = vec_splats(HEDLEY_STATIC_CAST(unsigned short, 0x0202));
+      byte_index16 = vec_splats(HEDLEY_STATIC_CAST(unsigned short, 0x0100));
+      test = vec_splats(HEDLEY_STATIC_CAST(unsigned char, 0x20));
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m128i_private) / sizeof(r_.m128i_private[0])) ; i++) {
+        index16 = vec_and(idx_.m128i_private[i].altivec_u16, mask16);
+        index16 = vec_mladd(index16, shift16, byte_index16);
+        index = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), index16);
+        r01 = vec_perm(a_.m128i_private[0].altivec_u8, a_.m128i_private[1].altivec_u8, index);
+        r23 = vec_perm(a_.m128i_private[2].altivec_u8, a_.m128i_private[3].altivec_u8, index);
+        r_.m128i_private[i].altivec_u8 = vec_sel(r01, r23, vec_cmpeq(vec_and(index, test), test));
+      }
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE) && !SIMDE_BUG_EMSCRIPTEN_OPTIMIZATION_FAILURES
+      v128_t index, r, t;
+      const v128_t mask = wasm_i16x8_splat(0x001F);
+      const v128_t shift = wasm_i16x8_splat(0x0202);
+      const v128_t byte_index = wasm_i16x8_splat(0x0100);
+      const v128_t sixteen = wasm_i8x16_splat(16);
+      const v128_t a0 = a_.m128i_private[0].wasm_v128;
+      const v128_t a1 = a_.m128i_private[1].wasm_v128;
+      const v128_t a2 = a_.m128i_private[2].wasm_v128;
+      const v128_t a3 = a_.m128i_private[3].wasm_v128;
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m128i_private) / sizeof(r_.m128i_private[0])) ; i++) {
+        index = wasm_v128_and(idx_.m128i_private[i].wasm_v128, mask);
+        index = wasm_i16x8_mul(index, shift);
+        index = wasm_i16x8_add(index, byte_index);
+        r = wasm_v8x16_swizzle(a0, index);
+
+        index = wasm_i8x16_sub(index, sixteen);
+        t = wasm_v8x16_swizzle(a1, index);
+        r = wasm_v128_or(r, t);
+
+        index = wasm_i8x16_sub(index, sixteen);
+        t = wasm_v8x16_swizzle(a2, index);
+        r = wasm_v128_or(r, t);
+
+        index = wasm_i8x16_sub(index, sixteen);
+        t = wasm_v8x16_swizzle(a3, index);
+        r_.m128i_private[i].wasm_v128 = wasm_v128_or(r, t);
       }
     #else
       SIMDE_VECTORIZE
@@ -123,7 +767,19 @@ simde_mm512_permutexvar_epi32 (simde__m512i idx, simde__m512i a) {
       a_ = simde__m512i_to_private(a),
       r_;
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    #if defined(SIMDE_X86_AVX2_NATIVE)
+      simde__m256i index, r0, r1, select;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256i_private) / sizeof(r_.m256i_private[0])) ; i++) {
+        index = idx_.m256i[i];
+        r0 = simde_mm256_permutevar8x32_epi32(a_.m256i[0], index);
+        r1 = simde_mm256_permutevar8x32_epi32(a_.m256i[1], index);
+        select = simde_mm256_slli_epi32(index, 28);
+        r_.m256i[i] = HEDLEY_REINTERPRET_CAST(simde__m256i, simde_mm256_blendv_ps(HEDLEY_REINTERPRET_CAST(simde__m256, r0),
+                                                                                  HEDLEY_REINTERPRET_CAST(simde__m256, r1),
+                                                                                  HEDLEY_REINTERPRET_CAST(simde__m256, select)));
+      }
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
       uint8x16x4_t table = { { a_.m128i_private[0].neon_u8,
                                a_.m128i_private[1].neon_u8,
                                a_.m128i_private[2].neon_u8,
@@ -137,6 +793,60 @@ simde_mm512_permutexvar_epi32 (simde__m512i idx, simde__m512i a) {
         index32 = vmulq_n_u32(index32, 0x04040404);
         index32 = vaddq_u32(index32, byte_index32);
         r_.m128i_private[i].neon_u8 = vqtbl4q_u8(table, vreinterpretq_u8_u32(index32));
+      }
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) index32, mask32, byte_index32, temp32, two, eight, sixteen;
+      SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) index, test, r01, r23;
+      mask32 = vec_splats(HEDLEY_STATIC_CAST(unsigned int, 0x0000000F));
+      byte_index32 = vec_splats(HEDLEY_STATIC_CAST(unsigned int, 0x03020100));
+      two = vec_splat_u32(2);
+      eight = vec_splat_u32(8);
+      sixteen = vec_splats(HEDLEY_STATIC_CAST(unsigned int, 16));
+      test = vec_splats(HEDLEY_STATIC_CAST(unsigned char, 0x20));
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m128i_private) / sizeof(r_.m128i_private[0])) ; i++) {
+        index32 = vec_and(idx_.m128i_private[i].altivec_u32, mask32);
+        index32 = vec_sl(index32, two);
+        temp32 = vec_sl(index32, eight);
+        index32 = vec_add(index32, temp32);
+        temp32 = vec_sl(index32, sixteen);
+        index32 = vec_add(index32, temp32);
+        index32 = vec_add(index32, byte_index32);
+        index = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), index32);
+        r01 = vec_perm(a_.m128i_private[0].altivec_u8, a_.m128i_private[1].altivec_u8, index);
+        r23 = vec_perm(a_.m128i_private[2].altivec_u8, a_.m128i_private[3].altivec_u8, index);
+        r_.m128i_private[i].altivec_u8 = vec_sel(r01, r23, vec_cmpeq(vec_and(index, test), test));
+      }
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE) && !SIMDE_BUG_EMSCRIPTEN_OPTIMIZATION_FAILURES
+      v128_t index, r, t;
+      const v128_t mask = wasm_i32x4_splat(0x0000000F);
+      const v128_t shift = wasm_i32x4_splat(0x04040404);
+      const v128_t byte_index = wasm_i32x4_splat(0x03020100);
+      const v128_t sixteen = wasm_i8x16_splat(16);
+      const v128_t a0 = a_.m128i_private[0].wasm_v128;
+      const v128_t a1 = a_.m128i_private[1].wasm_v128;
+      const v128_t a2 = a_.m128i_private[2].wasm_v128;
+      const v128_t a3 = a_.m128i_private[3].wasm_v128;
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m128i_private) / sizeof(r_.m128i_private[0])) ; i++) {
+        index = wasm_v128_and(idx_.m128i_private[i].wasm_v128, mask);
+        index = wasm_i32x4_mul(index, shift);
+        index = wasm_i32x4_add(index, byte_index);
+        r = wasm_v8x16_swizzle(a0, index);
+
+        index = wasm_i8x16_sub(index, sixteen);
+        t = wasm_v8x16_swizzle(a1, index);
+        r = wasm_v128_or(r, t);
+
+        index = wasm_i8x16_sub(index, sixteen);
+        t = wasm_v8x16_swizzle(a2, index);
+        r = wasm_v128_or(r, t);
+
+        index = wasm_i8x16_sub(index, sixteen);
+        t = wasm_v8x16_swizzle(a3, index);
+        r_.m128i_private[i].wasm_v128 = wasm_v128_or(r, t);
       }
     #else
       #if !defined(__INTEL_COMPILER)
@@ -268,7 +978,29 @@ simde_mm512_permutexvar_epi8 (simde__m512i idx, simde__m512i a) {
       a_ = simde__m512i_to_private(a),
       r_;
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    #if defined(SIMDE_X86_AVX2_NATIVE)
+      simde__m256i t0, t1, index, select, a01, a23;
+      simde__m256i mask = simde_mm256_set1_epi8(0x3F);
+      simde__m256i a0 = simde_mm256_broadcastsi128_si256(a_.m128i[0]);
+      simde__m256i a1 = simde_mm256_broadcastsi128_si256(a_.m128i[1]);
+      simde__m256i a2 = simde_mm256_broadcastsi128_si256(a_.m128i[2]);
+      simde__m256i a3 = simde_mm256_broadcastsi128_si256(a_.m128i[3]);
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256i_private) / sizeof(r_.m256i_private[0])) ; i++) {
+        index = idx_.m256i[i];
+        index = simde_mm256_and_si256(index, mask);
+        select = simde_mm256_slli_epi64(index, 3);
+        t0 = simde_mm256_shuffle_epi8(a0, index);
+        t1 = simde_mm256_shuffle_epi8(a1, index);
+        a01 = simde_mm256_blendv_epi8(t0, t1, select);
+        t0 = simde_mm256_shuffle_epi8(a2, index);
+        t1 = simde_mm256_shuffle_epi8(a3, index);
+        a23 = simde_mm256_blendv_epi8(t0, t1, select);
+        select = simde_mm256_slli_epi64(index, 2);
+        r_.m256i[i] = simde_mm256_blendv_epi8(a01, a23, select);
+      }
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
       uint8x16x4_t table = { { a_.m128i_private[0].neon_u8,
                                a_.m128i_private[1].neon_u8,
                                a_.m128i_private[2].neon_u8,
@@ -278,6 +1010,41 @@ simde_mm512_permutexvar_epi8 (simde__m512i idx, simde__m512i a) {
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.m128i_private) / sizeof(r_.m128i_private[0])) ; i++) {
         r_.m128i_private[i].neon_u8 = vqtbl4q_u8(table, vandq_u8(idx_.m128i_private[i].neon_u8, mask));
+      }
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) test, r01, r23;
+      test = vec_splats(HEDLEY_STATIC_CAST(unsigned char, 0x20));
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m128i_private) / sizeof(r_.m128i_private[0])) ; i++) {
+        r01 = vec_perm(a_.m128i_private[0].altivec_u8, a_.m128i_private[1].altivec_u8, idx_.m128i_private[i].altivec_u8);
+        r23 = vec_perm(a_.m128i_private[2].altivec_u8, a_.m128i_private[3].altivec_u8, idx_.m128i_private[i].altivec_u8);
+        r_.m128i_private[i].altivec_u8 = vec_sel(r01, r23, vec_cmpeq(vec_and(idx_.m128i_private[i].altivec_u8, test), test));
+      }
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE) && !SIMDE_BUG_EMSCRIPTEN_OPTIMIZATION_FAILURES
+      v128_t index, r, t;
+      const v128_t mask = wasm_i8x16_splat(0x3F);
+      const v128_t sixteen = wasm_i8x16_splat(16);
+      const v128_t a0 = a_.m128i_private[0].wasm_v128;
+      const v128_t a1 = a_.m128i_private[1].wasm_v128;
+      const v128_t a2 = a_.m128i_private[2].wasm_v128;
+      const v128_t a3 = a_.m128i_private[3].wasm_v128;
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m128i_private) / sizeof(r_.m128i_private[0])) ; i++) {
+        index = wasm_v128_and(idx_.m128i_private[i].wasm_v128, mask);
+        r = wasm_v8x16_swizzle(a0, index);
+
+        index = wasm_i8x16_sub(index, sixteen);
+        t = wasm_v8x16_swizzle(a1, index);
+        r = wasm_v128_or(r, t);
+
+        index = wasm_i8x16_sub(index, sixteen);
+        t = wasm_v8x16_swizzle(a2, index);
+        r = wasm_v128_or(r, t);
+
+        index = wasm_i8x16_sub(index, sixteen);
+        t = wasm_v8x16_swizzle(a3, index);
+        r_.m128i_private[i].wasm_v128 = wasm_v128_or(r, t);
       }
     #else
       SIMDE_VECTORIZE
@@ -328,19 +1095,7 @@ simde_mm512_permutexvar_pd (simde__m512i idx, simde__m512d a) {
   #if defined(SIMDE_X86_AVX512F_NATIVE)
     return _mm512_permutexvar_pd(idx, a);
   #else
-    simde__m512i_private idx_ = simde__m512i_to_private(idx);
-    simde__m512d_private
-      a_ = simde__m512d_to_private(a),
-      r_;
-
-    #if !defined(__INTEL_COMPILER)
-      SIMDE_VECTORIZE
-    #endif
-    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-      r_.f64[i] = a_.f64[idx_.i64[i] & 7];
-    }
-
-    return simde__m512d_from_private(r_);
+    return HEDLEY_REINTERPRET_CAST(simde__m512d, simde_mm512_permutexvar_epi64(idx, HEDLEY_REINTERPRET_CAST(simde__m512i, a)));
   #endif
 }
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
@@ -382,19 +1137,7 @@ simde_mm512_permutexvar_ps (simde__m512i idx, simde__m512 a) {
   #if defined(SIMDE_X86_AVX512F_NATIVE)
     return _mm512_permutexvar_ps(idx, a);
   #else
-    simde__m512i_private idx_ = simde__m512i_to_private(idx);
-    simde__m512_private
-      a_ = simde__m512_to_private(a),
-      r_;
-
-    #if !defined(__INTEL_COMPILER)
-      SIMDE_VECTORIZE
-    #endif
-    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
-      r_.f32[i] = a_.f32[idx_.i32[i] & 0x0F];
-    }
-
-    return simde__m512_from_private(r_);
+    return HEDLEY_REINTERPRET_CAST(simde__m512, simde_mm512_permutexvar_epi32(idx, HEDLEY_REINTERPRET_CAST(simde__m512i, a)));
   #endif
 }
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)

--- a/test/x86/avx512/permutexvar.c
+++ b/test/x86/avx512/permutexvar.c
@@ -31,6 +31,2101 @@
 #include <simde/x86/avx512/set.h>
 #include <simde/x86/avx512/permutexvar.h>
 
+static int
+test_simde_mm_permutexvar_epi16 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const int16_t idx[8];
+    const int16_t a[8];
+    const int16_t r[8];
+  } test_vec[] = {
+    { {  INT16_C(  6502), -INT16_C( 30001), -INT16_C( 24228),  INT16_C(  3581), -INT16_C(   616), -INT16_C(  1803),  INT16_C(  7078),  INT16_C( 16289) },
+      { -INT16_C(  9505),  INT16_C(  1150),  INT16_C( 11629), -INT16_C(  6820),  INT16_C(  5125), -INT16_C(   892),  INT16_C( 21083), -INT16_C( 15937) },
+      {  INT16_C( 21083), -INT16_C( 15937),  INT16_C(  5125), -INT16_C(   892), -INT16_C(  9505), -INT16_C(   892),  INT16_C( 21083),  INT16_C(  1150) } },
+    { { -INT16_C( 29077), -INT16_C( 14517),  INT16_C( 18480), -INT16_C( 14124), -INT16_C( 14011), -INT16_C(  5184),  INT16_C( 25060), -INT16_C( 15574) },
+      { -INT16_C( 22213), -INT16_C( 22328),  INT16_C(  9430), -INT16_C(  9075),  INT16_C(  4665), -INT16_C( 27432), -INT16_C( 26524), -INT16_C( 12459) },
+      { -INT16_C(  9075), -INT16_C(  9075), -INT16_C( 22213),  INT16_C(  4665), -INT16_C( 27432), -INT16_C( 22213),  INT16_C(  4665),  INT16_C(  9430) } },
+    { { -INT16_C( 24538),  INT16_C( 22166),  INT16_C( 27368),  INT16_C( 11550), -INT16_C(  8653),  INT16_C(  5912),  INT16_C( 17215),  INT16_C( 31450) },
+      { -INT16_C( 23828), -INT16_C( 15838), -INT16_C( 20281),  INT16_C(   158),  INT16_C( 30658),  INT16_C(  9876), -INT16_C(  5873),  INT16_C( 13813) },
+      { -INT16_C(  5873), -INT16_C(  5873), -INT16_C( 23828), -INT16_C(  5873),  INT16_C(   158), -INT16_C( 23828),  INT16_C( 13813), -INT16_C( 20281) } },
+    { { -INT16_C( 29815),  INT16_C( 29068), -INT16_C( 21771),  INT16_C( 10398), -INT16_C( 18807), -INT16_C( 14273),  INT16_C(  6649), -INT16_C(  6845) },
+      {  INT16_C( 26044), -INT16_C( 31832),  INT16_C( 17941), -INT16_C( 10365),  INT16_C(  6077), -INT16_C( 13059), -INT16_C(  3584), -INT16_C( 30462) },
+      { -INT16_C( 31832),  INT16_C(  6077), -INT16_C( 13059), -INT16_C(  3584), -INT16_C( 31832), -INT16_C( 30462), -INT16_C( 31832), -INT16_C( 10365) } },
+    { { -INT16_C( 29059),  INT16_C( 29434), -INT16_C( 26568), -INT16_C( 15974), -INT16_C(  9906),  INT16_C( 18570), -INT16_C( 12813), -INT16_C( 20691) },
+      { -INT16_C( 10958),  INT16_C( 18482), -INT16_C( 19172), -INT16_C(  9953),  INT16_C(  7628), -INT16_C( 13146), -INT16_C( 22513), -INT16_C( 29355) },
+      { -INT16_C( 13146), -INT16_C( 19172), -INT16_C( 10958), -INT16_C( 19172), -INT16_C( 22513), -INT16_C( 19172), -INT16_C(  9953), -INT16_C( 13146) } },
+    { {  INT16_C( 20278),  INT16_C( 28415), -INT16_C( 25881),  INT16_C( 13616), -INT16_C( 17805),  INT16_C( 26237), -INT16_C( 21625), -INT16_C( 18155) },
+      {  INT16_C( 18304), -INT16_C( 25599),  INT16_C(  8700), -INT16_C( 14218),  INT16_C(  7230),  INT16_C( 19860), -INT16_C(  5692), -INT16_C(  1318) },
+      { -INT16_C(  5692), -INT16_C(  1318), -INT16_C(  1318),  INT16_C( 18304), -INT16_C( 14218),  INT16_C( 19860), -INT16_C(  1318),  INT16_C( 19860) } },
+    { { -INT16_C(  9672),  INT16_C(  8040), -INT16_C( 26508), -INT16_C(  6315), -INT16_C( 11694), -INT16_C(  9906),  INT16_C( 25469), -INT16_C(   365) },
+      { -INT16_C( 27477), -INT16_C( 22630),  INT16_C(  4277), -INT16_C(  3216),  INT16_C(  1068), -INT16_C(  4031),  INT16_C(  7150),  INT16_C(  9962) },
+      { -INT16_C( 27477), -INT16_C( 27477),  INT16_C(  1068), -INT16_C(  4031),  INT16_C(  4277),  INT16_C(  7150), -INT16_C(  4031), -INT16_C(  3216) } },
+    { {  INT16_C( 21493),  INT16_C( 26950), -INT16_C( 25621),  INT16_C( 15953), -INT16_C( 24723), -INT16_C(  5353), -INT16_C( 22014), -INT16_C( 21015) },
+      { -INT16_C( 31937), -INT16_C(  2987), -INT16_C( 14956), -INT16_C( 16152),  INT16_C( 10697), -INT16_C( 18511), -INT16_C( 25788),  INT16_C( 15070) },
+      { -INT16_C( 18511), -INT16_C( 25788), -INT16_C( 16152), -INT16_C(  2987), -INT16_C( 18511),  INT16_C( 15070), -INT16_C( 14956), -INT16_C(  2987) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m128i idx = simde_mm_loadu_epi16(test_vec[i].idx);
+    simde__m128i a = simde_mm_loadu_epi16(test_vec[i].a);
+    simde__m128i r = simde_mm_permutexvar_epi16(idx, a);
+    simde_test_x86_assert_equal_i16x8(r, simde_mm_loadu_epi16(test_vec[i].r));
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__m128i idx = simde_test_x86_random_i16x8();
+    simde__m128i a = simde_test_x86_random_i16x8();
+    simde__m128i r = simde_mm_permutexvar_epi16(idx, a);
+
+    simde_test_x86_write_i16x8(2, idx, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_i16x8(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i16x8(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm_mask_permutexvar_epi16 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const int16_t src[8];
+    const simde__mmask8 k;
+    const int16_t idx[8];
+    const int16_t a[8];
+    const int16_t r[8];
+  } test_vec[] = {
+    { {  INT16_C(  9454), -INT16_C(  9565), -INT16_C(  2881),  INT16_C( 11288),  INT16_C( 12179), -INT16_C( 27113),  INT16_C(   218),  INT16_C(  6467) },
+      UINT8_C(132),
+      {  INT16_C(  3480),  INT16_C( 23832), -INT16_C(  9995),  INT16_C(  7719), -INT16_C(  8567),  INT16_C(  9571), -INT16_C( 25156), -INT16_C(  8173) },
+      { -INT16_C(  4800),  INT16_C( 13727), -INT16_C( 13307),  INT16_C( 13768),  INT16_C( 24291), -INT16_C(  7153),  INT16_C( 10402),  INT16_C( 14952) },
+      {  INT16_C(  9454), -INT16_C(  9565), -INT16_C(  7153),  INT16_C( 11288),  INT16_C( 12179), -INT16_C( 27113),  INT16_C(   218),  INT16_C( 13768) } },
+    { { -INT16_C( 32715),  INT16_C( 11160), -INT16_C( 16552), -INT16_C(  7607), -INT16_C( 21347),  INT16_C( 23047),  INT16_C(  6729), -INT16_C( 30150) },
+      UINT8_C(  8),
+      { -INT16_C( 16422), -INT16_C( 23027),  INT16_C( 17031), -INT16_C(  6519),  INT16_C( 27985),  INT16_C( 31112), -INT16_C( 15659),  INT16_C( 21935) },
+      { -INT16_C(  9638),  INT16_C(  6574), -INT16_C( 28637), -INT16_C( 12105),  INT16_C(  4503), -INT16_C( 20199), -INT16_C( 23733),  INT16_C(  9657) },
+      { -INT16_C( 32715),  INT16_C( 11160), -INT16_C( 16552),  INT16_C(  6574), -INT16_C( 21347),  INT16_C( 23047),  INT16_C(  6729), -INT16_C( 30150) } },
+    { { -INT16_C( 14494), -INT16_C(  5429),  INT16_C( 21769),  INT16_C( 23504),  INT16_C( 22722), -INT16_C( 26412), -INT16_C( 31974),  INT16_C( 30189) },
+      UINT8_C( 93),
+      { -INT16_C( 29029),  INT16_C( 11137),  INT16_C( 20805),  INT16_C( 22210),  INT16_C( 29802),  INT16_C(  3746), -INT16_C( 14547), -INT16_C(  2960) },
+      {  INT16_C( 23187), -INT16_C(  5890),  INT16_C( 22826), -INT16_C( 32086),  INT16_C( 16941), -INT16_C( 20067),  INT16_C(  4656), -INT16_C( 13554) },
+      { -INT16_C( 32086), -INT16_C(  5429), -INT16_C( 20067),  INT16_C( 22826),  INT16_C( 22826), -INT16_C( 26412), -INT16_C( 20067),  INT16_C( 30189) } },
+    { { -INT16_C( 28768), -INT16_C(  6409), -INT16_C( 17952),  INT16_C( 19260), -INT16_C(  8659),  INT16_C( 23385), -INT16_C( 13914),  INT16_C( 14671) },
+      UINT8_C( 36),
+      {  INT16_C(  8525), -INT16_C( 22962), -INT16_C( 11829),  INT16_C(  3796), -INT16_C( 31378), -INT16_C( 32706),  INT16_C(  2451),  INT16_C(  8992) },
+      {  INT16_C(  1536), -INT16_C( 17917),  INT16_C( 20035),  INT16_C(  8679),  INT16_C( 17063),  INT16_C( 29127),  INT16_C(   146), -INT16_C(  8299) },
+      { -INT16_C( 28768), -INT16_C(  6409),  INT16_C(  8679),  INT16_C( 19260), -INT16_C(  8659),  INT16_C(   146), -INT16_C( 13914),  INT16_C( 14671) } },
+    { { -INT16_C(  7391), -INT16_C(  4730),  INT16_C( 23220),  INT16_C(  8955),  INT16_C( 14815),  INT16_C( 29346), -INT16_C( 15550),  INT16_C( 17301) },
+      UINT8_C(201),
+      { -INT16_C(   615), -INT16_C(  6388),  INT16_C( 12004),  INT16_C( 10127),  INT16_C(   245), -INT16_C(  2375), -INT16_C( 26475),  INT16_C( 30743) },
+      {  INT16_C(  1054),  INT16_C( 30765),  INT16_C( 20479),  INT16_C( 14423), -INT16_C( 13582), -INT16_C( 19077), -INT16_C( 16801), -INT16_C(  1922) },
+      {  INT16_C( 30765), -INT16_C(  4730),  INT16_C( 23220), -INT16_C(  1922),  INT16_C( 14815),  INT16_C( 29346), -INT16_C( 19077), -INT16_C(  1922) } },
+    { { -INT16_C( 29765), -INT16_C( 24608),  INT16_C( 28601), -INT16_C( 20794),  INT16_C( 32623),  INT16_C(  1188), -INT16_C( 17384),  INT16_C( 13948) },
+      UINT8_C(192),
+      { -INT16_C( 20567), -INT16_C(  1600), -INT16_C(  2042), -INT16_C( 12053), -INT16_C( 24461),  INT16_C( 12592),  INT16_C( 10270), -INT16_C( 22036) },
+      { -INT16_C( 29688),  INT16_C( 30562),  INT16_C(  4434), -INT16_C( 11546), -INT16_C(  5451),  INT16_C( 29162),  INT16_C(  8295),  INT16_C(  4146) },
+      { -INT16_C( 29765), -INT16_C( 24608),  INT16_C( 28601), -INT16_C( 20794),  INT16_C( 32623),  INT16_C(  1188),  INT16_C(  8295), -INT16_C(  5451) } },
+    { { -INT16_C(  3377), -INT16_C( 10743), -INT16_C(  2838),  INT16_C( 24230), -INT16_C( 10604), -INT16_C( 19569),  INT16_C( 31999),  INT16_C(  1884) },
+      UINT8_C(  8),
+      {  INT16_C( 32703), -INT16_C( 12198),  INT16_C( 11365),  INT16_C( 20613), -INT16_C(  2282),  INT16_C( 14263), -INT16_C( 14551),  INT16_C(  6918) },
+      { -INT16_C(  9007), -INT16_C( 15099),  INT16_C( 25475),  INT16_C( 22874),  INT16_C(  3571),  INT16_C( 28504),  INT16_C( 24681),  INT16_C( 10359) },
+      { -INT16_C(  3377), -INT16_C( 10743), -INT16_C(  2838),  INT16_C( 28504), -INT16_C( 10604), -INT16_C( 19569),  INT16_C( 31999),  INT16_C(  1884) } },
+    { { -INT16_C( 11809),  INT16_C( 17656),  INT16_C( 32510),  INT16_C(  5268),  INT16_C( 19317), -INT16_C( 25013),  INT16_C( 21011), -INT16_C(  6983) },
+      UINT8_C( 46),
+      { -INT16_C( 22082),  INT16_C(  8881),  INT16_C(  2819),  INT16_C(  4117), -INT16_C( 31645), -INT16_C( 15494), -INT16_C( 23813), -INT16_C( 13150) },
+      { -INT16_C(  6245),  INT16_C(  6602), -INT16_C(  8325), -INT16_C( 14450),  INT16_C( 11306),  INT16_C( 31962), -INT16_C( 16667), -INT16_C( 23637) },
+      { -INT16_C( 11809),  INT16_C(  6602), -INT16_C( 14450),  INT16_C( 31962),  INT16_C( 19317), -INT16_C(  8325),  INT16_C( 21011), -INT16_C(  6983) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m128i src = simde_mm_loadu_epi16(test_vec[i].src);
+    simde__m128i idx = simde_mm_loadu_epi16(test_vec[i].idx);
+    simde__m128i a = simde_mm_loadu_epi16(test_vec[i].a);
+    simde__m128i r = simde_mm_mask_permutexvar_epi16(src, test_vec[i].k, idx, a);
+    simde_test_x86_assert_equal_i16x8(r, simde_mm_loadu_epi16(test_vec[i].r));
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__m128i src = simde_test_x86_random_i16x8();
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m128i idx = simde_test_x86_random_i16x8();
+    simde__m128i a = simde_test_x86_random_i16x8();
+    simde__m128i r = simde_mm_mask_permutexvar_epi16(src, k, idx, a);
+
+    simde_test_x86_write_i16x8(2, src, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i16x8(2, idx, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i16x8(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i16x8(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm_maskz_permutexvar_epi16 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde__mmask8 k;
+    const int16_t idx[8];
+    const int16_t a[8];
+    const int16_t r[8];
+  } test_vec[] = {
+    { UINT8_C(103),
+      { -INT16_C( 15012),  INT16_C( 26475),  INT16_C( 31706),  INT16_C( 24267), -INT16_C( 28939), -INT16_C( 26535),  INT16_C(  9777),  INT16_C(  6195) },
+      {  INT16_C( 19696), -INT16_C( 12397),  INT16_C( 23258),  INT16_C(  1786),  INT16_C( 30260), -INT16_C(  3349), -INT16_C( 29151),  INT16_C( 32346) },
+      {  INT16_C( 30260),  INT16_C(  1786),  INT16_C( 23258),  INT16_C(     0),  INT16_C(     0), -INT16_C( 12397), -INT16_C( 12397),  INT16_C(     0) } },
+    { UINT8_C( 84),
+      { -INT16_C(  6715),  INT16_C( 16430), -INT16_C( 29264),  INT16_C( 16182), -INT16_C( 12570),  INT16_C(  3184), -INT16_C( 30719),  INT16_C( 19965) },
+      { -INT16_C( 13285),  INT16_C( 30247),  INT16_C( 11718),  INT16_C( 15786), -INT16_C( 25320), -INT16_C( 22946), -INT16_C(  8969), -INT16_C( 17158) },
+      {  INT16_C(     0),  INT16_C(     0), -INT16_C( 13285),  INT16_C(     0), -INT16_C(  8969),  INT16_C(     0),  INT16_C( 30247),  INT16_C(     0) } },
+    { UINT8_C(194),
+      { -INT16_C(   983), -INT16_C( 18830), -INT16_C( 20174),  INT16_C(   156), -INT16_C( 22239), -INT16_C( 22271),  INT16_C( 20134),  INT16_C( 29381) },
+      {  INT16_C( 15221), -INT16_C( 24007),  INT16_C( 30437), -INT16_C( 32070),  INT16_C( 25044), -INT16_C( 20103),  INT16_C( 13659), -INT16_C( 31629) },
+      {  INT16_C(     0),  INT16_C( 30437),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0),  INT16_C( 13659), -INT16_C( 20103) } },
+    { UINT8_C( 50),
+      {  INT16_C( 15077), -INT16_C( 26780),  INT16_C( 26071), -INT16_C( 32584),  INT16_C( 25190), -INT16_C( 19162), -INT16_C( 26585),  INT16_C( 25130) },
+      { -INT16_C( 12847),  INT16_C( 18247), -INT16_C( 13689), -INT16_C(  6116), -INT16_C( 12989),  INT16_C( 31044), -INT16_C( 14272),  INT16_C(  9643) },
+      {  INT16_C(     0), -INT16_C( 12989),  INT16_C(     0),  INT16_C(     0), -INT16_C( 14272), -INT16_C( 14272),  INT16_C(     0),  INT16_C(     0) } },
+    { UINT8_C(  3),
+      { -INT16_C( 17393),  INT16_C( 29914),  INT16_C( 23157), -INT16_C( 10277), -INT16_C( 28544),  INT16_C(  6398),  INT16_C( 24762), -INT16_C( 30742) },
+      {  INT16_C( 12711),  INT16_C( 28943), -INT16_C(  2227),  INT16_C(  6837),  INT16_C( 11835),  INT16_C(  1114), -INT16_C( 32551), -INT16_C(  6137) },
+      { -INT16_C(  6137), -INT16_C(  2227),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0) } },
+    { UINT8_C( 60),
+      {  INT16_C( 24033),  INT16_C( 15281), -INT16_C( 30664), -INT16_C( 14149), -INT16_C( 11386), -INT16_C(  6526),  INT16_C(  2749), -INT16_C(  4210) },
+      { -INT16_C(   231),  INT16_C(  4156),  INT16_C( 22452), -INT16_C(  7604),  INT16_C( 20657),  INT16_C( 12731), -INT16_C( 23465),  INT16_C( 14446) },
+      {  INT16_C(     0),  INT16_C(     0), -INT16_C(   231), -INT16_C(  7604), -INT16_C( 23465),  INT16_C( 22452),  INT16_C(     0),  INT16_C(     0) } },
+    { UINT8_C(  1),
+      {  INT16_C( 29471), -INT16_C( 22471),  INT16_C(   302),  INT16_C(   302),  INT16_C(  5507), -INT16_C( 29249), -INT16_C( 20829), -INT16_C( 23898) },
+      { -INT16_C( 18454),  INT16_C( 16727),  INT16_C( 14595),  INT16_C( 21491),  INT16_C(  9461), -INT16_C( 26198), -INT16_C(  7534), -INT16_C( 19814) },
+      { -INT16_C( 19814),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0) } },
+    { UINT8_C( 85),
+      {  INT16_C( 23251), -INT16_C( 11133), -INT16_C( 31608), -INT16_C( 25257), -INT16_C(  6845), -INT16_C(  3776), -INT16_C(  7285),  INT16_C( 17116) },
+      {  INT16_C(  7482),  INT16_C( 29509), -INT16_C( 26608),  INT16_C( 13672),  INT16_C(   322),  INT16_C(  9415),  INT16_C( 31131),  INT16_C( 28281) },
+      {  INT16_C( 13672),  INT16_C(     0),  INT16_C(  7482),  INT16_C(     0),  INT16_C( 13672),  INT16_C(     0),  INT16_C( 13672),  INT16_C(     0) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m128i idx = simde_mm_loadu_epi16(test_vec[i].idx);
+    simde__m128i a = simde_mm_loadu_epi16(test_vec[i].a);
+    simde__m128i r = simde_mm_maskz_permutexvar_epi16(test_vec[i].k, idx, a);
+    simde_test_x86_assert_equal_i16x8(r, simde_mm_loadu_epi16(test_vec[i].r));
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m128i idx = simde_test_x86_random_i16x8();
+    simde__m128i a = simde_test_x86_random_i16x8();
+    simde__m128i r = simde_mm_maskz_permutexvar_epi16(k, idx, a);
+
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_i16x8(2, idx, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i16x8(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i16x8(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm_permutexvar_epi8 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const int8_t idx[16];
+    const int8_t a[16];
+    const int8_t r[16];
+  } test_vec[] = {
+    { { -INT8_C(  89),  INT8_C( 112),  INT8_C( 118),  INT8_C( 112),  INT8_C(  27), -INT8_C(  75), -INT8_C(  48), -INT8_C( 116),
+         INT8_C(  48), -INT8_C( 117), -INT8_C( 112), -INT8_C(  23), -INT8_C( 119), -INT8_C(  91),  INT8_C(  15),  INT8_C(  59) },
+      { -INT8_C(  71),  INT8_C( 114),  INT8_C( 108),  INT8_C(  13),  INT8_C(  18), -INT8_C(   6),  INT8_C( 114),  INT8_C( 113),
+        -INT8_C(  41), -INT8_C(   3),  INT8_C(  44),  INT8_C(  29),  INT8_C(  73), -INT8_C( 122),  INT8_C(  24), -INT8_C(  15) },
+      {  INT8_C( 113), -INT8_C(  71),  INT8_C( 114), -INT8_C(  71),  INT8_C(  29), -INT8_C(   6), -INT8_C(  71),  INT8_C(  73),
+        -INT8_C(  71),  INT8_C(  29), -INT8_C(  71), -INT8_C(   3), -INT8_C(   3), -INT8_C(   6), -INT8_C(  15),  INT8_C(  29) } },
+    { { -INT8_C(  10), -INT8_C( 114),  INT8_C(  97),  INT8_C(  18),  INT8_C(  67),  INT8_C(  49), -INT8_C(  98),  INT8_C( 115),
+        -INT8_C(  67),  INT8_C(  47),  INT8_C(  92),  INT8_C(  70), -INT8_C(  44),  INT8_C( 108), -INT8_C( 127), -INT8_C( 114) },
+      { -INT8_C(  34), -INT8_C(  19), -INT8_C( 101), -INT8_C(  15), -INT8_C(  24),  INT8_C(  13),  INT8_C(  98), -INT8_C(  65),
+         INT8_C(  10), -INT8_C( 113), -INT8_C(  36),  INT8_C(  83),  INT8_C(  21), -INT8_C(  12),  INT8_C(  68),  INT8_C(  11) },
+      {  INT8_C(  98),  INT8_C(  68), -INT8_C(  19), -INT8_C( 101), -INT8_C(  15), -INT8_C(  19),  INT8_C(  68), -INT8_C(  15),
+        -INT8_C(  12),  INT8_C(  11),  INT8_C(  21),  INT8_C(  98), -INT8_C(  24),  INT8_C(  21), -INT8_C(  19),  INT8_C(  68) } },
+    { { -INT8_C( 126), -INT8_C(  91),  INT8_C(  29), -INT8_C(  59), -INT8_C(  41), -INT8_C(  68),  INT8_C(  56), -INT8_C( 108),
+        -INT8_C(  21), -INT8_C( 107), -INT8_C(  38), -INT8_C(  65),  INT8_C(   1),  INT8_C(  92),  INT8_C(  77), -INT8_C(  33) },
+      {  INT8_C(  73), -INT8_C(  24), -INT8_C(  48),  INT8_C(  49), -INT8_C(  11),  INT8_C(  51), -INT8_C(  16), -INT8_C(   1),
+        -INT8_C(  62), -INT8_C(  51),  INT8_C(  83), -INT8_C(  41), -INT8_C(  63), -INT8_C( 105), -INT8_C(  30),  INT8_C(  68) },
+      { -INT8_C(  48),  INT8_C(  51), -INT8_C( 105),  INT8_C(  51), -INT8_C(   1), -INT8_C(  63), -INT8_C(  62), -INT8_C(  11),
+        -INT8_C(  41),  INT8_C(  51),  INT8_C(  83),  INT8_C(  68), -INT8_C(  24), -INT8_C(  63), -INT8_C( 105),  INT8_C(  68) } },
+    { {  INT8_C(  61),  INT8_C(   0),  INT8_C(   9),  INT8_C(  20), -INT8_C(  68),  INT8_C(  66), -INT8_C(  88), -INT8_C(  89),
+        -INT8_C(  41), -INT8_C( 126),  INT8_C( 102), -INT8_C(  40), -INT8_C(  34), -INT8_C(  76), -INT8_C(  73),  INT8_C(  40) },
+      { -INT8_C( 100), -INT8_C( 120),  INT8_C(  89), -INT8_C( 110), -INT8_C(  69),  INT8_C(  74), -INT8_C( 111),  INT8_C( 125),
+         INT8_C(  23), -INT8_C(  28),  INT8_C(  84), -INT8_C(  40),  INT8_C( 124),  INT8_C(  54),  INT8_C(  28), -INT8_C(  71) },
+      {  INT8_C(  54), -INT8_C( 100), -INT8_C(  28), -INT8_C(  69),  INT8_C( 124),  INT8_C(  89),  INT8_C(  23),  INT8_C( 125),
+         INT8_C( 125),  INT8_C(  89), -INT8_C( 111),  INT8_C(  23),  INT8_C(  28), -INT8_C(  69),  INT8_C( 125),  INT8_C(  23) } },
+    { {  INT8_C(  54),  INT8_C(  38), -INT8_C(  51), -INT8_C(  14),  INT8_C( 104),  INT8_C( 117), -INT8_C( 103),  INT8_C(  63),
+        -INT8_C(   9),  INT8_C(   0),  INT8_C(  23), -INT8_C(  42), -INT8_C(  76), -INT8_C(  50), -INT8_C(   2),  INT8_C(  80) },
+      {  INT8_C(  86),  INT8_C(  87), -INT8_C(  30),  INT8_C(  17), -INT8_C(  95),  INT8_C( 116), -INT8_C( 114), -INT8_C(  72),
+         INT8_C(  88), -INT8_C(  30), -INT8_C( 111), -INT8_C(  44),  INT8_C(  25), -INT8_C(  83), -INT8_C( 115),  INT8_C(  79) },
+      { -INT8_C( 114), -INT8_C( 114), -INT8_C(  83), -INT8_C(  30),  INT8_C(  88),  INT8_C( 116), -INT8_C(  30),  INT8_C(  79),
+        -INT8_C(  72),  INT8_C(  86), -INT8_C(  72), -INT8_C( 114), -INT8_C(  95), -INT8_C( 115), -INT8_C( 115),  INT8_C(  86) } },
+    { { -INT8_C(  45),  INT8_C(  90),  INT8_C(  66),  INT8_C(  59), -INT8_C(  49), -INT8_C(  37),  INT8_C( 122), -INT8_C(  57),
+        -INT8_C(  37), -INT8_C( 111), -INT8_C(  99), -INT8_C( 113),  INT8_C(  96), -INT8_C( 101), -INT8_C(  32), -INT8_C(  74) },
+      { -INT8_C(  14), -INT8_C(  62), -INT8_C(  56), -INT8_C( 108),  INT8_C(  54),  INT8_C(  86),  INT8_C(  76), -INT8_C( 113),
+         INT8_C(  57), -INT8_C(  35),  INT8_C(  99),  INT8_C(  82), -INT8_C( 117), -INT8_C(  15), -INT8_C(  95),  INT8_C(  94) },
+      { -INT8_C( 108),  INT8_C(  99), -INT8_C(  56),  INT8_C(  82),  INT8_C(  94),  INT8_C(  82),  INT8_C(  99), -INT8_C( 113),
+         INT8_C(  82), -INT8_C(  62), -INT8_C(  15),  INT8_C(  94), -INT8_C(  14),  INT8_C(  82), -INT8_C(  14),  INT8_C(  76) } },
+    { {  INT8_C(  75), -INT8_C(  29), -INT8_C( 102),  INT8_C(  27), -INT8_C(  65),  INT8_C(  20), -INT8_C(  30), -INT8_C( 102),
+        -INT8_C(  90),      INT8_MAX,  INT8_C(  42),  INT8_C(   6),  INT8_C(  26),  INT8_C(  10), -INT8_C(  68),  INT8_C(  12) },
+      { -INT8_C(  52), -INT8_C( 124), -INT8_C(  96),  INT8_C(   3), -INT8_C(  37), -INT8_C(  19), -INT8_C( 110),  INT8_C(  20),
+        -INT8_C(  54), -INT8_C(  11),  INT8_C( 102),  INT8_C(  85), -INT8_C(  26),  INT8_C(   7), -INT8_C(  76),  INT8_C(  50) },
+      {  INT8_C(  85),  INT8_C(   3),  INT8_C( 102),  INT8_C(  85),  INT8_C(  50), -INT8_C(  37), -INT8_C(  96),  INT8_C( 102),
+        -INT8_C( 110),  INT8_C(  50),  INT8_C( 102), -INT8_C( 110),  INT8_C( 102),  INT8_C( 102), -INT8_C(  26), -INT8_C(  26) } },
+    { { -INT8_C(  21),  INT8_C(  78),  INT8_C(  77), -INT8_C(  86),  INT8_C(  98),  INT8_C(  47),  INT8_C(  68),  INT8_C(   8),
+        -INT8_C(  82),  INT8_C( 110),  INT8_C(  14), -INT8_C(  56),  INT8_C( 120), -INT8_C(  53), -INT8_C(  44),  INT8_C(  69) },
+      {  INT8_C(  79),  INT8_C( 117),  INT8_C(  72),  INT8_C(  42),  INT8_C(  98), -INT8_C(  38),  INT8_C(  62),  INT8_C(  44),
+        -INT8_C(  49), -INT8_C(  92), -INT8_C( 126), -INT8_C(  74), -INT8_C(  84),  INT8_C(  54), -INT8_C(  24), -INT8_C( 105) },
+      { -INT8_C(  74), -INT8_C(  24),  INT8_C(  54), -INT8_C( 126),  INT8_C(  72), -INT8_C( 105),  INT8_C(  98), -INT8_C(  49),
+        -INT8_C(  24), -INT8_C(  24), -INT8_C(  24), -INT8_C(  49), -INT8_C(  49), -INT8_C(  74),  INT8_C(  98), -INT8_C(  38) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m128i idx = simde_mm_loadu_epi8(test_vec[i].idx);
+    simde__m128i a = simde_mm_loadu_epi8(test_vec[i].a);
+    simde__m128i r = simde_mm_permutexvar_epi8(idx, a);
+    simde_test_x86_assert_equal_i8x16(r, simde_mm_loadu_epi8(test_vec[i].r));
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__m128i idx = simde_test_x86_random_i8x16();
+    simde__m128i a = simde_test_x86_random_i8x16();
+    simde__m128i r = simde_mm_permutexvar_epi8(idx, a);
+
+    simde_test_x86_write_i8x16(2, idx, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_i8x16(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i8x16(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm_mask_permutexvar_epi8 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const int8_t src[16];
+    const simde__mmask16 k;
+    const int8_t idx[16];
+    const int8_t a[16];
+    const int8_t r[16];
+  } test_vec[] = {
+    { { -INT8_C( 124),  INT8_C(  53),  INT8_C(  65), -INT8_C(  26),  INT8_C( 100), -INT8_C( 123), -INT8_C(  17),  INT8_C(  18),
+        -INT8_C(  12), -INT8_C(   3), -INT8_C(  38),  INT8_C( 108), -INT8_C(  56), -INT8_C(  82), -INT8_C(  79),  INT8_C(  24) },
+      UINT16_C(63779),
+      {  INT8_C(  66), -INT8_C( 123), -INT8_C(  45), -INT8_C( 127), -INT8_C(  78), -INT8_C(  93),  INT8_C(  37),  INT8_C(  52),
+         INT8_C(  89), -INT8_C(  47),  INT8_C( 106),  INT8_C(  65),  INT8_C( 104), -INT8_C(  18),  INT8_C( 118), -INT8_C(  87) },
+      { -INT8_C(  44), -INT8_C(  38),  INT8_C(  47), -INT8_C(  61), -INT8_C(  20),  INT8_C(  35), -INT8_C(  63), -INT8_C(  58),
+        -INT8_C( 113), -INT8_C( 119),  INT8_C( 116),  INT8_C(  65), -INT8_C(  95), -INT8_C( 104),  INT8_C(  58), -INT8_C(  28) },
+      {  INT8_C(  47),  INT8_C(  35),  INT8_C(  65), -INT8_C(  26),  INT8_C( 100), -INT8_C(  61), -INT8_C(  17),  INT8_C(  18),
+        -INT8_C( 119), -INT8_C(   3), -INT8_C(  38), -INT8_C(  38), -INT8_C( 113),  INT8_C(  58), -INT8_C(  63), -INT8_C( 119) } },
+    { {  INT8_C(  29),  INT8_C(  14),  INT8_C( 101), -INT8_C(  49), -INT8_C(  79), -INT8_C( 118),  INT8_C(   3),  INT8_C(  10),
+         INT8_C(  92),  INT8_C( 109),  INT8_C(  75), -INT8_C(  60),  INT8_C(  91), -INT8_C(  63),  INT8_C( 110),  INT8_C(  48) },
+      UINT16_C(40347),
+      { -INT8_C(  13), -INT8_C( 121), -INT8_C(  64), -INT8_C(  76),  INT8_C(  77),  INT8_C(  79),  INT8_C(  62), -INT8_C(  63),
+        -INT8_C( 112), -INT8_C(  33),  INT8_C(  89), -INT8_C(  53), -INT8_C(  61),  INT8_C( 119), -INT8_C(  39),  INT8_C(  40) },
+      {  INT8_C(  70), -INT8_C( 118), -INT8_C(  77),  INT8_C(  74), -INT8_C( 108),  INT8_C(  15), -INT8_C(  73), -INT8_C(  33),
+        -INT8_C(  45),  INT8_C(  19), -INT8_C(  96),  INT8_C(  65),  INT8_C(  67),  INT8_C(  59), -INT8_C(  34),  INT8_C(  54) },
+      {  INT8_C(  74), -INT8_C(  33),  INT8_C( 101), -INT8_C( 108),  INT8_C(  59), -INT8_C( 118),  INT8_C(   3), -INT8_C( 118),
+         INT8_C(  70),  INT8_C( 109),  INT8_C(  19),  INT8_C(  65),  INT8_C(  74), -INT8_C(  63),  INT8_C( 110), -INT8_C(  45) } },
+    { { -INT8_C(  62), -INT8_C(  98), -INT8_C(  21),  INT8_C(  15), -INT8_C(  18),  INT8_C(  41), -INT8_C(  48),  INT8_C( 126),
+         INT8_C(   8),  INT8_C(  42),  INT8_C(  73), -INT8_C(  52), -INT8_C(  95),  INT8_C(  34), -INT8_C(  12), -INT8_C(  25) },
+      UINT16_C(42924),
+      {  INT8_C(  49),  INT8_C(  64), -INT8_C(  74), -INT8_C(  23),  INT8_C(  31), -INT8_C( 118), -INT8_C(   4), -INT8_C(  65),
+        -INT8_C(  53),  INT8_C(  63), -INT8_C(   6), -INT8_C(  86),  INT8_C( 117), -INT8_C(  68),  INT8_C(  72),  INT8_C(  96) },
+      { -INT8_C(  53),  INT8_C(  54), -INT8_C( 119), -INT8_C( 100), -INT8_C(  75), -INT8_C( 110), -INT8_C(  58), -INT8_C(   2),
+         INT8_C(  94),  INT8_C( 103),  INT8_C(  33),  INT8_C(  82),  INT8_C(  78), -INT8_C(  51), -INT8_C(   6),      INT8_MIN },
+      { -INT8_C(  62), -INT8_C(  98), -INT8_C(  58),  INT8_C( 103), -INT8_C(  18),  INT8_C(  33), -INT8_C(  48),      INT8_MIN,
+         INT8_C(  82),      INT8_MIN,  INT8_C(  33), -INT8_C(  52), -INT8_C(  95),  INT8_C(  78), -INT8_C(  12), -INT8_C(  53) } },
+    { {  INT8_C(  14), -INT8_C(  80),  INT8_C( 105),  INT8_C(  45),  INT8_C(  58),  INT8_C( 101), -INT8_C(  19),  INT8_C(   6),
+        -INT8_C(  92), -INT8_C(  25), -INT8_C(  80),  INT8_C(  25), -INT8_C(  92), -INT8_C(   8),  INT8_C( 122),  INT8_C( 111) },
+      UINT16_C(  815),
+      {  INT8_C(  11), -INT8_C(  28), -INT8_C( 107), -INT8_C(  47), -INT8_C(  30), -INT8_C(  13),  INT8_C(  56),  INT8_C(   3),
+         INT8_C(  70), -INT8_C( 121), -INT8_C(  47),  INT8_C(  64),  INT8_C(   7), -INT8_C(  33), -INT8_C(  16),  INT8_C( 112) },
+      {  INT8_C(  12),  INT8_C(  43), -INT8_C(  43), -INT8_C(   7),  INT8_C(  49),  INT8_C( 121), -INT8_C(  31), -INT8_C(  31),
+        -INT8_C( 110), -INT8_C( 123), -INT8_C(  39),  INT8_C(  12), -INT8_C(  12),  INT8_C(   8),  INT8_C(  16),  INT8_C(   0) },
+      {  INT8_C(  12),  INT8_C(  49),  INT8_C( 121),  INT8_C(  43),  INT8_C(  58), -INT8_C(   7), -INT8_C(  19),  INT8_C(   6),
+        -INT8_C(  31), -INT8_C(  31), -INT8_C(  80),  INT8_C(  25), -INT8_C(  92), -INT8_C(   8),  INT8_C( 122),  INT8_C( 111) } },
+    { { -INT8_C(  20), -INT8_C(  91), -INT8_C(  47), -INT8_C(  49), -INT8_C( 103),  INT8_C(  10), -INT8_C(  46), -INT8_C(  33),
+        -INT8_C( 111), -INT8_C(  93),  INT8_C(  31), -INT8_C( 104), -INT8_C( 126),  INT8_C(  15),  INT8_C(   8), -INT8_C( 113) },
+      UINT16_C(56634),
+      { -INT8_C( 120),  INT8_C( 107),  INT8_C(  86),  INT8_C( 105),  INT8_C(  76), -INT8_C(  24), -INT8_C(  18),  INT8_C(  38),
+        -INT8_C(  11), -INT8_C(  29),  INT8_C(  46),  INT8_C(   5), -INT8_C(  29),  INT8_C(  27), -INT8_C(  86), -INT8_C(  76) },
+      { -INT8_C(  22),  INT8_C(  67), -INT8_C(  66), -INT8_C(  68),  INT8_C(  34),  INT8_C(  79),  INT8_C(  96),  INT8_C(  65),
+        -INT8_C(  25), -INT8_C(  30),  INT8_C(  81), -INT8_C(  17),  INT8_C( 113), -INT8_C( 117), -INT8_C(  52), -INT8_C(   6) },
+      { -INT8_C(  20), -INT8_C(  17), -INT8_C(  47), -INT8_C(  30),  INT8_C( 113), -INT8_C(  25), -INT8_C(  46), -INT8_C(  33),
+         INT8_C(  79), -INT8_C(  93), -INT8_C(  52),  INT8_C(  79), -INT8_C(  68),  INT8_C(  15),  INT8_C(  81),  INT8_C(  34) } },
+    { { -INT8_C(   9),  INT8_C(  34),  INT8_C(  99),  INT8_C(  67),  INT8_C(  11),  INT8_C(  82),  INT8_C( 105),  INT8_C(   0),
+         INT8_C(  53), -INT8_C( 104),  INT8_C(   5),  INT8_C(  24), -INT8_C(  77), -INT8_C(  81), -INT8_C(  52), -INT8_C(  99) },
+      UINT16_C(35827),
+      {  INT8_C(  89),  INT8_C(  21), -INT8_C(  38), -INT8_C(  71),  INT8_C(  87), -INT8_C(  62), -INT8_C( 100), -INT8_C(  88),
+        -INT8_C(  79),  INT8_C(  13),  INT8_C(  51),  INT8_C( 126),  INT8_C(   7),  INT8_C(  42), -INT8_C(  96),  INT8_C( 107) },
+      {  INT8_C( 110), -INT8_C(  85), -INT8_C(  67), -INT8_C(  41), -INT8_C(  85), -INT8_C(  14),  INT8_C( 111), -INT8_C(  80),
+         INT8_C(  10),  INT8_C(  34),  INT8_C(  96), -INT8_C(  42), -INT8_C(  65),  INT8_C(  83),  INT8_C(  97),  INT8_C(  25) },
+      {  INT8_C(  34), -INT8_C(  14),  INT8_C(  99),  INT8_C(  67), -INT8_C(  80), -INT8_C(  67), -INT8_C(  65),  INT8_C(  10),
+        -INT8_C(  85),  INT8_C(  83),  INT8_C(   5),  INT8_C(  97), -INT8_C(  77), -INT8_C(  81), -INT8_C(  52), -INT8_C(  42) } },
+    { {  INT8_C( 104),  INT8_C(  60), -INT8_C(  46), -INT8_C(  65), -INT8_C(   2),  INT8_C( 110),  INT8_C( 103), -INT8_C(  81),
+         INT8_C( 124), -INT8_C( 101),  INT8_C(  45), -INT8_C( 125), -INT8_C(  59), -INT8_C(  50), -INT8_C(  18),  INT8_C(  51) },
+      UINT16_C(43897),
+      {  INT8_C(  11),  INT8_C(  37), -INT8_C(  99),  INT8_C( 122), -INT8_C(  43), -INT8_C(  89), -INT8_C(  99),  INT8_C(  53),
+         INT8_C( 126),  INT8_C(  92), -INT8_C( 120), -INT8_C(  33),  INT8_C( 117), -INT8_C(  15),  INT8_C(  27),  INT8_C(  72) },
+      { -INT8_C(  80),  INT8_C(  25), -INT8_C(  74),  INT8_C(  24), -INT8_C(  55),  INT8_C(  50), -INT8_C(  77), -INT8_C(  10),
+        -INT8_C(  74),  INT8_C( 120), -INT8_C(  60), -INT8_C(  92), -INT8_C(  84),  INT8_C(  62),  INT8_C(  80), -INT8_C(  73) },
+      { -INT8_C(  92),  INT8_C(  60), -INT8_C(  46), -INT8_C(  60),  INT8_C(  50), -INT8_C(  10),  INT8_C(  62), -INT8_C(  81),
+         INT8_C(  80), -INT8_C(  84),  INT8_C(  45), -INT8_C(  73), -INT8_C(  59),  INT8_C(  25), -INT8_C(  18), -INT8_C(  74) } },
+    { {  INT8_C(  99), -INT8_C(  19),  INT8_C(  49),  INT8_C(  56), -INT8_C( 107), -INT8_C(  50),  INT8_C( 110),  INT8_C(  19),
+         INT8_C(  43), -INT8_C(  10), -INT8_C(  14), -INT8_C(  96), -INT8_C(  25),  INT8_C(  14), -INT8_C(  24), -INT8_C( 104) },
+      UINT16_C(40743),
+      { -INT8_C(  80), -INT8_C(  16), -INT8_C(  47),  INT8_C(  99), -INT8_C(  25), -INT8_C( 121), -INT8_C(  37), -INT8_C(  85),
+         INT8_C(  44), -INT8_C( 121), -INT8_C(  23),  INT8_C( 124),  INT8_C(  62),  INT8_C(  76),  INT8_C( 105),  INT8_C( 112) },
+      { -INT8_C( 123), -INT8_C(   2),  INT8_C(  62), -INT8_C(  13),  INT8_C(  17),  INT8_C( 105), -INT8_C(  23),  INT8_C(   4),
+         INT8_C(  10), -INT8_C(  47),  INT8_C(  18), -INT8_C(  14),  INT8_C( 105),  INT8_C(  57), -INT8_C( 111),  INT8_C(  25) },
+      { -INT8_C( 123), -INT8_C( 123), -INT8_C(   2),  INT8_C(  56), -INT8_C( 107),  INT8_C(   4),  INT8_C( 110),  INT8_C(  19),
+         INT8_C( 105),  INT8_C(   4), -INT8_C(  47),  INT8_C( 105), -INT8_C( 111),  INT8_C(  14), -INT8_C(  24), -INT8_C( 123) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m128i src = simde_mm_loadu_epi8(test_vec[i].src);
+    simde__m128i idx = simde_mm_loadu_epi8(test_vec[i].idx);
+    simde__m128i a = simde_mm_loadu_epi8(test_vec[i].a);
+    simde__m128i r = simde_mm_mask_permutexvar_epi8(src, test_vec[i].k, idx, a);
+    simde_test_x86_assert_equal_i8x16(r, simde_mm_loadu_epi8(test_vec[i].r));
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__m128i src = simde_test_x86_random_i8x16();
+    simde__mmask16 k = simde_test_x86_random_mmask16();
+    simde__m128i idx = simde_test_x86_random_i8x16();
+    simde__m128i a = simde_test_x86_random_i8x16();
+    simde__m128i r = simde_mm_mask_permutexvar_epi8(src, k, idx, a);
+
+    simde_test_x86_write_i8x16(2, src, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_mmask16(2, k, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i8x16(2, idx, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i8x16(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i8x16(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm_maskz_permutexvar_epi8 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde__mmask16 k;
+    const int8_t idx[16];
+    const int8_t a[16];
+    const int8_t r[16];
+  } test_vec[] = {
+    { UINT16_C(25386),
+      {  INT8_C( 124),  INT8_C(  17), -INT8_C(  22),  INT8_C(  87), -INT8_C(  68),  INT8_C(  22), -INT8_C(  33), -INT8_C(  90),
+        -INT8_C( 110),  INT8_C(  29), -INT8_C(  14), -INT8_C(   4), -INT8_C( 115),  INT8_C( 119), -INT8_C(   6), -INT8_C(  52) },
+      {  INT8_C( 106),  INT8_C(  12),  INT8_C(  53),  INT8_C(  84),  INT8_C(  16),  INT8_C(  63),  INT8_C(  37),  INT8_C(  34),
+         INT8_C(  50), -INT8_C( 114),  INT8_C(  91), -INT8_C(  61), -INT8_C(  89), -INT8_C( 123),  INT8_C(  38),  INT8_C(  35) },
+      {  INT8_C(   0),  INT8_C(  12),  INT8_C(   0),  INT8_C(  34),  INT8_C(   0),  INT8_C(  37),  INT8_C(   0),  INT8_C(   0),
+         INT8_C(  53), -INT8_C( 123),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0),  INT8_C(  34),  INT8_C(  91),  INT8_C(   0) } },
+    { UINT16_C( 4502),
+      {  INT8_C( 122),  INT8_C(  83),  INT8_C(  39),  INT8_C(  89), -INT8_C(   7), -INT8_C(  70),  INT8_C( 119), -INT8_C(  21),
+        -INT8_C(  74),  INT8_C(   4),  INT8_C(  99), -INT8_C(  80), -INT8_C(  48), -INT8_C(  51), -INT8_C(  68),  INT8_C(   6) },
+      {  INT8_C(  33), -INT8_C(  52),  INT8_C(  69),  INT8_C(  70), -INT8_C(  18),  INT8_C( 119), -INT8_C(  44),  INT8_C(  74),
+         INT8_C(  59),  INT8_C( 123), -INT8_C(  49),  INT8_C(  97), -INT8_C(  98),  INT8_C( 102),  INT8_C( 114),  INT8_C(  25) },
+      {  INT8_C(   0),  INT8_C(  70),  INT8_C(  74),  INT8_C(   0),  INT8_C( 123),  INT8_C(   0),  INT8_C(   0),  INT8_C(  97),
+        -INT8_C(  44),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0),  INT8_C(  33),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0) } },
+    { UINT16_C(39609),
+      {  INT8_C( 114), -INT8_C(  78),  INT8_C(  84), -INT8_C(  23), -INT8_C(  99),  INT8_C(  10), -INT8_C(  18),  INT8_C(   0),
+        -INT8_C(  70), -INT8_C(  66), -INT8_C(  50),  INT8_C( 119), -INT8_C(  60), -INT8_C(  17),  INT8_C(  67),  INT8_C(  10) },
+      {  INT8_C(  54),  INT8_C(  50), -INT8_C( 127),  INT8_C(  10),  INT8_C( 124), -INT8_C(  68), -INT8_C( 122),  INT8_C(  75),
+         INT8_C(  30),  INT8_C(  36), -INT8_C(  79), -INT8_C( 112),  INT8_C(  61),  INT8_C( 106),  INT8_C(  42), -INT8_C(  80) },
+      { -INT8_C( 127),  INT8_C(   0),  INT8_C(   0),  INT8_C(  36),  INT8_C( 106), -INT8_C(  79),  INT8_C(   0),  INT8_C(  54),
+         INT8_C(   0),  INT8_C(  42),  INT8_C(   0),  INT8_C(  75),  INT8_C( 124),  INT8_C(   0),  INT8_C(   0), -INT8_C(  79) } },
+    { UINT16_C(32284),
+      { -INT8_C( 103), -INT8_C(  70), -INT8_C( 120), -INT8_C( 121), -INT8_C(  70),  INT8_C(  67),  INT8_C(  70), -INT8_C( 120),
+        -INT8_C(  70),  INT8_C(  10),  INT8_C( 120), -INT8_C(   3),  INT8_C(  20), -INT8_C(  82),  INT8_C(  47), -INT8_C( 106) },
+      { -INT8_C(  72), -INT8_C(  85),  INT8_C(  82),  INT8_C(  62), -INT8_C(   9),  INT8_C( 112),  INT8_C(  99), -INT8_C(  88),
+         INT8_C(   1), -INT8_C(  96),  INT8_C(  19),  INT8_C(  43),  INT8_C(  80),  INT8_C(  47), -INT8_C(  86), -INT8_C(  22) },
+      {  INT8_C(   0),  INT8_C(   0),  INT8_C(   1), -INT8_C(  88),  INT8_C(  19),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0),
+         INT8_C(   0),  INT8_C(  19),  INT8_C(   1),  INT8_C(  47), -INT8_C(   9), -INT8_C(  86), -INT8_C(  22),  INT8_C(   0) } },
+    { UINT16_C(13033),
+      {  INT8_C( 113), -INT8_C(  92),  INT8_C( 117), -INT8_C(  73),  INT8_C(  44),  INT8_C(  47), -INT8_C(  62), -INT8_C(  92),
+         INT8_C(  45), -INT8_C(  42),  INT8_C(  82),  INT8_C(  92),  INT8_C( 108),  INT8_C(  11),  INT8_C(   8), -INT8_C(  65) },
+      {  INT8_C(  73), -INT8_C(   1),  INT8_C(  47), -INT8_C(  84), -INT8_C(  89),  INT8_C(  48),  INT8_C(  77), -INT8_C(  70),
+         INT8_C(  92), -INT8_C(  99), -INT8_C(  22),  INT8_C(   6), -INT8_C( 121), -INT8_C(  45),  INT8_C(  56), -INT8_C(   7) },
+      { -INT8_C(   1),  INT8_C(   0),  INT8_C(   0), -INT8_C(  70),  INT8_C(   0), -INT8_C(   7),  INT8_C(  47), -INT8_C(  89),
+         INT8_C(   0),  INT8_C(  77),  INT8_C(   0),  INT8_C(   0), -INT8_C( 121),  INT8_C(   6),  INT8_C(   0),  INT8_C(   0) } },
+    { UINT16_C(44663),
+      { -INT8_C(  80), -INT8_C(  92), -INT8_C(  35),  INT8_C( 114),  INT8_C(  72),  INT8_C(  10),  INT8_C(  73), -INT8_C( 101),
+         INT8_C( 103), -INT8_C(  75), -INT8_C(  90),  INT8_C( 111),  INT8_C( 116), -INT8_C(  17),  INT8_C( 110), -INT8_C(  92) },
+      { -INT8_C( 100),  INT8_C(  21), -INT8_C(  44), -INT8_C(  23), -INT8_C(  48),  INT8_C(  48), -INT8_C( 122), -INT8_C(  70),
+         INT8_C(  54),  INT8_C(  14), -INT8_C( 115),  INT8_C( 111),  INT8_C(   7),  INT8_C(   5),  INT8_C(  29), -INT8_C(  73) },
+      { -INT8_C( 100), -INT8_C(  48),  INT8_C(   5),  INT8_C(   0),  INT8_C(  54), -INT8_C( 115),  INT8_C(  14),  INT8_C(   0),
+         INT8_C(   0),  INT8_C(  48), -INT8_C( 122), -INT8_C(  73),  INT8_C(   0), -INT8_C(  73),  INT8_C(   0), -INT8_C(  48) } },
+    { UINT16_C(64169),
+      {  INT8_C(  42), -INT8_C(  15),  INT8_C(   5),  INT8_C( 115), -INT8_C( 116),  INT8_C( 108),  INT8_C(  40),  INT8_C(  50),
+        -INT8_C(  37), -INT8_C(  99),  INT8_C(  34),  INT8_C(  73),  INT8_C(  65), -INT8_C(  66),  INT8_C(  94),  INT8_C(  21) },
+      { -INT8_C(  89),  INT8_C(  46),  INT8_C(  70),  INT8_C(  45), -INT8_C(  24),  INT8_C( 124),  INT8_C(  59),  INT8_C( 118),
+        -INT8_C(  21),  INT8_C(  66),  INT8_C( 123),  INT8_C(   8), -INT8_C(   6),  INT8_C(  36),  INT8_C(   3),  INT8_C(  36) },
+      {  INT8_C( 123),  INT8_C(   0),  INT8_C(   0),  INT8_C(  45),  INT8_C(   0), -INT8_C(   6),  INT8_C(   0),  INT8_C(  70),
+         INT8_C(   0),  INT8_C(  36),  INT8_C(   0),  INT8_C(  66),  INT8_C(  46),  INT8_C(   3),  INT8_C(   3),  INT8_C( 124) } },
+    { UINT16_C( 2069),
+      { -INT8_C( 105), -INT8_C(  94),  INT8_C( 116), -INT8_C(  65), -INT8_C(  44),  INT8_C(  79),  INT8_C(  92), -INT8_C(  10),
+        -INT8_C( 104), -INT8_C(  99), -INT8_C(  76), -INT8_C(  10), -INT8_C(  77),  INT8_C(  91),  INT8_C(  37), -INT8_C(   7) },
+      { -INT8_C( 119),  INT8_C(  13),  INT8_C( 117), -INT8_C(  60), -INT8_C( 125),  INT8_C(  97),  INT8_C(   7), -INT8_C(   2),
+         INT8_C( 105),  INT8_C(   1),  INT8_C(  34),  INT8_C( 108),  INT8_C(  37),  INT8_C(  56),  INT8_C( 116), -INT8_C(  68) },
+      { -INT8_C(   2),  INT8_C(   0), -INT8_C( 125),  INT8_C(   0), -INT8_C( 125),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0),
+         INT8_C(   0),  INT8_C(   0),  INT8_C(   0),  INT8_C(   7),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m128i idx = simde_mm_loadu_epi8(test_vec[i].idx);
+    simde__m128i a = simde_mm_loadu_epi8(test_vec[i].a);
+    simde__m128i r = simde_mm_maskz_permutexvar_epi8(test_vec[i].k, idx, a);
+    simde_test_x86_assert_equal_i8x16(r, simde_mm_loadu_epi8(test_vec[i].r));
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__mmask16 k = simde_test_x86_random_mmask16();
+    simde__m128i idx = simde_test_x86_random_i8x16();
+    simde__m128i a = simde_test_x86_random_i8x16();
+    simde__m128i r = simde_mm_maskz_permutexvar_epi8(k, idx, a);
+
+    simde_test_x86_write_mmask16(2, k, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_i8x16(2, idx, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i8x16(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i8x16(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_permutexvar_epi16 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const int16_t idx[16];
+    const int16_t a[16];
+    const int16_t r[16];
+  } test_vec[] = {
+    { {  INT16_C(  5893), -INT16_C( 32362),  INT16_C( 15791), -INT16_C( 31311), -INT16_C( 29409), -INT16_C( 15393),  INT16_C(  6807), -INT16_C( 24848),
+        -INT16_C( 12998),  INT16_C(  1199),  INT16_C(  9359),  INT16_C( 30035),  INT16_C( 14670), -INT16_C( 18355), -INT16_C( 18338),  INT16_C( 25575) },
+      {  INT16_C( 32208),  INT16_C( 32740), -INT16_C( 27206), -INT16_C(  9980), -INT16_C(  7390), -INT16_C( 18019), -INT16_C( 29187),  INT16_C( 14423),
+         INT16_C(  1626), -INT16_C(  5828), -INT16_C( 28886),  INT16_C( 31071), -INT16_C( 21304),  INT16_C(  9777),  INT16_C(  6244),  INT16_C( 13449) },
+      { -INT16_C( 18019), -INT16_C( 29187),  INT16_C( 13449),  INT16_C( 32740),  INT16_C( 13449),  INT16_C( 13449),  INT16_C( 14423),  INT16_C( 32208),
+        -INT16_C( 28886),  INT16_C( 13449),  INT16_C( 13449), -INT16_C(  9980),  INT16_C(  6244),  INT16_C(  9777),  INT16_C(  6244),  INT16_C( 14423) } },
+    { {  INT16_C( 28053),  INT16_C( 20659), -INT16_C( 18430),  INT16_C(  9257), -INT16_C( 14693), -INT16_C( 26147),  INT16_C( 13395), -INT16_C( 20783),
+         INT16_C(  3387),  INT16_C( 26007), -INT16_C(  2403),  INT16_C( 26078),  INT16_C(  4002),  INT16_C(  1932),  INT16_C(  5415), -INT16_C( 17093) },
+      { -INT16_C(  4221), -INT16_C( 31475),  INT16_C( 13991),  INT16_C( 17066), -INT16_C( 30723),  INT16_C( 20699), -INT16_C( 21316), -INT16_C(  2050),
+        -INT16_C( 26950),  INT16_C( 22364),  INT16_C( 15244),  INT16_C( 12220),  INT16_C( 18506),  INT16_C( 29238),  INT16_C( 29022), -INT16_C(  7889) },
+      {  INT16_C( 20699),  INT16_C( 17066),  INT16_C( 13991),  INT16_C( 22364),  INT16_C( 12220),  INT16_C( 29238),  INT16_C( 17066), -INT16_C( 31475),
+         INT16_C( 12220), -INT16_C(  2050),  INT16_C( 29238),  INT16_C( 29022),  INT16_C( 13991),  INT16_C( 18506), -INT16_C(  2050),  INT16_C( 12220) } },
+    { {  INT16_C( 15456),  INT16_C(  1894),  INT16_C(  4210),  INT16_C( 28490),  INT16_C(  9624),  INT16_C( 21696), -INT16_C( 16686), -INT16_C( 29621),
+        -INT16_C( 22700), -INT16_C(  7709), -INT16_C( 24606),  INT16_C( 11536),  INT16_C( 18152),  INT16_C( 18079), -INT16_C( 12617),  INT16_C(  6183) },
+      { -INT16_C( 29430),  INT16_C( 31775),  INT16_C( 27038),  INT16_C( 14060), -INT16_C( 21361),  INT16_C( 24970), -INT16_C( 10902), -INT16_C( 16403),
+        -INT16_C( 12164),  INT16_C( 24480), -INT16_C( 20369),  INT16_C( 22412),  INT16_C( 11254), -INT16_C( 21091), -INT16_C( 15111),  INT16_C(   965) },
+      { -INT16_C( 29430), -INT16_C( 10902),  INT16_C( 27038), -INT16_C( 20369), -INT16_C( 12164), -INT16_C( 29430),  INT16_C( 27038),  INT16_C( 22412),
+        -INT16_C( 21361),  INT16_C( 14060),  INT16_C( 27038), -INT16_C( 29430), -INT16_C( 12164),  INT16_C(   965), -INT16_C( 16403), -INT16_C( 16403) } },
+    { { -INT16_C(  6830), -INT16_C(  3969),  INT16_C( 27470), -INT16_C(  8922), -INT16_C( 20457), -INT16_C( 32194),  INT16_C( 11141),  INT16_C(   321),
+        -INT16_C(  7685),  INT16_C( 27488), -INT16_C(  4975), -INT16_C( 30782),  INT16_C( 24599),  INT16_C(  4148), -INT16_C(  1500),  INT16_C( 30227) },
+      { -INT16_C( 27681),  INT16_C( 11622), -INT16_C( 29442),  INT16_C(  5643),  INT16_C( 18748), -INT16_C( 15976), -INT16_C(  9867),  INT16_C( 28867),
+         INT16_C(  9146),  INT16_C( 19419), -INT16_C( 25072),  INT16_C( 10194),  INT16_C(  1790),  INT16_C(  8760),  INT16_C( 19200), -INT16_C(  8295) },
+      { -INT16_C( 29442), -INT16_C(  8295),  INT16_C( 19200), -INT16_C(  9867),  INT16_C( 28867),  INT16_C( 19200), -INT16_C( 15976),  INT16_C( 11622),
+         INT16_C( 10194), -INT16_C( 27681),  INT16_C( 11622), -INT16_C( 29442),  INT16_C( 28867),  INT16_C( 18748),  INT16_C( 18748),  INT16_C(  5643) } },
+    { { -INT16_C(    34), -INT16_C(  8947),  INT16_C(  6284), -INT16_C( 14093), -INT16_C( 29855), -INT16_C( 10614),  INT16_C( 19812),  INT16_C(  7751),
+         INT16_C(  8816), -INT16_C( 32663),  INT16_C( 15296), -INT16_C( 16728), -INT16_C(  8127),  INT16_C( 17121),  INT16_C( 31275),  INT16_C(  2593) },
+      {  INT16_C( 11897),  INT16_C(  1511), -INT16_C(  9658), -INT16_C( 22322),  INT16_C( 22629), -INT16_C( 13954), -INT16_C( 14939),  INT16_C(  5607),
+         INT16_C( 20712), -INT16_C( 22378),  INT16_C( 16011), -INT16_C( 13209),  INT16_C( 18462),  INT16_C( 18702),  INT16_C( 12482),  INT16_C( 15187) },
+      {  INT16_C( 12482),  INT16_C( 18702),  INT16_C( 18462), -INT16_C( 22322),  INT16_C(  1511),  INT16_C( 16011),  INT16_C( 22629),  INT16_C(  5607),
+         INT16_C( 11897), -INT16_C( 22378),  INT16_C( 11897),  INT16_C( 20712),  INT16_C(  1511),  INT16_C(  1511), -INT16_C( 13209),  INT16_C(  1511) } },
+    { {  INT16_C( 14942), -INT16_C( 23231),  INT16_C(  3860),  INT16_C( 31053), -INT16_C( 13465),  INT16_C(  3138),  INT16_C( 10641),  INT16_C( 31009),
+        -INT16_C( 18567),  INT16_C(  1057), -INT16_C( 30475),  INT16_C(  5073), -INT16_C(  8240), -INT16_C( 28067), -INT16_C( 20465),  INT16_C( 28366) },
+      {  INT16_C(  4075), -INT16_C(   237),  INT16_C( 24606), -INT16_C( 31367), -INT16_C( 17621), -INT16_C( 17263), -INT16_C( 19739),  INT16_C( 24117),
+         INT16_C( 22378),  INT16_C( 24419),  INT16_C( 13535), -INT16_C( 20365), -INT16_C( 12269),  INT16_C(  9026),  INT16_C(  4224),  INT16_C( 27537) },
+      {  INT16_C(  4224), -INT16_C(   237), -INT16_C( 17621),  INT16_C(  9026),  INT16_C( 24117),  INT16_C( 24606), -INT16_C(   237), -INT16_C(   237),
+         INT16_C( 24419), -INT16_C(   237), -INT16_C( 17263), -INT16_C(   237),  INT16_C(  4075),  INT16_C(  9026),  INT16_C( 27537),  INT16_C(  4224) } },
+    { { -INT16_C( 23521),  INT16_C( 15723), -INT16_C(  7164),  INT16_C( 12226),  INT16_C( 21407), -INT16_C( 31508),  INT16_C(  8454),  INT16_C( 28899),
+         INT16_C( 18040),  INT16_C( 22735),  INT16_C( 17018), -INT16_C( 29432),  INT16_C( 18962), -INT16_C( 27728),  INT16_C( 16731),  INT16_C( 31486) },
+      {  INT16_C( 27109), -INT16_C(  5704),  INT16_C( 31309), -INT16_C(  4839),  INT16_C(  1486), -INT16_C( 11151),  INT16_C( 21542), -INT16_C( 24764),
+         INT16_C(  5018),  INT16_C(  5367), -INT16_C(   170),  INT16_C( 26786),  INT16_C( 21065), -INT16_C( 23301), -INT16_C(  1388),  INT16_C( 31007) },
+      {  INT16_C( 31007),  INT16_C( 26786),  INT16_C(  1486),  INT16_C( 31309),  INT16_C( 31007),  INT16_C( 21065),  INT16_C( 21542), -INT16_C(  4839),
+         INT16_C(  5018),  INT16_C( 31007), -INT16_C(   170),  INT16_C(  5018),  INT16_C( 31309),  INT16_C( 27109),  INT16_C( 26786), -INT16_C(  1388) } },
+    { { -INT16_C( 10397), -INT16_C( 20125),  INT16_C( 31825),  INT16_C(  8094),  INT16_C(  3969), -INT16_C( 22541),  INT16_C( 14180), -INT16_C(   442),
+         INT16_C( 15691), -INT16_C( 24301), -INT16_C( 19140), -INT16_C( 31223),  INT16_C(  1287), -INT16_C( 25814),  INT16_C( 18943),  INT16_C( 25109) },
+      {  INT16_C( 30752),  INT16_C( 29203), -INT16_C( 19980),  INT16_C( 30097), -INT16_C( 31295),  INT16_C(  9500),  INT16_C( 25532),  INT16_C(  1827),
+         INT16_C( 13984), -INT16_C(  8792), -INT16_C( 19733), -INT16_C(  3229), -INT16_C( 29257), -INT16_C( 18802), -INT16_C( 23593), -INT16_C(  2280) },
+      {  INT16_C( 30097),  INT16_C( 30097),  INT16_C( 29203), -INT16_C( 23593),  INT16_C( 29203),  INT16_C( 30097), -INT16_C( 31295),  INT16_C( 25532),
+        -INT16_C(  3229),  INT16_C( 30097), -INT16_C( 29257), -INT16_C(  8792),  INT16_C(  1827), -INT16_C( 19733), -INT16_C(  2280),  INT16_C(  9500) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256i idx = simde_mm256_loadu_epi16(test_vec[i].idx);
+    simde__m256i a = simde_mm256_loadu_epi16(test_vec[i].a);
+    simde__m256i r = simde_mm256_permutexvar_epi16(idx, a);
+    simde_test_x86_assert_equal_i16x16(r, simde_mm256_loadu_epi16(test_vec[i].r));
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__m256i idx = simde_test_x86_random_i16x16();
+    simde__m256i a = simde_test_x86_random_i16x16();
+    simde__m256i r = simde_mm256_permutexvar_epi16(idx, a);
+
+    simde_test_x86_write_i16x16(2, idx, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_i16x16(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i16x16(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_mask_permutexvar_epi16 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const int16_t src[16];
+    const simde__mmask16 k;
+    const int16_t idx[16];
+    const int16_t a[16];
+    const int16_t r[16];
+  } test_vec[] = {
+    { {  INT16_C( 11291),  INT16_C(  3945), -INT16_C(  1059), -INT16_C( 24956), -INT16_C( 24192),  INT16_C( 15555), -INT16_C(  6396), -INT16_C( 23484),
+        -INT16_C(  5091),  INT16_C(  2433), -INT16_C(  7010),  INT16_C( 22012), -INT16_C( 30094),  INT16_C( 18699),  INT16_C(  9262),  INT16_C( 18752) },
+      UINT16_C(43600),
+      {  INT16_C( 11609), -INT16_C(  8795),  INT16_C(  9676), -INT16_C( 28802), -INT16_C( 32159), -INT16_C( 23178), -INT16_C( 27609), -INT16_C( 22382),
+         INT16_C( 12445), -INT16_C( 26227), -INT16_C(   122), -INT16_C( 28381),  INT16_C( 20808), -INT16_C( 30539),  INT16_C(  1435), -INT16_C(  3022) },
+      { -INT16_C( 10445), -INT16_C(    47),  INT16_C( 20732),  INT16_C( 24206),  INT16_C(  1490), -INT16_C(  1789), -INT16_C( 27239),  INT16_C( 13986),
+         INT16_C( 12230),  INT16_C( 19663), -INT16_C(  3538),  INT16_C( 30429), -INT16_C( 27836), -INT16_C(  8194),  INT16_C( 12696), -INT16_C( 13357) },
+      {  INT16_C( 11291),  INT16_C(  3945), -INT16_C(  1059), -INT16_C( 24956), -INT16_C(    47),  INT16_C( 15555),  INT16_C( 13986), -INT16_C( 23484),
+        -INT16_C(  5091), -INT16_C(  8194), -INT16_C(  7010),  INT16_C( 24206), -INT16_C( 30094), -INT16_C(  1789),  INT16_C(  9262),  INT16_C( 20732) } },
+    { { -INT16_C( 23544),  INT16_C(  1482),  INT16_C( 23028), -INT16_C( 14493),  INT16_C( 26206), -INT16_C(  2112),  INT16_C( 25340), -INT16_C( 15827),
+        -INT16_C(   879), -INT16_C( 16626), -INT16_C(  5138),  INT16_C( 12853),  INT16_C( 13438),  INT16_C(  5905), -INT16_C(  7067),  INT16_C( 28130) },
+      UINT16_C(44425),
+      {  INT16_C( 32114), -INT16_C( 11002),  INT16_C( 25668),  INT16_C(  1340),  INT16_C( 14427), -INT16_C( 30617), -INT16_C(  1542),  INT16_C(  2180),
+         INT16_C( 29368), -INT16_C(  4365),  INT16_C( 29349), -INT16_C( 18910), -INT16_C( 30839),  INT16_C( 27547),  INT16_C(  9460),  INT16_C( 26392) },
+      {  INT16_C(  7841), -INT16_C(  6596),  INT16_C( 30850), -INT16_C(  8725),  INT16_C( 21168), -INT16_C( 21915), -INT16_C(  5813),  INT16_C(  1202),
+        -INT16_C( 22948),  INT16_C(   498),  INT16_C(  5144), -INT16_C( 24137),  INT16_C( 21147), -INT16_C( 28916),  INT16_C(  9590),  INT16_C(  6390) },
+      {  INT16_C( 30850),  INT16_C(  1482),  INT16_C( 23028),  INT16_C( 21147),  INT16_C( 26206), -INT16_C(  2112),  INT16_C( 25340),  INT16_C( 21168),
+        -INT16_C( 22948), -INT16_C( 16626), -INT16_C( 21915),  INT16_C( 30850),  INT16_C( 13438), -INT16_C( 24137), -INT16_C(  7067), -INT16_C( 22948) } },
+    { {  INT16_C( 13123), -INT16_C( 14594), -INT16_C(  5717),  INT16_C( 23715),  INT16_C(  2363), -INT16_C( 30970), -INT16_C( 17934),  INT16_C( 20107),
+         INT16_C( 32095),  INT16_C( 30543),  INT16_C(  1937),  INT16_C( 11288),  INT16_C(  9305), -INT16_C( 12101), -INT16_C( 19895), -INT16_C( 29208) },
+      UINT16_C(59109),
+      { -INT16_C( 28589), -INT16_C(  2353),  INT16_C(  2796), -INT16_C(  3073), -INT16_C(  3439),  INT16_C(  7340),  INT16_C(  2880), -INT16_C( 28519),
+         INT16_C( 10882), -INT16_C( 25961), -INT16_C(  4010),  INT16_C(  4798),  INT16_C(  2240), -INT16_C( 22332), -INT16_C( 22123), -INT16_C(  6002) },
+      {  INT16_C( 23865),  INT16_C(  9950), -INT16_C(  8600), -INT16_C(  1767), -INT16_C( 14896),  INT16_C(  4118), -INT16_C( 20528),  INT16_C( 21152),
+         INT16_C( 14298),  INT16_C( 12524), -INT16_C( 21976), -INT16_C(  6078),  INT16_C(  1714),  INT16_C( 18321),  INT16_C(  8111), -INT16_C(  5841) },
+      { -INT16_C(  1767), -INT16_C( 14594),  INT16_C(  1714),  INT16_C( 23715),  INT16_C(  2363),  INT16_C(  1714),  INT16_C( 23865),  INT16_C( 12524),
+         INT16_C( 32095),  INT16_C( 21152), -INT16_C( 20528),  INT16_C( 11288),  INT16_C(  9305), -INT16_C( 14896),  INT16_C(  4118),  INT16_C(  8111) } },
+    { {  INT16_C(  3709), -INT16_C(  6897),  INT16_C( 10476), -INT16_C( 17186), -INT16_C(  2835), -INT16_C( 16948),  INT16_C( 28068),  INT16_C( 32271),
+        -INT16_C(  1116), -INT16_C( 13138), -INT16_C(  3675),  INT16_C( 22709),  INT16_C( 18167), -INT16_C( 22625), -INT16_C( 12443), -INT16_C(  7536) },
+      UINT16_C(40925),
+      { -INT16_C( 13881), -INT16_C( 22841), -INT16_C( 19323),  INT16_C( 20890),  INT16_C( 15985), -INT16_C( 32578),  INT16_C( 25532),  INT16_C( 27515),
+         INT16_C(  8239), -INT16_C(  7076),  INT16_C( 21368),  INT16_C(  6186), -INT16_C( 28422), -INT16_C( 29977), -INT16_C( 15246),  INT16_C( 14889) },
+      { -INT16_C(  3955),  INT16_C(  4832),  INT16_C( 31396),  INT16_C(  5475),  INT16_C(  8889),  INT16_C( 30101),  INT16_C(  4229), -INT16_C( 19232),
+         INT16_C( 15409), -INT16_C( 22119), -INT16_C( 15472), -INT16_C( 30015), -INT16_C( 22445), -INT16_C( 14827),  INT16_C( 15980), -INT16_C(  1792) },
+      { -INT16_C( 19232), -INT16_C(  6897),  INT16_C( 30101), -INT16_C( 15472),  INT16_C(  4832), -INT16_C( 16948), -INT16_C( 22445), -INT16_C( 30015),
+        -INT16_C(  1792), -INT16_C( 22445),  INT16_C( 15409), -INT16_C( 15472), -INT16_C( 15472), -INT16_C( 22625), -INT16_C( 12443), -INT16_C( 22119) } },
+    { { -INT16_C(  8145), -INT16_C( 11509),  INT16_C( 28506),  INT16_C(  5097),  INT16_C( 32401),  INT16_C(  5769),  INT16_C( 27023), -INT16_C( 16182),
+         INT16_C( 25510),  INT16_C( 13929),  INT16_C( 11047),  INT16_C( 31424), -INT16_C( 10797),  INT16_C( 16448),  INT16_C( 16404),  INT16_C( 17209) },
+      UINT16_C(17696),
+      {  INT16_C( 31510), -INT16_C(    76),  INT16_C( 17806),  INT16_C(  6014),  INT16_C(  3419),  INT16_C(  9601),  INT16_C( 10189),  INT16_C( 13961),
+        -INT16_C( 20387),  INT16_C(  7521),  INT16_C( 13610),  INT16_C( 27635),  INT16_C(  1909), -INT16_C( 20821), -INT16_C( 13238),  INT16_C( 24819) },
+      { -INT16_C( 22713), -INT16_C( 10912), -INT16_C(  8468),  INT16_C( 18413),  INT16_C( 28395), -INT16_C( 18323), -INT16_C(  2411), -INT16_C(  3346),
+         INT16_C( 20646), -INT16_C( 12273),  INT16_C(   645), -INT16_C(  1477), -INT16_C(  6391),  INT16_C( 21416), -INT16_C( 25421), -INT16_C(  1356) },
+      { -INT16_C(  8145), -INT16_C( 11509),  INT16_C( 28506),  INT16_C(  5097),  INT16_C( 32401), -INT16_C( 10912),  INT16_C( 27023), -INT16_C( 16182),
+         INT16_C( 21416),  INT16_C( 13929),  INT16_C(   645),  INT16_C( 31424), -INT16_C( 10797),  INT16_C( 16448),  INT16_C(   645),  INT16_C( 17209) } },
+    { {  INT16_C(  5187),  INT16_C( 12495), -INT16_C( 17166), -INT16_C(  8841), -INT16_C(  7126), -INT16_C( 16491), -INT16_C( 31782), -INT16_C( 32591),
+        -INT16_C( 15917),  INT16_C( 22609), -INT16_C( 29501), -INT16_C( 12974), -INT16_C(  1165),  INT16_C(  9760), -INT16_C( 11113), -INT16_C(  9696) },
+      UINT16_C(61672),
+      { -INT16_C(  9718), -INT16_C( 32084), -INT16_C( 10313),  INT16_C( 19558),  INT16_C( 16790),  INT16_C( 18640), -INT16_C( 23615),  INT16_C(  4617),
+        -INT16_C( 13060),  INT16_C( 20127),  INT16_C(  4761), -INT16_C( 17847), -INT16_C(  8135),  INT16_C( 22926),  INT16_C( 30651), -INT16_C( 15031) },
+      { -INT16_C(  2479),  INT16_C(  2375), -INT16_C( 20787),  INT16_C( 25429),  INT16_C(  9711), -INT16_C( 20309), -INT16_C( 19255), -INT16_C( 14909),
+         INT16_C( 25217),  INT16_C(  6675),  INT16_C( 23924), -INT16_C( 21036),  INT16_C( 25405), -INT16_C(  2041),  INT16_C( 20698),  INT16_C( 11198) },
+      {  INT16_C(  5187),  INT16_C( 12495), -INT16_C( 17166), -INT16_C( 19255), -INT16_C(  7126), -INT16_C(  2479),  INT16_C(  2375),  INT16_C(  6675),
+        -INT16_C( 15917),  INT16_C( 22609), -INT16_C( 29501), -INT16_C( 12974),  INT16_C(  6675),  INT16_C( 20698), -INT16_C( 21036),  INT16_C(  6675) } },
+    { {  INT16_C(  1350),  INT16_C(  4916), -INT16_C( 30029), -INT16_C( 23945),  INT16_C(  8879),  INT16_C( 30803),  INT16_C(  5847),  INT16_C( 22589),
+         INT16_C( 20856), -INT16_C(  5006),  INT16_C( 18350), -INT16_C(  5222), -INT16_C( 24150), -INT16_C( 31516), -INT16_C( 23823),  INT16_C( 14511) },
+      UINT16_C(58535),
+      {  INT16_C( 23371), -INT16_C( 15762),  INT16_C(  7677),  INT16_C( 20709), -INT16_C( 17258), -INT16_C( 11418), -INT16_C(  8684), -INT16_C( 31196),
+        -INT16_C( 11573),  INT16_C( 26061),  INT16_C( 30654), -INT16_C( 24058), -INT16_C(  2053), -INT16_C( 21692), -INT16_C(  5329),  INT16_C( 31631) },
+      { -INT16_C(   698),  INT16_C( 17469),  INT16_C(  8730), -INT16_C( 20332), -INT16_C(  1058), -INT16_C(  3452), -INT16_C( 22311), -INT16_C( 23431),
+         INT16_C( 18043),  INT16_C( 14601),  INT16_C(  4030), -INT16_C( 17957),  INT16_C(  7943),  INT16_C( 13924), -INT16_C(  3318),  INT16_C( 20913) },
+      { -INT16_C( 17957), -INT16_C(  3318),  INT16_C( 13924), -INT16_C( 23945),  INT16_C(  8879), -INT16_C( 22311),  INT16_C(  5847), -INT16_C(  1058),
+         INT16_C( 20856), -INT16_C(  5006), -INT16_C(  3318), -INT16_C(  5222), -INT16_C( 24150), -INT16_C(  1058),  INT16_C( 20913),  INT16_C( 20913) } },
+    { { -INT16_C(  4112),  INT16_C(  2965),  INT16_C( 10513), -INT16_C(  3909),  INT16_C( 16164), -INT16_C(   286),  INT16_C( 23528),  INT16_C( 25506),
+        -INT16_C( 21342),  INT16_C( 24732),  INT16_C( 30651), -INT16_C( 15847),  INT16_C( 32406), -INT16_C( 24327), -INT16_C( 21903),  INT16_C( 25329) },
+      UINT16_C(34457),
+      { -INT16_C( 21651),  INT16_C( 10416), -INT16_C( 11109),  INT16_C( 32104),  INT16_C( 20690),  INT16_C( 30169),  INT16_C( 31667),  INT16_C( 20257),
+        -INT16_C(  8997), -INT16_C(  2874),  INT16_C( 23711), -INT16_C( 26510), -INT16_C(  6916), -INT16_C(  4542), -INT16_C(  9146), -INT16_C( 19596) },
+      {  INT16_C(  9351),  INT16_C(  8923),  INT16_C( 17401), -INT16_C( 13409),  INT16_C( 30867),  INT16_C( 17984),  INT16_C( 25075), -INT16_C( 12651),
+         INT16_C( 23358), -INT16_C(  8765),  INT16_C( 13751), -INT16_C( 19339), -INT16_C( 18663),  INT16_C( 24482),  INT16_C(  5779),  INT16_C(  6674) },
+      {  INT16_C( 24482),  INT16_C(  2965),  INT16_C( 10513),  INT16_C( 23358),  INT16_C( 17401), -INT16_C(   286),  INT16_C( 23528),  INT16_C(  8923),
+        -INT16_C( 21342),  INT16_C( 25075),  INT16_C(  6674), -INT16_C( 15847),  INT16_C( 32406), -INT16_C( 24327), -INT16_C( 21903),  INT16_C( 30867) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256i src = simde_mm256_loadu_epi16(test_vec[i].src);
+    simde__m256i idx = simde_mm256_loadu_epi16(test_vec[i].idx);
+    simde__m256i a = simde_mm256_loadu_epi16(test_vec[i].a);
+    simde__m256i r = simde_mm256_mask_permutexvar_epi16(src, test_vec[i].k, idx, a);
+    simde_test_x86_assert_equal_i16x16(r, simde_mm256_loadu_epi16(test_vec[i].r));
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__m256i src = simde_test_x86_random_i16x16();
+    simde__mmask16 k = simde_test_x86_random_mmask16();
+    simde__m256i idx = simde_test_x86_random_i16x16();
+    simde__m256i a = simde_test_x86_random_i16x16();
+    simde__m256i r = simde_mm256_mask_permutexvar_epi16(src, k, idx, a);
+
+    simde_test_x86_write_i16x16(2, src, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_mmask16(2, k, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i16x16(2, idx, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i16x16(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i16x16(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_maskz_permutexvar_epi16 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde__mmask16 k;
+    const int16_t idx[16];
+    const int16_t a[16];
+    const int16_t r[16];
+  } test_vec[] = {
+    { UINT16_C(60987),
+      {  INT16_C( 13372), -INT16_C(  9167), -INT16_C( 14849),  INT16_C( 16468),  INT16_C( 18443), -INT16_C( 24159), -INT16_C(  8426), -INT16_C(  9732),
+        -INT16_C( 19268),  INT16_C( 12559),  INT16_C( 10344),  INT16_C(  2793),  INT16_C( 31880), -INT16_C( 26080),  INT16_C( 23447), -INT16_C( 11384) },
+      { -INT16_C( 17777), -INT16_C( 28753),  INT16_C(  1151), -INT16_C( 30001),  INT16_C( 28748),  INT16_C( 25131),  INT16_C( 10320),  INT16_C(  3132),
+         INT16_C( 19420),  INT16_C( 17470),  INT16_C( 10099), -INT16_C(  1202),  INT16_C( 28323),  INT16_C( 14998),  INT16_C(  7882),  INT16_C( 22798) },
+      {  INT16_C( 28323), -INT16_C( 28753),  INT16_C(     0),  INT16_C( 28748), -INT16_C(  1202), -INT16_C( 28753),  INT16_C(     0),  INT16_C(     0),
+         INT16_C(     0),  INT16_C( 22798),  INT16_C( 19420),  INT16_C( 17470),  INT16_C(     0), -INT16_C( 17777),  INT16_C(  3132),  INT16_C( 19420) } },
+    { UINT16_C(48600),
+      {  INT16_C( 22504), -INT16_C( 18495),  INT16_C(  3554),  INT16_C(  3368),  INT16_C( 30832), -INT16_C( 21451),  INT16_C(  4484), -INT16_C( 15625),
+         INT16_C( 27221), -INT16_C( 23575), -INT16_C( 29338), -INT16_C(  1006), -INT16_C(  9017), -INT16_C( 10982), -INT16_C(  3275),  INT16_C(  7827) },
+      {  INT16_C( 21578),  INT16_C( 11477), -INT16_C(   670), -INT16_C( 11718),  INT16_C( 28533), -INT16_C(  1410),  INT16_C( 30081), -INT16_C( 10564),
+        -INT16_C( 22817),  INT16_C( 17786), -INT16_C( 29645), -INT16_C(  1471),  INT16_C( 23656), -INT16_C( 25136),  INT16_C( 25423), -INT16_C( 26181) },
+      {  INT16_C(     0),  INT16_C(     0),  INT16_C(     0), -INT16_C( 22817),  INT16_C( 21578),  INT16_C(     0),  INT16_C( 28533), -INT16_C( 10564),
+        -INT16_C(  1410),  INT16_C(     0),  INT16_C( 30081), -INT16_C(   670), -INT16_C( 10564), -INT16_C( 29645),  INT16_C(     0), -INT16_C( 11718) } },
+    { UINT16_C(37303),
+      {  INT16_C(  6598),  INT16_C(   142),  INT16_C(  1259),  INT16_C( 26991), -INT16_C(  3842), -INT16_C( 17698), -INT16_C( 16697),  INT16_C( 16736),
+        -INT16_C( 27901),  INT16_C( 17869),  INT16_C( 13710),  INT16_C( 24225), -INT16_C(  3886), -INT16_C( 28991),  INT16_C( 30857),  INT16_C( 20255) },
+      { -INT16_C( 21102),  INT16_C( 32079), -INT16_C( 16463), -INT16_C( 20505), -INT16_C( 14929),  INT16_C( 30314), -INT16_C( 13693), -INT16_C( 30793),
+        -INT16_C( 31650), -INT16_C(  4916),  INT16_C( 28089), -INT16_C( 29622),  INT16_C(  2909), -INT16_C(  6630),  INT16_C( 14723),  INT16_C(  5430) },
+      { -INT16_C( 13693),  INT16_C( 14723), -INT16_C( 29622),  INT16_C(     0),  INT16_C( 14723),  INT16_C( 14723),  INT16_C(     0), -INT16_C( 21102),
+        -INT16_C( 20505),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0), -INT16_C( 16463),  INT16_C(     0),  INT16_C(     0),  INT16_C(  5430) } },
+    { UINT16_C(34278),
+      { -INT16_C( 26477),  INT16_C( 31300), -INT16_C(  3001), -INT16_C( 20161), -INT16_C( 15510),  INT16_C(  8828), -INT16_C(  9654),  INT16_C(  5798),
+         INT16_C( 24774),  INT16_C(  4227), -INT16_C(  7956),  INT16_C(  1563), -INT16_C( 24890), -INT16_C(   961),  INT16_C(  9652),  INT16_C( 18306) },
+      { -INT16_C( 14659),  INT16_C(  1473),  INT16_C(   186),  INT16_C(  9654),  INT16_C( 12995),  INT16_C(  3399), -INT16_C(  4852), -INT16_C( 11741),
+        -INT16_C( 22963),  INT16_C( 14818), -INT16_C(   634),  INT16_C( 19775),  INT16_C( 32412),  INT16_C( 20553), -INT16_C( 13404),  INT16_C( 24983) },
+      {  INT16_C(     0),  INT16_C( 12995), -INT16_C( 11741),  INT16_C(     0),  INT16_C(     0),  INT16_C( 32412), -INT16_C(   634), -INT16_C(  4852),
+        -INT16_C(  4852),  INT16_C(     0),  INT16_C( 32412),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0),  INT16_C(   186) } },
+    { UINT16_C(22674),
+      {  INT16_C( 19558),  INT16_C(  7512),  INT16_C(  7281), -INT16_C( 18353),  INT16_C( 23593),  INT16_C( 19878), -INT16_C(  3282),  INT16_C(  4595),
+         INT16_C( 31277),  INT16_C( 27662), -INT16_C( 21817),  INT16_C(  4331), -INT16_C( 28678), -INT16_C( 28196),  INT16_C( 28400),  INT16_C( 22505) },
+      {  INT16_C( 17082),  INT16_C( 11380), -INT16_C( 15522), -INT16_C( 30748), -INT16_C( 30177),  INT16_C( 20180), -INT16_C( 14210), -INT16_C( 21665),
+         INT16_C( 27970),  INT16_C(  2327),  INT16_C(   536),  INT16_C(  4633), -INT16_C(  2671), -INT16_C( 32092), -INT16_C( 29341),  INT16_C(  7897) },
+      {  INT16_C(     0),  INT16_C( 27970),  INT16_C(     0),  INT16_C(     0),  INT16_C(  2327),  INT16_C(     0),  INT16_C(     0), -INT16_C( 30748),
+         INT16_C(     0),  INT16_C(     0),  INT16_C(     0),  INT16_C(  4633),  INT16_C(   536),  INT16_C(     0),  INT16_C( 17082),  INT16_C(     0) } },
+    { UINT16_C(19919),
+      {  INT16_C( 11594),  INT16_C( 11792),  INT16_C( 12469), -INT16_C( 30279),  INT16_C( 14206), -INT16_C(  8879), -INT16_C( 27678), -INT16_C(  1718),
+         INT16_C( 25244), -INT16_C( 18692), -INT16_C( 29323),  INT16_C(  6571),  INT16_C(  3855), -INT16_C(  5978),  INT16_C( 30253),  INT16_C( 30517) },
+      {  INT16_C( 18083),  INT16_C( 22693),  INT16_C( 24182), -INT16_C(  2846),  INT16_C( 13205),  INT16_C( 30673),  INT16_C(  7111),  INT16_C( 25457),
+         INT16_C( 28030), -INT16_C(  3303), -INT16_C( 14854),  INT16_C(  2572), -INT16_C( 19756),  INT16_C(   498),  INT16_C( 10280), -INT16_C( 13192) },
+      { -INT16_C( 14854),  INT16_C( 18083),  INT16_C( 30673), -INT16_C(  3303),  INT16_C(     0),  INT16_C(     0),  INT16_C( 24182), -INT16_C( 14854),
+        -INT16_C( 19756),  INT16_C(     0),  INT16_C( 30673),  INT16_C(  2572),  INT16_C(     0),  INT16_C(     0),  INT16_C(   498),  INT16_C(     0) } },
+    { UINT16_C( 7534),
+      { -INT16_C(  7132),  INT16_C(  1660),  INT16_C(  4568), -INT16_C( 22214),  INT16_C(   393), -INT16_C(  1340),  INT16_C( 16996),  INT16_C( 32359),
+         INT16_C( 24885),  INT16_C( 16707),  INT16_C(  5995),  INT16_C( 24308),  INT16_C(  7192), -INT16_C( 28538), -INT16_C(  2840),  INT16_C(  3501) },
+      {  INT16_C( 10712), -INT16_C( 20461),  INT16_C( 19771), -INT16_C( 15271),  INT16_C(  7502), -INT16_C( 19522),  INT16_C(  9568), -INT16_C( 27343),
+         INT16_C( 29830), -INT16_C(  3369), -INT16_C( 13429), -INT16_C( 23728), -INT16_C( 10521), -INT16_C( 12237), -INT16_C(  7990), -INT16_C( 23843) },
+      {  INT16_C(     0), -INT16_C( 10521),  INT16_C( 29830), -INT16_C( 13429),  INT16_C(     0),  INT16_C(  7502),  INT16_C(  7502),  INT16_C(     0),
+        -INT16_C( 19522),  INT16_C(     0), -INT16_C( 23728),  INT16_C(  7502),  INT16_C( 29830),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0) } },
+    { UINT16_C(61450),
+      {  INT16_C( 17746), -INT16_C( 21698), -INT16_C( 29687), -INT16_C( 14392),  INT16_C( 10303),  INT16_C( 28908),  INT16_C( 29374), -INT16_C( 27164),
+         INT16_C( 28516), -INT16_C( 19360),  INT16_C( 18194),  INT16_C( 17802),  INT16_C( 21527), -INT16_C(  3034),  INT16_C( 12534),  INT16_C( 18661) },
+      {  INT16_C(  9077),  INT16_C( 32499), -INT16_C( 17233), -INT16_C(  4283),  INT16_C( 12772), -INT16_C( 23969),  INT16_C( 17571),  INT16_C(  2103),
+        -INT16_C( 26701), -INT16_C( 14660),  INT16_C( 18399), -INT16_C(  2549),  INT16_C( 12699), -INT16_C( 27925), -INT16_C( 12191), -INT16_C( 10534) },
+      {  INT16_C(     0), -INT16_C( 12191),  INT16_C(     0), -INT16_C( 26701),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0),
+         INT16_C(     0),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0),  INT16_C(  2103),  INT16_C( 17571),  INT16_C( 17571), -INT16_C( 23969) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256i idx = simde_mm256_loadu_epi16(test_vec[i].idx);
+    simde__m256i a = simde_mm256_loadu_epi16(test_vec[i].a);
+    simde__m256i r = simde_mm256_maskz_permutexvar_epi16(test_vec[i].k, idx, a);
+    simde_test_x86_assert_equal_i16x16(r, simde_mm256_loadu_epi16(test_vec[i].r));
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__mmask16 k = simde_test_x86_random_mmask16();
+    simde__m256i idx = simde_test_x86_random_i16x16();
+    simde__m256i a = simde_test_x86_random_i16x16();
+    simde__m256i r = simde_mm256_maskz_permutexvar_epi16(k, idx, a);
+
+    simde_test_x86_write_mmask16(2, k, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_i16x16(2, idx, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i16x16(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i16x16(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_permutexvar_epi32(SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const int32_t idx[8];
+    const int32_t a[8];
+    const int32_t r[8];
+  } test_vec[] = {
+    { { -INT32_C(  1307444235), -INT32_C(  1706430584), -INT32_C(   604486448), -INT32_C(  1741113544), -INT32_C(   524345514),  INT32_C(  1817309466), -INT32_C(  1187810749),  INT32_C(  1039629383) },
+      { -INT32_C(     1111689), -INT32_C(   929482504), -INT32_C(  1264348804), -INT32_C(  1622287543),  INT32_C(   343870714),  INT32_C(  1082183933), -INT32_C(  1963281597), -INT32_C(  1496846033) },
+      {  INT32_C(  1082183933), -INT32_C(     1111689), -INT32_C(     1111689), -INT32_C(     1111689), -INT32_C(  1963281597), -INT32_C(  1264348804), -INT32_C(  1622287543), -INT32_C(  1496846033) } },
+    { { -INT32_C(   223954950),  INT32_C(  1824145391),  INT32_C(   438328785),  INT32_C(   867790137),  INT32_C(  2001222010),  INT32_C(  1287178249), -INT32_C(  1411927428), -INT32_C(  1638752605) },
+      {  INT32_C(  1167128661),  INT32_C(   145836855), -INT32_C(   517811800), -INT32_C(  1189749697),  INT32_C(   506486037), -INT32_C(  1586763739),  INT32_C(  1045250714),  INT32_C(   920428512) },
+      { -INT32_C(   517811800),  INT32_C(   920428512),  INT32_C(   145836855),  INT32_C(   145836855), -INT32_C(   517811800),  INT32_C(   145836855),  INT32_C(   506486037), -INT32_C(  1189749697) } },
+    { { -INT32_C(   830772073),  INT32_C(  1624714423),  INT32_C(  1010956797), -INT32_C(   353020203), -INT32_C(   653711693), -INT32_C(  1451592690), -INT32_C(  1763194954), -INT32_C(    36912282) },
+      { -INT32_C(   406042833),  INT32_C(  1900520307),  INT32_C(  1923975324), -INT32_C(  1839422497), -INT32_C(   680827447), -INT32_C(  1887377703),  INT32_C(   338061229),  INT32_C(  1511125546) },
+      {  INT32_C(  1511125546),  INT32_C(  1511125546), -INT32_C(  1887377703), -INT32_C(  1887377703), -INT32_C(  1839422497),  INT32_C(   338061229),  INT32_C(   338061229),  INT32_C(   338061229) } },
+    { { -INT32_C(  1388192454),  INT32_C(   488540288), -INT32_C(   275788784),  INT32_C(   948104047),  INT32_C(   705686865), -INT32_C(  2118479661),  INT32_C(   580247799),  INT32_C(   209495762) },
+      {  INT32_C(    79347076),  INT32_C(  1428281413),  INT32_C(   323334308), -INT32_C(   313800804), -INT32_C(  2011735116), -INT32_C(   502672917), -INT32_C(  2080072015), -INT32_C(   930054076) },
+      {  INT32_C(   323334308),  INT32_C(    79347076),  INT32_C(    79347076), -INT32_C(   930054076),  INT32_C(  1428281413), -INT32_C(   313800804), -INT32_C(   930054076),  INT32_C(   323334308) } },
+    { { -INT32_C(  2100475331), -INT32_C(   942084573),  INT32_C(  1004215711), -INT32_C(  1742199068),  INT32_C(  1814052737), -INT32_C(  1034999535),  INT32_C(   205935559),  INT32_C(   299161556) },
+      {  INT32_C(  1150591265),  INT32_C(   789343376),  INT32_C(  1835722633), -INT32_C(  1895460339), -INT32_C(   486857007),  INT32_C(   396708431),  INT32_C(  1914956702), -INT32_C(   461113406) },
+      {  INT32_C(   396708431), -INT32_C(  1895460339), -INT32_C(   461113406), -INT32_C(   486857007),  INT32_C(   789343376),  INT32_C(   789343376), -INT32_C(   461113406), -INT32_C(   486857007) } },
+    { {  INT32_C(   690493337),  INT32_C(   207107203),  INT32_C(   695845403),  INT32_C(   632848212), -INT32_C(   200756315), -INT32_C(  1676956162),  INT32_C(  1527656088), -INT32_C(  1086353114) },
+      {  INT32_C(   753428393), -INT32_C(  1220984676),  INT32_C(  1457566210), -INT32_C(   696543183),  INT32_C(  1254851404), -INT32_C(   907618768),  INT32_C(   723842053),  INT32_C(   787112837) },
+      { -INT32_C(  1220984676), -INT32_C(   696543183), -INT32_C(   696543183),  INT32_C(  1254851404), -INT32_C(   907618768),  INT32_C(   723842053),  INT32_C(   753428393),  INT32_C(   723842053) } },
+    { {  INT32_C(  1717293770),  INT32_C(   337548306),  INT32_C(  2020277830), -INT32_C(   481368681), -INT32_C(  1725097623), -INT32_C(   178121744), -INT32_C(  1944025593), -INT32_C(  1262810391) },
+      { -INT32_C(   300280100), -INT32_C(   268289878), -INT32_C(   832017353), -INT32_C(  1162758319), -INT32_C(  1068179760), -INT32_C(   122308879),  INT32_C(   646239549), -INT32_C(  1143324705) },
+      { -INT32_C(   832017353), -INT32_C(   832017353),  INT32_C(   646239549), -INT32_C(  1143324705), -INT32_C(   268289878), -INT32_C(   300280100), -INT32_C(  1143324705), -INT32_C(   268289878) } },
+    { { -INT32_C(     5638827),  INT32_C(  1693494061),  INT32_C(  1764907031), -INT32_C(   534519025), -INT32_C(  1298106431),  INT32_C(  1806325294),  INT32_C(   194064171), -INT32_C(   993629074) },
+      { -INT32_C(  1899794335),  INT32_C(   871609115),  INT32_C(   463217932), -INT32_C(   889471223),  INT32_C(  1702730807),  INT32_C(   500180978), -INT32_C(   987209386),  INT32_C(   780791757) },
+      {  INT32_C(   500180978),  INT32_C(   500180978),  INT32_C(   780791757),  INT32_C(   780791757),  INT32_C(   871609115), -INT32_C(   987209386), -INT32_C(   889471223), -INT32_C(   987209386) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256i idx = simde_mm256_loadu_epi32(test_vec[i].idx);
+    simde__m256i a = simde_mm256_loadu_epi32(test_vec[i].a);
+    simde__m256i r = simde_mm256_permutexvar_epi32(idx, a);
+    simde_test_x86_assert_equal_i32x8(r, simde_mm256_loadu_epi32(test_vec[i].r));
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__m256i idx = simde_test_x86_random_i32x8();
+    simde__m256i a = simde_test_x86_random_i32x8();
+    simde__m256i r = simde_mm256_permutexvar_epi32(idx, a);
+
+    simde_test_x86_write_i32x8(2, idx, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_i32x8(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x8(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_mask_permutexvar_epi32(SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const int32_t src[8];
+    const simde__mmask8 k;
+    const int32_t idx[8];
+    const int32_t a[8];
+    const int32_t r[8];
+  } test_vec[] = {
+    { {  INT32_C(  2059226207),  INT32_C(   212709376), -INT32_C(   567850539),  INT32_C(  1084826377), -INT32_C(  1314576705), -INT32_C(  1529973427), -INT32_C(  1536559146),  INT32_C(  1171452646) },
+      UINT8_C( 62),
+      {  INT32_C(  1061076879), -INT32_C(  1240118675), -INT32_C(  1782582414), -INT32_C(  1034616932),  INT32_C(   420480420), -INT32_C(   890194733),  INT32_C(   263230493), -INT32_C(   162663066) },
+      {  INT32_C(   573934773),  INT32_C(  1222134486), -INT32_C(   623011778),  INT32_C(  1016934807),  INT32_C(   173387062),  INT32_C(  2127840609),  INT32_C(  1083016665),  INT32_C(   792124026) },
+      {  INT32_C(  2059226207),  INT32_C(  2127840609), -INT32_C(   623011778),  INT32_C(   173387062),  INT32_C(   173387062),  INT32_C(  1016934807), -INT32_C(  1536559146),  INT32_C(  1171452646) } },
+    { {  INT32_C(  1028746086), -INT32_C(   192599370),  INT32_C(  1506698178), -INT32_C(   879400044),  INT32_C(  2044062488),  INT32_C(   184002864), -INT32_C(  1454734290), -INT32_C(   975667105) },
+      UINT8_C(235),
+      {  INT32_C(  1419837994), -INT32_C(   350841464), -INT32_C(   813731996), -INT32_C(   253212155), -INT32_C(   920624865), -INT32_C(   571004327), -INT32_C(   197353356), -INT32_C(  1545600391) },
+      { -INT32_C(  1929936636),  INT32_C(  2071399703), -INT32_C(  2125793412),  INT32_C(  1634808385), -INT32_C(   315977068),  INT32_C(   835330492),  INT32_C(   992282562),  INT32_C(   232654089) },
+      { -INT32_C(  2125793412), -INT32_C(  1929936636),  INT32_C(  1506698178),  INT32_C(   835330492),  INT32_C(  2044062488),  INT32_C(  2071399703), -INT32_C(   315977068),  INT32_C(  2071399703) } },
+    { { -INT32_C(  1634019961),  INT32_C(  1578701282),  INT32_C(  1256219400),  INT32_C(   715870614), -INT32_C(  1609050653), -INT32_C(  1194204682), -INT32_C(   235669784), -INT32_C(  2080386564) },
+      UINT8_C(166),
+      { -INT32_C(  1433919079), -INT32_C(  1649154246),  INT32_C(   406060487),  INT32_C(  2113691048),  INT32_C(  1450417268),  INT32_C(  1665018989), -INT32_C(   245420001), -INT32_C(   929570257) },
+      {  INT32_C(  1030889475), -INT32_C(   824498937), -INT32_C(   890892766), -INT32_C(   532159892), -INT32_C(   348734594),  INT32_C(   105870823), -INT32_C(   721965403), -INT32_C(  1801678959) },
+      { -INT32_C(  1634019961), -INT32_C(   890892766), -INT32_C(  1801678959),  INT32_C(   715870614), -INT32_C(  1609050653),  INT32_C(   105870823), -INT32_C(   235669784), -INT32_C(  1801678959) } },
+    { { -INT32_C(  1227747665),  INT32_C(  1451535668),  INT32_C(   656501435), -INT32_C(   888641459),  INT32_C(   179781155),  INT32_C(  1477510835),  INT32_C(  1160513716),  INT32_C(  1188743319) },
+      UINT8_C(215),
+      {  INT32_C(  1493957804), -INT32_C(   350985856), -INT32_C(   348636030), -INT32_C(  2113010876), -INT32_C(  1070196294),  INT32_C(   846564906), -INT32_C(  2083865925),  INT32_C(  1079644308) },
+      { -INT32_C(  1919326963),  INT32_C(  1232645831),  INT32_C(   775205098),  INT32_C(  1857045428), -INT32_C(  2043681188),  INT32_C(   817407093), -INT32_C(   206339490), -INT32_C(  1607266669) },
+      { -INT32_C(  2043681188), -INT32_C(  1919326963),  INT32_C(   775205098), -INT32_C(   888641459),  INT32_C(   775205098),  INT32_C(  1477510835),  INT32_C(  1857045428), -INT32_C(  2043681188) } },
+    { {  INT32_C(   976080243),  INT32_C(  1703192187),  INT32_C(   177453142),  INT32_C(  1467565051), -INT32_C(  1612863446), -INT32_C(  1429236148), -INT32_C(  1415740904),  INT32_C(    72077712) },
+      UINT8_C(158),
+      {  INT32_C(   521748089),  INT32_C(  2071297730),  INT32_C(  1417052177), -INT32_C(  1585524999),  INT32_C(  1106058667),  INT32_C(  1868208108),  INT32_C(   117376309), -INT32_C(   895220911) },
+      {  INT32_C(    82427202),  INT32_C(  1283415611), -INT32_C(   677316898),  INT32_C(  1870143428),  INT32_C(   699491644),  INT32_C(   848825341),  INT32_C(  1631098640), -INT32_C(   584328037) },
+      {  INT32_C(   976080243), -INT32_C(   677316898),  INT32_C(  1283415611),  INT32_C(  1283415611),  INT32_C(  1870143428), -INT32_C(  1429236148), -INT32_C(  1415740904),  INT32_C(  1283415611) } },
+    { { -INT32_C(   723446631),  INT32_C(  1361076595),  INT32_C(   455721047),  INT32_C(   478847455),  INT32_C(    71645959),  INT32_C(  1463213382),  INT32_C(   263745140), -INT32_C(   471014326) },
+      UINT8_C(248),
+      {  INT32_C(   795588558), -INT32_C(  1752777257), -INT32_C(  2022202906),  INT32_C(  1737397035), -INT32_C(  1246915880),  INT32_C(   908657864), -INT32_C(  1585432131), -INT32_C(   208051419) },
+      { -INT32_C(   249428710), -INT32_C(  1467373374),  INT32_C(  1966014537),  INT32_C(  1809628819),  INT32_C(   421562704),  INT32_C(  1263487374), -INT32_C(  1460875134),  INT32_C(  1318815027) },
+      { -INT32_C(   723446631),  INT32_C(  1361076595),  INT32_C(   455721047),  INT32_C(  1809628819), -INT32_C(   249428710), -INT32_C(   249428710),  INT32_C(  1263487374),  INT32_C(  1263487374) } },
+    { {  INT32_C(  1279245962), -INT32_C(  1326135194),  INT32_C(  1529160904),  INT32_C(   851837410),  INT32_C(   407627402), -INT32_C(  1302095056), -INT32_C(  1638248597),  INT32_C(  1609365205) },
+      UINT8_C(180),
+      { -INT32_C(   199578580), -INT32_C(   994194784), -INT32_C(   257550097), -INT32_C(   981739041), -INT32_C(  1074425052),  INT32_C(  1177200887), -INT32_C(   132396798), -INT32_C(   508789835) },
+      { -INT32_C(   942225625), -INT32_C(  2121493615), -INT32_C(  1972292949),  INT32_C(   810609675),  INT32_C(  2012169600), -INT32_C(   256042259), -INT32_C(  1729570333),  INT32_C(  2071631188) },
+      {  INT32_C(  1279245962), -INT32_C(  1326135194),  INT32_C(  2071631188),  INT32_C(   851837410),  INT32_C(  2012169600),  INT32_C(  2071631188), -INT32_C(  1638248597), -INT32_C(   256042259) } },
+    { { -INT32_C(   314421156), -INT32_C(  1905340701),  INT32_C(   203022337),  INT32_C(  1279027660), -INT32_C(  1664930642),  INT32_C(   697073990), -INT32_C(  1363053478),  INT32_C(  1697200905) },
+      UINT8_C(139),
+      {  INT32_C(   980308843), -INT32_C(  1589903935),  INT32_C(  2137933590), -INT32_C(  1339180412), -INT32_C(      603778), -INT32_C(   900128939),  INT32_C(   483592160), -INT32_C(  1683539664) },
+      {  INT32_C(  1305810572),  INT32_C(   703533075), -INT32_C(   592945832), -INT32_C(  1785932521), -INT32_C(   191593825), -INT32_C(  2118193759),  INT32_C(   614306548),  INT32_C(  1472218571) },
+      { -INT32_C(  1785932521),  INT32_C(   703533075),  INT32_C(   203022337), -INT32_C(   191593825), -INT32_C(  1664930642),  INT32_C(   697073990), -INT32_C(  1363053478),  INT32_C(  1305810572) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256i src = simde_mm256_loadu_epi32(test_vec[i].src);
+    simde__m256i idx = simde_mm256_loadu_epi32(test_vec[i].idx);
+    simde__m256i a = simde_mm256_loadu_epi32(test_vec[i].a);
+    simde__m256i r = simde_mm256_mask_permutexvar_epi32(src, test_vec[i].k, idx, a);
+    simde_test_x86_assert_equal_i32x8(r, simde_mm256_loadu_epi32(test_vec[i].r));
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__m256i src = simde_test_x86_random_i32x8();
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m256i idx = simde_test_x86_random_i32x8();
+    simde__m256i a = simde_test_x86_random_i32x8();
+    simde__m256i r = simde_mm256_mask_permutexvar_epi32(src, k, idx, a);
+
+    simde_test_x86_write_i32x8(2, src, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x8(2, idx, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x8(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x8(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_maskz_permutexvar_epi32(SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde__mmask8 k;
+    const int32_t idx[8];
+    const int32_t a[8];
+    const int32_t r[8];
+  } test_vec[] = {
+    { UINT8_C( 91),
+      { -INT32_C(  1502698347), -INT32_C(   251750509),  INT32_C(   336124479), -INT32_C(   390881946),  INT32_C(   529115186), -INT32_C(   132904346), -INT32_C(   305973080), -INT32_C(  1907877128) },
+      {  INT32_C(  1379186367), -INT32_C(  1941753267),  INT32_C(  1923107596),  INT32_C(   442127592),  INT32_C(  1648026620), -INT32_C(  1789178131),  INT32_C(  2139233926), -INT32_C(   133313991) },
+      { -INT32_C(  1789178131),  INT32_C(   442127592),  INT32_C(           0),  INT32_C(  2139233926),  INT32_C(  1923107596),  INT32_C(           0),  INT32_C(  1379186367),  INT32_C(           0) } },
+    { UINT8_C(128),
+      {  INT32_C(  1942833729), -INT32_C(   662742643),  INT32_C(  1321333242),  INT32_C(   776657739),  INT32_C(  1662757909),  INT32_C(   652914951), -INT32_C(    27301581), -INT32_C(  1216456842) },
+      {  INT32_C(   791301281), -INT32_C(  1626887771), -INT32_C(   437401446), -INT32_C(  1189922908), -INT32_C(   350408988),  INT32_C(   319883231), -INT32_C(   435064720),  INT32_C(  1771933639) },
+      {  INT32_C(           0),  INT32_C(           0),  INT32_C(           0),  INT32_C(           0),  INT32_C(           0),  INT32_C(           0),  INT32_C(           0), -INT32_C(   435064720) } },
+    { UINT8_C(219),
+      {  INT32_C(  1887541447),  INT32_C(  1745494175),  INT32_C(  1158475534),  INT32_C(   808043778), -INT32_C(   384821790), -INT32_C(  1755765978), -INT32_C(  1017233612), -INT32_C(  1549809700) },
+      { -INT32_C(    15523745),  INT32_C(  1315380544),  INT32_C(   244609804),  INT32_C(   457162040), -INT32_C(   117157934), -INT32_C(  1500488078),  INT32_C(  2053762717),  INT32_C(   354224310) },
+      {  INT32_C(   354224310),  INT32_C(   354224310),  INT32_C(           0),  INT32_C(   244609804),  INT32_C(   244609804),  INT32_C(           0), -INT32_C(   117157934), -INT32_C(   117157934) } },
+    { UINT8_C( 40),
+      {  INT32_C(  1315509297), -INT32_C(   295979141),  INT32_C(   153577803), -INT32_C(   136625496), -INT32_C(  1536568250),  INT32_C(  1396838244), -INT32_C(  2130068359),  INT32_C(   178921177) },
+      { -INT32_C(  1369894093),  INT32_C(   379434186), -INT32_C(   970996707),  INT32_C(  1287518726),  INT32_C(   871442383), -INT32_C(  1350159562), -INT32_C(   936275985), -INT32_C(   506209362) },
+      {  INT32_C(           0),  INT32_C(           0),  INT32_C(           0), -INT32_C(  1369894093),  INT32_C(           0),  INT32_C(   871442383),  INT32_C(           0),  INT32_C(           0) } },
+    { UINT8_C(238),
+      { -INT32_C(   524775636), -INT32_C(   251802068), -INT32_C(   386481171), -INT32_C(  1464384639),  INT32_C(  1742662196),  INT32_C(     5672561), -INT32_C(  1699864897),  INT32_C(   495489009) },
+      {  INT32_C(  1274888223), -INT32_C(    63112433),  INT32_C(  1071919806), -INT32_C(  1444439179), -INT32_C(   149895546),  INT32_C(   334980692),  INT32_C(  1991091845),  INT32_C(  1418999093) },
+      {  INT32_C(           0), -INT32_C(   149895546),  INT32_C(   334980692), -INT32_C(    63112433),  INT32_C(           0), -INT32_C(    63112433),  INT32_C(  1418999093), -INT32_C(    63112433) } },
+    { UINT8_C(117),
+      { -INT32_C(  1937465199),  INT32_C(   239829468),  INT32_C(    25463397),  INT32_C(   948383090), -INT32_C(  1534296514),  INT32_C(   455712629), -INT32_C(  2125356980), -INT32_C(   973691596) },
+      {  INT32_C(   559053637),  INT32_C(  1630576124), -INT32_C(  1721584601),  INT32_C(   533850593), -INT32_C(   574333593),  INT32_C(  1224273404), -INT32_C(  1043773043),  INT32_C(   881311983) },
+      {  INT32_C(  1630576124),  INT32_C(           0),  INT32_C(  1224273404),  INT32_C(           0), -INT32_C(  1043773043),  INT32_C(  1224273404), -INT32_C(   574333593),  INT32_C(           0) } },
+    { UINT8_C( 59),
+      {  INT32_C(  1983338201),  INT32_C(   983406726), -INT32_C(   467978245),  INT32_C(  1716271880), -INT32_C(   329111041),  INT32_C(  1803201313),  INT32_C(   878328692), -INT32_C(  1687187774) },
+      {  INT32_C(  1779541732),  INT32_C(   983871295), -INT32_C(   299974426), -INT32_C(    95130885), -INT32_C(  1243170925), -INT32_C(   702521246),  INT32_C(  1577810588), -INT32_C(   302351864) },
+      {  INT32_C(   983871295),  INT32_C(  1577810588),  INT32_C(           0),  INT32_C(  1779541732), -INT32_C(   302351864),  INT32_C(   983871295),  INT32_C(           0),  INT32_C(           0) } },
+    { UINT8_C( 33),
+      { -INT32_C(  1168091381), -INT32_C(  1130325252),  INT32_C(   599232440), -INT32_C(  1699302941), -INT32_C(   117675113),  INT32_C(    93639563),  INT32_C(  1477374686), -INT32_C(   126223380) },
+      {  INT32_C(  1320343890),  INT32_C(   738874227), -INT32_C(   984628766),  INT32_C(   174065010), -INT32_C(    66954127),  INT32_C(   218273327),  INT32_C(  1969623176),  INT32_C(  1567481611) },
+      {  INT32_C(   174065010),  INT32_C(           0),  INT32_C(           0),  INT32_C(           0),  INT32_C(           0),  INT32_C(   174065010),  INT32_C(           0),  INT32_C(           0) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256i idx = simde_mm256_loadu_epi32(test_vec[i].idx);
+    simde__m256i a = simde_mm256_loadu_epi32(test_vec[i].a);
+    simde__m256i r = simde_mm256_maskz_permutexvar_epi32(test_vec[i].k, idx, a);
+    simde_test_x86_assert_equal_i32x8(r, simde_mm256_loadu_epi32(test_vec[i].r));
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m256i idx = simde_test_x86_random_i32x8();
+    simde__m256i a = simde_test_x86_random_i32x8();
+    simde__m256i r = simde_mm256_maskz_permutexvar_epi32(k, idx, a);
+
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_i32x8(2, idx, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x8(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x8(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_permutexvar_epi64(SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  const struct {
+    const int64_t idx[4];
+    const int64_t a[4];
+    const int64_t r[4];
+  } test_vec[8] = {
+    { {  INT64_C( 3465447535646586345),  INT64_C( 3112574604386585021), -INT64_C( 3298717360923514682),  INT64_C( 5323359623116614530) },
+      {  INT64_C( 5940711443930208020), -INT64_C( 6109672874813763858),  INT64_C( 1105777252857738108),  INT64_C( 5770626510813846893) },
+      { -INT64_C( 6109672874813763858), -INT64_C( 6109672874813763858),  INT64_C( 1105777252857738108),  INT64_C( 1105777252857738108) } },
+    { {  INT64_C( 3900401264022889273), -INT64_C( 7755349089616591920), -INT64_C( 7492176496441054870),  INT64_C( 2727909151360780622) },
+      {  INT64_C( 4511785965612985374), -INT64_C( 4628483991183106535), -INT64_C( 7007675447010468101), -INT64_C( 4803647970284657595) },
+      { -INT64_C( 4628483991183106535),  INT64_C( 4511785965612985374), -INT64_C( 7007675447010468101), -INT64_C( 7007675447010468101) } },
+    { {  INT64_C( 8654722626887043695),  INT64_C( 6607463866478169758),  INT64_C( 7654221770983106635), -INT64_C( 3115662575998901914) },
+      {  INT64_C( 4977548128634988091),  INT64_C( 8473499790535605467), -INT64_C( 4403595353433040557), -INT64_C( 6060566984611365205) },
+      { -INT64_C( 6060566984611365205), -INT64_C( 4403595353433040557), -INT64_C( 6060566984611365205), -INT64_C( 4403595353433040557) } },
+    { {  INT64_C( 4565342033187083888), -INT64_C( 3263400542231358442), -INT64_C( 4951375666792905173),  INT64_C(  777064012164305068) },
+      {  INT64_C( 9217034901363166790), -INT64_C( 6745700139769306096), -INT64_C( 8716872267551101636), -INT64_C( 4096186034266254718) },
+      {  INT64_C( 9217034901363166790), -INT64_C( 8716872267551101636), -INT64_C( 4096186034266254718),  INT64_C( 9217034901363166790) } },
+    { { -INT64_C( 3070791090430719878), -INT64_C( 3181573684470668865), -INT64_C(  732355612710600332),  INT64_C( 7007947256713345784) },
+      { -INT64_C( 3666591945649245566), -INT64_C( 4813825418525965625),  INT64_C( 7945724640348623068),  INT64_C( 1415301886787475293) },
+      {  INT64_C( 7945724640348623068),  INT64_C( 1415301886787475293), -INT64_C( 3666591945649245566), -INT64_C( 3666591945649245566) } },
+    { {  INT64_C( 6248314088218945755),  INT64_C( 8070704056713394682),  INT64_C( 5411923700867861558),  INT64_C(  648293139388236634) },
+      { -INT64_C( 3746810366719337956), -INT64_C( 3358542259622529696), -INT64_C( 9127219581637745893),  INT64_C( 3734164790968116381) },
+      {  INT64_C( 3734164790968116381), -INT64_C( 9127219581637745893), -INT64_C( 9127219581637745893), -INT64_C( 9127219581637745893) } },
+    { { -INT64_C( 3862999505957895227), -INT64_C( 7205721465562434925), -INT64_C( 5265557781999092155), -INT64_C( 8490883141550974497) },
+      {  INT64_C( 8811721370948929557),  INT64_C( 7932431214771177463), -INT64_C( 7640982706706597081), -INT64_C( 2563191643271564001) },
+      {  INT64_C( 7932431214771177463), -INT64_C( 2563191643271564001),  INT64_C( 7932431214771177463), -INT64_C( 2563191643271564001) } },
+    { {  INT64_C(  801258192282292158), -INT64_C( 7619357814459938901),  INT64_C(  117599237026749525), -INT64_C( 6780922528876188351) },
+      { -INT64_C( 8070339593422618399),  INT64_C( 8372656936451409195),  INT64_C( 1487915019302602691), -INT64_C( 4696126461883675825) },
+      {  INT64_C( 1487915019302602691), -INT64_C( 4696126461883675825),  INT64_C( 8372656936451409195),  INT64_C( 8372656936451409195) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256i idx = simde_mm256_loadu_epi64(test_vec[i].idx);
+    simde__m256i a = simde_mm256_loadu_epi64(test_vec[i].a);
+    simde__m256i r = simde_mm256_permutexvar_epi64(idx, a);
+    simde_test_x86_assert_equal_i64x4(r, simde_mm256_loadu_epi64(test_vec[i].r));
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__m256i idx = simde_test_x86_random_i64x4();
+    simde__m256i a = simde_test_x86_random_i64x4();
+    simde__m256i r = simde_mm256_permutexvar_epi64(idx, a);
+
+    simde_test_x86_write_i64x4(2, idx, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_i64x4(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i64x4(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_mask_permutexvar_epi64(SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  const struct {
+    const int64_t src[4];
+    const simde__mmask8 k;
+    const int64_t idx[4];
+    const int64_t a[4];
+    const int64_t r[4];
+  } test_vec[8] = {
+    { { -INT64_C( 6145245807815484862), -INT64_C( 8661416298178864072), -INT64_C( 4727139763093681026), -INT64_C( 4181093611599723938) },
+      UINT8_C(224),
+      { -INT64_C( 4568891220371182420),  INT64_C(  595615055643734095),  INT64_C( 9037376429611259449),  INT64_C( 5533734961594607142) },
+      { -INT64_C( 9000649239165130061), -INT64_C( 2163542389232657355), -INT64_C( 3775044921414815709),  INT64_C( 1723614651087298047) },
+      { -INT64_C( 6145245807815484862), -INT64_C( 8661416298178864072), -INT64_C( 4727139763093681026), -INT64_C( 4181093611599723938) } },
+    { {  INT64_C( 1325331378370156717),  INT64_C( 6821541915016801569), -INT64_C( 1162463134921942931), -INT64_C( 4309247653774977609) },
+      UINT8_C( 18),
+      { -INT64_C( 5312276096657414752),  INT64_C( 6011548742202757124), -INT64_C(  892782143459852084), -INT64_C( 8552951516681816127) },
+      {  INT64_C( 4698651055233121396),  INT64_C( 4617508433955005702),  INT64_C( 5512619848525830191), -INT64_C( 3535935548222305414) },
+      {  INT64_C( 1325331378370156717),  INT64_C( 4698651055233121396), -INT64_C( 1162463134921942931), -INT64_C( 4309247653774977609) } },
+    { { -INT64_C( 7453033442925831150), -INT64_C( 5594756606993968218), -INT64_C( 4711116760529534522),  INT64_C(  969134818784781899) },
+      UINT8_C(170),
+      { -INT64_C( 4474372485495890496), -INT64_C( 2349483318866410961),  INT64_C( 8737231027810055477),  INT64_C( 1782442867293545731) },
+      { -INT64_C(  248188577289471777), -INT64_C(  251639970792811965), -INT64_C( 8538770441765804877),  INT64_C( 6307104878424159510) },
+      { -INT64_C( 7453033442925831150),  INT64_C( 6307104878424159510), -INT64_C( 4711116760529534522),  INT64_C( 6307104878424159510) } },
+    { {  INT64_C( 7285050831330992463),  INT64_C( 7226457372175610757), -INT64_C( 8990332279521068244),  INT64_C( 8913038368937531105) },
+      UINT8_C( 90),
+      {  INT64_C( 7210230780587186390), -INT64_C( 2261517686396330775),  INT64_C( 7039918466464043237), -INT64_C( 7812045795274912574) },
+      { -INT64_C( 2470739017216552287),  INT64_C( 3030337906147249031), -INT64_C( 1429421007458051524),  INT64_C( 7064387224332711865) },
+      {  INT64_C( 7285050831330992463),  INT64_C( 3030337906147249031), -INT64_C( 8990332279521068244), -INT64_C( 1429421007458051524) } },
+    { { -INT64_C( 2764529222298622256),  INT64_C( 1847905064078209334),  INT64_C(  541849563344969838),  INT64_C( 4315441763754880448) },
+      UINT8_C(173),
+      { -INT64_C( 7765937887782174569), -INT64_C(  405453318237604642),  INT64_C( 3041144148134000746),  INT64_C( 3459838291440154062) },
+      { -INT64_C( 5185776384920649007),  INT64_C( 7886938757980059936), -INT64_C( 2618818936096834303), -INT64_C( 2408243768127898165) },
+      { -INT64_C( 2408243768127898165),  INT64_C( 1847905064078209334), -INT64_C( 2618818936096834303), -INT64_C( 2618818936096834303) } },
+    { {  INT64_C( 5964835402527458869),  INT64_C( 8882295261415371219),  INT64_C(  569038202891478525),  INT64_C( 9208453081059759838) },
+      UINT8_C(197),
+      { -INT64_C( 4086373076156576228), -INT64_C( 8479226529983684331),  INT64_C( 6427988257266884277),  INT64_C(  503315643414814520) },
+      {  INT64_C( 6038701740289553584),  INT64_C( 9212390983602867944), -INT64_C( 6631821568448815526),  INT64_C( 7861269252833712681) },
+      {  INT64_C( 6038701740289553584),  INT64_C( 8882295261415371219),  INT64_C( 9212390983602867944),  INT64_C( 9208453081059759838) } },
+    { {  INT64_C( 4997660079327253962),  INT64_C( 6600424377078187087), -INT64_C( 6838733108989563127), -INT64_C( 7875444692090556021) },
+      UINT8_C( 98),
+      { -INT64_C(  452606310463071704), -INT64_C( 2662941931776388457), -INT64_C( 8662122382630879411), -INT64_C( 1308328928534916951) },
+      {  INT64_C( 3632450635218458235),  INT64_C(  299560531238675169),  INT64_C( 1863939872889404352), -INT64_C( 8516757631211197156) },
+      {  INT64_C( 4997660079327253962), -INT64_C( 8516757631211197156), -INT64_C( 6838733108989563127), -INT64_C( 7875444692090556021) } },
+    { {  INT64_C( 1426060201470534909),  INT64_C(   36178607548202948), -INT64_C( 1545239560821751292), -INT64_C( 9153397452835185311) },
+      UINT8_C(189),
+      { -INT64_C( 2154968146796144399), -INT64_C( 2958827486221003933),  INT64_C( 1085243208166040697),  INT64_C( 7543269306760658521) },
+      {  INT64_C(  428357227795750444), -INT64_C( 5813618019834719129), -INT64_C( 2573969351176751803),  INT64_C( 1930493853078313706) },
+      { -INT64_C( 5813618019834719129),  INT64_C(   36178607548202948), -INT64_C( 5813618019834719129), -INT64_C( 5813618019834719129) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256i src = simde_mm256_loadu_epi64(test_vec[i].src);
+    simde__m256i idx = simde_mm256_loadu_epi64(test_vec[i].idx);
+    simde__m256i a = simde_mm256_loadu_epi64(test_vec[i].a);
+    simde__m256i r = simde_mm256_mask_permutexvar_epi64(src, test_vec[i].k, idx, a);
+    simde_test_x86_assert_equal_i64x4(r, simde_mm256_loadu_epi64(test_vec[i].r));
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__m256i src = simde_test_x86_random_i64x4();
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m256i idx = simde_test_x86_random_i64x4();
+    simde__m256i a = simde_test_x86_random_i64x4();
+    simde__m256i r = simde_mm256_mask_permutexvar_epi64(src, k, idx, a);
+
+    simde_test_x86_write_i64x4(2, src, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i64x4(2, idx, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i64x4(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i64x4(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_maskz_permutexvar_epi64(SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  const struct {
+    const simde__mmask8 k;
+    const int64_t idx[4];
+    const int64_t a[4];
+    const int64_t r[4];
+  } test_vec[8] = {
+    { UINT8_C( 27),
+      {  INT64_C( 3369187414697126278), -INT64_C( 9018154180520100685),  INT64_C( 3731480067352891761),  INT64_C( 8739300992515910063) },
+      {  INT64_C( 8839886327673718116), -INT64_C( 7430403753900109103),  INT64_C( 8684416486551775225),  INT64_C( 5176022328699823975) },
+      {  INT64_C( 8684416486551775225),  INT64_C( 5176022328699823975),  INT64_C(                   0),  INT64_C( 5176022328699823975) } },
+    { UINT8_C(241),
+      { -INT64_C( 8787030352415111512),  INT64_C( 3900474958566747456), -INT64_C( 6962152737219906629),  INT64_C( 4105534155763399707) },
+      {  INT64_C( 2632500097026732431),  INT64_C( 3924444501427107313),  INT64_C(  466283003580020192),  INT64_C( 5914923698406488653) },
+      {  INT64_C( 2632500097026732431),  INT64_C(                   0),  INT64_C(                   0),  INT64_C(                   0) } },
+    { UINT8_C(184),
+      {  INT64_C( 1369588916891178379),  INT64_C( 3268422251213373709), -INT64_C( 6353981294143589132),  INT64_C( 5903301870556524589) },
+      {  INT64_C( 6269963180229888274),  INT64_C( 5370593499786940835), -INT64_C( 1317405420199894686), -INT64_C(  979236192142679470) },
+      {  INT64_C(                   0),  INT64_C(                   0),  INT64_C(                   0),  INT64_C( 5370593499786940835) } },
+    { UINT8_C(150),
+      {  INT64_C( 8561405448582914762),  INT64_C( 6168547978405161738), -INT64_C( 8946116566893352219),  INT64_C( 2722238345616027939) },
+      { -INT64_C( 1544134480098121929),  INT64_C( 6365483424972692813), -INT64_C( 8048574177363399832),  INT64_C( 4334863096951648425) },
+      {  INT64_C(                   0), -INT64_C( 8048574177363399832),  INT64_C( 6365483424972692813),  INT64_C(                   0) } },
+    { UINT8_C( 47),
+      {  INT64_C( 5181665057797199994), -INT64_C( 6178918623323952869),  INT64_C(  527668101296622321), -INT64_C(  567936792988461464) },
+      {  INT64_C( 4670650789240516000), -INT64_C( 8047833996201456538),  INT64_C( 8629332360195303267), -INT64_C( 5379121953059189278) },
+      {  INT64_C( 8629332360195303267), -INT64_C( 5379121953059189278), -INT64_C( 8047833996201456538),  INT64_C( 4670650789240516000) } },
+    { UINT8_C(178),
+      { -INT64_C( 7075410026506534931),  INT64_C( 3237749231414113585),  INT64_C( 3995733465180645381),  INT64_C( 1823960239742767897) },
+      {  INT64_C( 8138094958596007746), -INT64_C(  235900256028775481), -INT64_C( 4597330073135221615), -INT64_C( 4316226894482734893) },
+      {  INT64_C(                   0), -INT64_C(  235900256028775481),  INT64_C(                   0),  INT64_C(                   0) } },
+    { UINT8_C(213),
+      {  INT64_C( 3726312010818066332), -INT64_C( 1082228419914480768), -INT64_C( 6231197197802146125),  INT64_C( 4339764287597479605) },
+      {  INT64_C( 6071664643769323016),  INT64_C( 4976962000991906853), -INT64_C( 5295530570217379409), -INT64_C( 6421479277348671995) },
+      {  INT64_C( 6071664643769323016),  INT64_C(                   0), -INT64_C( 6421479277348671995),  INT64_C(                   0) } },
+    { UINT8_C(160),
+      {  INT64_C( 7283667468859782669), -INT64_C( 1086144558918060667), -INT64_C(  740096361840458443),  INT64_C( 5742998000986513344) },
+      {  INT64_C( 8380728246458525680), -INT64_C( 5134209665999944312),  INT64_C( 1630908168763388005),  INT64_C( 6996021448102459014) },
+      {  INT64_C(                   0),  INT64_C(                   0),  INT64_C(                   0),  INT64_C(                   0) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256i idx = simde_mm256_loadu_epi64(test_vec[i].idx);
+    simde__m256i a = simde_mm256_loadu_epi64(test_vec[i].a);
+    simde__m256i r = simde_mm256_maskz_permutexvar_epi64(test_vec[i].k, idx, a);
+    simde_test_x86_assert_equal_i64x4(r, simde_mm256_loadu_epi64(test_vec[i].r));
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m256i idx = simde_test_x86_random_i64x4();
+    simde__m256i a = simde_test_x86_random_i64x4();
+    simde__m256i r = simde_mm256_maskz_permutexvar_epi64(k, idx, a);
+
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_i64x4(2, idx, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i64x4(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i64x4(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_permutexvar_epi8 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const int8_t idx[32];
+    const int8_t a[32];
+    const int8_t r[32];
+  } test_vec[] = {
+    { {  INT8_C(  68), -INT8_C(  19),  INT8_C( 106),  INT8_C(  42),  INT8_C(  79),  INT8_C(  38),  INT8_C(  16), -INT8_C( 110),
+         INT8_C(  30), -INT8_C( 123), -INT8_C(  25), -INT8_C(  91), -INT8_C( 106),  INT8_C(  84), -INT8_C(  99),  INT8_C(  86),
+         INT8_C( 104), -INT8_C(   2),  INT8_C(  83),  INT8_C(  91),  INT8_C( 103),  INT8_C(   0),  INT8_C(  29), -INT8_C(  11),
+        -INT8_C(  51), -INT8_C(  11),  INT8_C(  85),  INT8_C(  85),  INT8_C( 102), -INT8_C(  55), -INT8_C(  18), -INT8_C(  86) },
+      { -INT8_C(  74),  INT8_C(  88), -INT8_C(  44),  INT8_C(   5),  INT8_C( 126), -INT8_C(  27), -INT8_C( 105), -INT8_C( 100),
+         INT8_C( 106),      INT8_MAX,  INT8_C(  65),  INT8_C(   0), -INT8_C(  45), -INT8_C(  33),  INT8_C(  87),  INT8_C(  59),
+        -INT8_C(  35), -INT8_C(  86), -INT8_C( 106),  INT8_C(  68), -INT8_C(  86), -INT8_C(  77),  INT8_C(  57),  INT8_C( 120),
+        -INT8_C(  88), -INT8_C( 113), -INT8_C(  51),  INT8_C(  14),  INT8_C(  88), -INT8_C(  69), -INT8_C(  71),  INT8_C(  14) },
+      {  INT8_C( 126), -INT8_C(  33),  INT8_C(  65),  INT8_C(  65),  INT8_C(  59), -INT8_C( 105), -INT8_C(  35), -INT8_C( 106),
+        -INT8_C(  71), -INT8_C(  27), -INT8_C( 100), -INT8_C(  27),  INT8_C(  57), -INT8_C(  86), -INT8_C(  69),  INT8_C(  57),
+         INT8_C( 106), -INT8_C(  71),  INT8_C(  68),  INT8_C(  14), -INT8_C( 100), -INT8_C(  74), -INT8_C(  69), -INT8_C(  77),
+        -INT8_C(  33), -INT8_C(  77), -INT8_C(  77), -INT8_C(  77), -INT8_C( 105),      INT8_MAX,  INT8_C(  87),  INT8_C(  65) } },
+    { {  INT8_C(  19), -INT8_C( 115),  INT8_C(  19), -INT8_C( 111),  INT8_C( 114), -INT8_C(  86),  INT8_C(  45), -INT8_C(  36),
+         INT8_C(  41),  INT8_C( 110), -INT8_C(  35), -INT8_C(   4),  INT8_C(  77),  INT8_C(  52),  INT8_C(  55),  INT8_C(  42),
+        -INT8_C(  34), -INT8_C(  51),  INT8_C( 111), -INT8_C( 120),      INT8_MIN, -INT8_C(  88),  INT8_C(   0),  INT8_C(  40),
+         INT8_C(  55), -INT8_C(  51),  INT8_C(  55), -INT8_C( 113), -INT8_C( 120), -INT8_C(  16), -INT8_C(  99), -INT8_C( 101) },
+      {  INT8_C( 125), -INT8_C(  80),  INT8_C(  44), -INT8_C(  16),  INT8_C(  91),  INT8_C(  89), -INT8_C(  52), -INT8_C( 124),
+        -INT8_C(  56), -INT8_C(  87), -INT8_C( 127),  INT8_C(  21), -INT8_C(  35), -INT8_C(  72),  INT8_C(  64), -INT8_C(  69),
+        -INT8_C( 122), -INT8_C(  81),  INT8_C(  68),  INT8_C(   6),  INT8_C(  87),  INT8_C(  68),  INT8_C(  47), -INT8_C( 113),
+         INT8_C(  18),  INT8_C( 102),  INT8_C(  30), -INT8_C( 102),  INT8_C(  86), -INT8_C(  68),  INT8_C(  54), -INT8_C(  45) },
+      {  INT8_C(   6), -INT8_C(  72),  INT8_C(   6), -INT8_C(  81),  INT8_C(  68), -INT8_C( 127), -INT8_C(  72),  INT8_C(  86),
+        -INT8_C(  87),  INT8_C(  64), -INT8_C(  68),  INT8_C(  86), -INT8_C(  72),  INT8_C(  87), -INT8_C( 113), -INT8_C( 127),
+         INT8_C(  54), -INT8_C(  72), -INT8_C(  69), -INT8_C(  56),  INT8_C( 125), -INT8_C(  56),  INT8_C( 125), -INT8_C(  56),
+        -INT8_C( 113), -INT8_C(  72), -INT8_C( 113), -INT8_C(  69), -INT8_C(  56), -INT8_C( 122), -INT8_C(  68), -INT8_C( 102) } },
+    { {  INT8_C( 108),  INT8_C(  98), -INT8_C(  61), -INT8_C(  57), -INT8_C(  68), -INT8_C( 112),  INT8_C(  76), -INT8_C( 124),
+         INT8_C(  57), -INT8_C(  51), -INT8_C( 103),  INT8_C(  23), -INT8_C( 123), -INT8_C(  39), -INT8_C(  46),  INT8_C(  11),
+        -INT8_C( 120),  INT8_C(  22),  INT8_C(  18), -INT8_C(  32),  INT8_C(  91),  INT8_C(  65),  INT8_C( 111),  INT8_C( 109),
+        -INT8_C(  89), -INT8_C( 115),  INT8_C(   7), -INT8_C(   3),  INT8_C(  73),  INT8_C(  61), -INT8_C(  48), -INT8_C(  74) },
+      { -INT8_C(  96), -INT8_C( 108),  INT8_C( 125),  INT8_C(  92),  INT8_C(  36), -INT8_C(  55), -INT8_C(  32),  INT8_C(  93),
+        -INT8_C( 106),  INT8_C( 121),  INT8_C( 116),  INT8_C(  28),  INT8_C(  83),  INT8_C(  71),  INT8_C(  39), -INT8_C(  37),
+         INT8_C(  93),  INT8_C(  57), -INT8_C(  69), -INT8_C(  72),  INT8_C( 122),  INT8_C(  42),  INT8_C(  37),  INT8_C(  33),
+        -INT8_C(  72),  INT8_C(  45),  INT8_C(  30),  INT8_C(   1),  INT8_C( 106), -INT8_C(  17), -INT8_C(  73),  INT8_C(  10) },
+      {  INT8_C(  83),  INT8_C( 125),  INT8_C(  92),  INT8_C(  93),  INT8_C( 106),  INT8_C(  93),  INT8_C(  83),  INT8_C(  36),
+         INT8_C(  45),  INT8_C(  71),  INT8_C(  45),  INT8_C(  33), -INT8_C(  55),  INT8_C(  45), -INT8_C(  69),  INT8_C(  28),
+        -INT8_C( 106),  INT8_C(  37), -INT8_C(  69), -INT8_C(  96),  INT8_C(   1), -INT8_C( 108), -INT8_C(  37),  INT8_C(  71),
+         INT8_C(  93),  INT8_C(  71),  INT8_C(  93), -INT8_C(  17),  INT8_C( 121), -INT8_C(  17),  INT8_C(  93),  INT8_C(  37) } },
+    { { -INT8_C( 125),  INT8_C(  53),  INT8_C( 102), -INT8_C(  89), -INT8_C(   2),  INT8_C(  70),  INT8_C(   4), -INT8_C( 107),
+        -INT8_C(  64),  INT8_C( 121), -INT8_C(  79),  INT8_C(  19), -INT8_C(  64), -INT8_C(  40), -INT8_C(  18),  INT8_C(  29),
+         INT8_C(  18), -INT8_C(  86), -INT8_C(  42), -INT8_C( 116), -INT8_C(  44), -INT8_C(   5), -INT8_C(  82), -INT8_C( 116),
+         INT8_C(  40), -INT8_C(  52), -INT8_C( 114), -INT8_C( 109), -INT8_C(  69),  INT8_C(  69), -INT8_C(  99),  INT8_C(  62) },
+      {  INT8_C( 122),  INT8_C(   4), -INT8_C(  27),  INT8_C( 121),  INT8_C(  74), -INT8_C(  22),  INT8_C(  14),  INT8_C(  10),
+         INT8_C(  99), -INT8_C(  65),  INT8_C(  29),  INT8_C(  35), -INT8_C( 105),  INT8_C(  12),  INT8_C(  64), -INT8_C(  87),
+        -INT8_C(  74),  INT8_C(  22),  INT8_C(  54), -INT8_C( 118),  INT8_C(  18), -INT8_C(  28),  INT8_C(  23),  INT8_C(  58),
+        -INT8_C(  80), -INT8_C(  91), -INT8_C(  51),  INT8_C( 108), -INT8_C(  22),  INT8_C( 107), -INT8_C(  86),  INT8_C( 101) },
+      {  INT8_C( 121), -INT8_C(  28),  INT8_C(  14),  INT8_C(  10), -INT8_C(  86),  INT8_C(  14),  INT8_C(  74), -INT8_C(  28),
+         INT8_C( 122), -INT8_C(  91),  INT8_C(  22), -INT8_C( 118),  INT8_C( 122), -INT8_C(  80),  INT8_C(  64),  INT8_C( 107),
+         INT8_C(  54),  INT8_C(  29),  INT8_C(  23), -INT8_C( 105),  INT8_C(  18),  INT8_C( 108),  INT8_C(  64), -INT8_C( 105),
+         INT8_C(  99), -INT8_C( 105),  INT8_C(  64), -INT8_C( 118),  INT8_C( 108), -INT8_C(  22),  INT8_C( 107), -INT8_C(  86) } },
+    { {  INT8_C( 111), -INT8_C( 112), -INT8_C(  34), -INT8_C(  71),  INT8_C( 122), -INT8_C(  20), -INT8_C(  60), -INT8_C(  35),
+        -INT8_C(  85), -INT8_C(  31),  INT8_C(   0),  INT8_C(  66), -INT8_C(  19),  INT8_C(  64), -INT8_C(  20), -INT8_C(  93),
+         INT8_C(  87),  INT8_C(  34),  INT8_C(  46),  INT8_C( 105),  INT8_C(   6),  INT8_C(  69), -INT8_C(  93), -INT8_C(  74),
+        -INT8_C(  22),  INT8_C( 113),  INT8_C(  34), -INT8_C(  44), -INT8_C(  36), -INT8_C(  51),  INT8_C(  57),  INT8_C(  75) },
+      {  INT8_C(  93),  INT8_C(  23),  INT8_C(   4), -INT8_C(  41),  INT8_C(   3), -INT8_C(  56), -INT8_C(  76), -INT8_C(  82),
+        -INT8_C(  86), -INT8_C(  76), -INT8_C(  15), -INT8_C( 105), -INT8_C(  12), -INT8_C(  35),  INT8_C(  59),  INT8_C(  75),
+        -INT8_C(   1),  INT8_C( 105), -INT8_C(  76),  INT8_C(   5), -INT8_C(  82),  INT8_C(  88), -INT8_C(  69), -INT8_C( 104),
+        -INT8_C(  55), -INT8_C(  34),  INT8_C( 108), -INT8_C(  91), -INT8_C(  85), -INT8_C(  90), -INT8_C(  16),  INT8_C(   8) },
+      {  INT8_C(  75), -INT8_C(   1), -INT8_C(  16), -INT8_C(  34),  INT8_C( 108), -INT8_C(  12),  INT8_C(   3), -INT8_C(  90),
+        -INT8_C( 105),  INT8_C(  23),  INT8_C(  93),  INT8_C(   4), -INT8_C(  35),  INT8_C(  93), -INT8_C(  12), -INT8_C(  41),
+        -INT8_C( 104),  INT8_C(   4),  INT8_C(  59), -INT8_C(  76), -INT8_C(  76), -INT8_C(  56), -INT8_C(  41), -INT8_C(  69),
+        -INT8_C(  15),  INT8_C( 105),  INT8_C(   4), -INT8_C(  82), -INT8_C(  85), -INT8_C(  35), -INT8_C(  34), -INT8_C( 105) } },
+    { { -INT8_C(  67), -INT8_C(  12), -INT8_C(  33), -INT8_C(  63), -INT8_C(  67), -INT8_C( 109),  INT8_C( 111),  INT8_C( 103),
+         INT8_C(  71),  INT8_C(  96), -INT8_C(   2),  INT8_C(  59),  INT8_C(  61),  INT8_C(  57), -INT8_C( 121),  INT8_C(  60),
+        -INT8_C(  94),  INT8_C(  59),  INT8_C(  65),  INT8_C(  80), -INT8_C( 109), -INT8_C(   3), -INT8_C(  24),  INT8_C(  92),
+        -INT8_C(  37),  INT8_C(  85),  INT8_C(   1), -INT8_C( 122), -INT8_C(   5), -INT8_C(  15), -INT8_C( 114), -INT8_C(  72) },
+      { -INT8_C(  26),  INT8_C( 109),  INT8_C( 121), -INT8_C(  93),  INT8_C(   0), -INT8_C(  23),  INT8_C(  10),  INT8_C(  71),
+         INT8_C(  73),  INT8_C(   8), -INT8_C( 126), -INT8_C( 121),  INT8_C(  66),  INT8_C(   9), -INT8_C(  61), -INT8_C(  28),
+         INT8_C(  69),  INT8_C(   5),  INT8_C(  53), -INT8_C(  40),  INT8_C(   2),  INT8_C(  29),  INT8_C(  53), -INT8_C(  35),
+         INT8_C( 114),  INT8_C(  54),  INT8_C(  99),  INT8_C( 109),  INT8_C(  40), -INT8_C(  15),  INT8_C(  38),  INT8_C(  14) },
+      { -INT8_C(  15),  INT8_C(   2),  INT8_C(  14),  INT8_C( 109), -INT8_C(  15), -INT8_C(  40), -INT8_C(  28),  INT8_C(  71),
+         INT8_C(  71), -INT8_C(  26),  INT8_C(  38),  INT8_C( 109), -INT8_C(  15),  INT8_C(  54),  INT8_C(  71),  INT8_C(  40),
+         INT8_C( 121),  INT8_C( 109),  INT8_C( 109),  INT8_C(  69), -INT8_C(  40), -INT8_C(  15),  INT8_C(  73),  INT8_C(  40),
+         INT8_C( 109),  INT8_C(  29),  INT8_C( 109),  INT8_C(  10),  INT8_C( 109),  INT8_C(   5), -INT8_C(  61),  INT8_C( 114) } },
+    { {  INT8_C(  94), -INT8_C(  97), -INT8_C(  79),  INT8_C(  94), -INT8_C( 120), -INT8_C(  69), -INT8_C(  91), -INT8_C(  46),
+        -INT8_C(  61),  INT8_C(  39),  INT8_C(  89),  INT8_C(   5),  INT8_C(  49),  INT8_C(  28), -INT8_C(  22),  INT8_C( 118),
+         INT8_C(  33),  INT8_C(  31),  INT8_C(  78),  INT8_C(  35),  INT8_C(  60), -INT8_C( 125),  INT8_C(   0), -INT8_C(  81),
+        -INT8_C(  70),  INT8_C(  99),  INT8_C(  28), -INT8_C(  30),  INT8_C(  84),  INT8_C(  66), -INT8_C(  16), -INT8_C(  78) },
+      { -INT8_C(  30), -INT8_C(  95),  INT8_C(  16),  INT8_C( 106),  INT8_C(  92), -INT8_C(  75),  INT8_C(  60),  INT8_C(  31),
+        -INT8_C(  35), -INT8_C( 107),  INT8_C(  37),  INT8_C(  14), -INT8_C(  78),  INT8_C(  15), -INT8_C( 124), -INT8_C(  45),
+         INT8_C(  46), -INT8_C(  46), -INT8_C(   9),  INT8_C( 106),  INT8_C(  86), -INT8_C(   9),  INT8_C(  25),  INT8_C(  16),
+         INT8_C(  91),  INT8_C(  54), -INT8_C(  14), -INT8_C(  81),  INT8_C( 120), -INT8_C(  30),  INT8_C(  98),  INT8_C(  90) },
+      {  INT8_C(  98),  INT8_C(  90), -INT8_C(  46),  INT8_C(  98), -INT8_C(  35), -INT8_C(  81), -INT8_C(  75), -INT8_C(   9),
+         INT8_C( 106),  INT8_C(  31),  INT8_C(  54), -INT8_C(  75), -INT8_C(  46),  INT8_C( 120),  INT8_C(  37),  INT8_C(  25),
+        -INT8_C(  95),  INT8_C(  90), -INT8_C( 124),  INT8_C( 106),  INT8_C( 120),  INT8_C( 106), -INT8_C(  30), -INT8_C(  45),
+        -INT8_C(  14),  INT8_C( 106),  INT8_C( 120),  INT8_C(  16),  INT8_C(  86),  INT8_C(  16),  INT8_C(  46), -INT8_C(   9) } },
+    { { -INT8_C( 125),  INT8_C( 114), -INT8_C(  59), -INT8_C(  33),  INT8_C(  40),  INT8_C(   1), -INT8_C(   2),  INT8_C(   5),
+        -INT8_C( 105),  INT8_C(  35),  INT8_C(  19),  INT8_C(  73),  INT8_C(  50), -INT8_C( 105),  INT8_C(  28),  INT8_C(  96),
+         INT8_C( 105),  INT8_C(  19), -INT8_C(  53), -INT8_C(  65),  INT8_C(  11), -INT8_C(  28), -INT8_C(  49),  INT8_C( 102),
+         INT8_C(  26), -INT8_C(  63),  INT8_C(  21), -INT8_C( 109), -INT8_C(  93),  INT8_C( 119), -INT8_C(  19),  INT8_C(  38) },
+      { -INT8_C(  22), -INT8_C(  78),  INT8_C(   5),  INT8_C(  18), -INT8_C(  76),  INT8_C(   4),  INT8_C(  23),  INT8_C(  75),
+         INT8_C(  39),  INT8_C(  42), -INT8_C( 108),  INT8_C(  90), -INT8_C(  63), -INT8_C(  80), -INT8_C(  70),  INT8_C(  42),
+        -INT8_C(  60), -INT8_C( 123), -INT8_C(  22), -INT8_C(  49),  INT8_C( 106), -INT8_C(  71),  INT8_C(  53), -INT8_C( 124),
+         INT8_C( 123),  INT8_C(  74),  INT8_C(  23),  INT8_C(  30), -INT8_C(  62),  INT8_C(   5),  INT8_C(  69), -INT8_C(  84) },
+      {  INT8_C(  18), -INT8_C(  22),  INT8_C(   4), -INT8_C(  84),  INT8_C(  39), -INT8_C(  78),  INT8_C(  69),  INT8_C(   4),
+        -INT8_C( 124),  INT8_C(  18), -INT8_C(  49),  INT8_C(  42), -INT8_C(  22), -INT8_C( 124), -INT8_C(  62), -INT8_C(  22),
+         INT8_C(  42), -INT8_C(  49),  INT8_C(  90), -INT8_C(  84),  INT8_C(  90), -INT8_C(  76),  INT8_C(  42),  INT8_C(  23),
+         INT8_C(  23), -INT8_C(  78), -INT8_C(  71), -INT8_C(  49),  INT8_C(  18), -INT8_C( 124), -INT8_C(  80),  INT8_C(  23) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256i idx = simde_mm256_loadu_epi8(test_vec[i].idx);
+    simde__m256i a = simde_mm256_loadu_epi8(test_vec[i].a);
+    simde__m256i r = simde_mm256_permutexvar_epi8(idx, a);
+    simde_test_x86_assert_equal_i8x32(r, simde_mm256_loadu_epi8(test_vec[i].r));
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__m256i idx = simde_test_x86_random_i8x32();
+    simde__m256i a = simde_test_x86_random_i8x32();
+    simde__m256i r = simde_mm256_permutexvar_epi8(idx, a);
+
+    simde_test_x86_write_i8x32(2, idx, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_i8x32(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i8x32(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_mask_permutexvar_epi8 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const int8_t src[32];
+    const simde__mmask32 k;
+    const int8_t idx[32];
+    const int8_t a[32];
+    const int8_t r[32];
+  } test_vec[] = {
+    { { -INT8_C(  73),  INT8_C(  74), -INT8_C(  66),  INT8_C( 107),  INT8_C(  78), -INT8_C(  43), -INT8_C(  74),  INT8_C( 118),
+        -INT8_C(   1),  INT8_C(  74), -INT8_C(  48), -INT8_C(  64), -INT8_C(   5), -INT8_C( 118), -INT8_C(  22), -INT8_C(  65),
+         INT8_C(  16), -INT8_C(  44), -INT8_C( 114),  INT8_C( 122), -INT8_C( 114), -INT8_C(  61), -INT8_C(   2),  INT8_C(   9),
+         INT8_C(  13),  INT8_C(  22),  INT8_C(  39), -INT8_C(  49),  INT8_C(  27),  INT8_C( 108),  INT8_C( 123), -INT8_C(  46) },
+      UINT32_C(  87964087),
+      {  INT8_C(  14), -INT8_C(  12),  INT8_C( 123),  INT8_C(  13),  INT8_C(  63),  INT8_C(  75), -INT8_C(  51),  INT8_C(  58),
+        -INT8_C(  42), -INT8_C(  72), -INT8_C(   7), -INT8_C(  26), -INT8_C( 116), -INT8_C( 121),  INT8_C(  96),  INT8_C(  26),
+         INT8_C(  74),  INT8_C(  94),  INT8_C(  35),  INT8_C(  87),  INT8_C( 116),  INT8_C(  75),  INT8_C(  39), -INT8_C( 113),
+        -INT8_C(  73), -INT8_C(  94),  INT8_C(  98),  INT8_C( 110), -INT8_C(  36), -INT8_C(  96),  INT8_C( 116), -INT8_C(  22) },
+      { -INT8_C( 108), -INT8_C(  17), -INT8_C(   8), -INT8_C(  45),  INT8_C(  59), -INT8_C(  59),  INT8_C(  13),  INT8_C(  17),
+         INT8_C( 125),  INT8_C(   6), -INT8_C(   9),  INT8_C(  10), -INT8_C( 115),  INT8_C(  87),  INT8_C(  36), -INT8_C(  41),
+        -INT8_C(  75),  INT8_C(  72),  INT8_C(  47),  INT8_C(  42), -INT8_C( 109),  INT8_C(  86), -INT8_C(  71),  INT8_C(  74),
+        -INT8_C(   8),  INT8_C(  27), -INT8_C(  71), -INT8_C(  44), -INT8_C(  69),  INT8_C(  45), -INT8_C(  65),  INT8_C(  80) },
+      {  INT8_C(  36), -INT8_C( 109), -INT8_C(  44),  INT8_C( 107),  INT8_C(  80),  INT8_C(  10), -INT8_C(  74), -INT8_C(  71),
+        -INT8_C(  71),  INT8_C(  74), -INT8_C(  48),  INT8_C(  13), -INT8_C( 115),  INT8_C(  17), -INT8_C(  22), -INT8_C(  65),
+         INT8_C(  16), -INT8_C(  65), -INT8_C(  45),  INT8_C(  74), -INT8_C( 109),  INT8_C(  10), -INT8_C(   2),  INT8_C(   9),
+         INT8_C(  74),  INT8_C(  22), -INT8_C(   8), -INT8_C(  49),  INT8_C(  27),  INT8_C( 108),  INT8_C( 123), -INT8_C(  46) } },
+    { {  INT8_C(  28), -INT8_C(  73),  INT8_C(  35),  INT8_C(  87),  INT8_C( 124),  INT8_C(  49),  INT8_C( 104), -INT8_C(   6),
+         INT8_C(  55),  INT8_C(  95),  INT8_C(   4), -INT8_C(  59), -INT8_C(  74),  INT8_C(  40), -INT8_C( 100),  INT8_C( 108),
+         INT8_C( 112), -INT8_C(  53), -INT8_C( 106),  INT8_C(   3),  INT8_C(  33),  INT8_C(  79),  INT8_C(  78),  INT8_C(  26),
+         INT8_C( 107),  INT8_C(   7), -INT8_C(  18),  INT8_C(  38),  INT8_C(  52), -INT8_C(  83),  INT8_C( 118),  INT8_C(  80) },
+      UINT32_C(3785923172),
+      { -INT8_C(  53),  INT8_C(  16), -INT8_C(  37),  INT8_C(   2),  INT8_C( 112), -INT8_C(  33), -INT8_C(  57),  INT8_C(  38),
+         INT8_C(   7),  INT8_C( 100), -INT8_C( 110),  INT8_C( 120),  INT8_C(  47),  INT8_C(  40),  INT8_C( 123),  INT8_C(  81),
+         INT8_C( 120), -INT8_C(  55),  INT8_C( 107), -INT8_C(  29), -INT8_C(  48),  INT8_C(  89),  INT8_C(   9),  INT8_C(   4),
+         INT8_C(   7),      INT8_MIN,  INT8_C(  85),  INT8_C( 107),  INT8_C(  26), -INT8_C(   3),  INT8_C(  76), -INT8_C(  27) },
+      {  INT8_C(  13),  INT8_C(  39), -INT8_C(  25),  INT8_C( 125),  INT8_C(   6), -INT8_C(  81), -INT8_C(  92),  INT8_C(  14),
+         INT8_C(  19),  INT8_C(  54), -INT8_C( 122),  INT8_C(  66),  INT8_C(  95),  INT8_C(   1), -INT8_C( 109), -INT8_C(  41),
+        -INT8_C(  53), -INT8_C(   2), -INT8_C(  70), -INT8_C( 101),  INT8_C(  88), -INT8_C(  61), -INT8_C(  96),  INT8_C(  95),
+         INT8_C(  67), -INT8_C(  11), -INT8_C(  54),  INT8_C(  93), -INT8_C(  14),  INT8_C(  23),  INT8_C(  66), -INT8_C(   1) },
+      {  INT8_C(  28), -INT8_C(  73),  INT8_C(  93),  INT8_C(  87),  INT8_C( 124), -INT8_C(   1),  INT8_C(  14), -INT8_C(   6),
+         INT8_C(  55),  INT8_C(   6),  INT8_C(   4),  INT8_C(  67), -INT8_C(  41),  INT8_C(  40), -INT8_C( 100), -INT8_C(   2),
+         INT8_C( 112), -INT8_C(  53), -INT8_C( 106),  INT8_C( 125),  INT8_C(  33), -INT8_C(  11),  INT8_C(  78),  INT8_C(   6),
+         INT8_C(  14),  INT8_C(   7), -INT8_C(  18),  INT8_C(  38),  INT8_C(  52),  INT8_C(  23),  INT8_C(  95), -INT8_C(  81) } },
+    { {  INT8_C(  62),  INT8_C(  42),  INT8_C( 125),  INT8_C(  69), -INT8_C(  39),  INT8_C(  33),  INT8_C(  83), -INT8_C(  20),
+         INT8_C(  87), -INT8_C(  39),  INT8_C(  46), -INT8_C(  74), -INT8_C(  38), -INT8_C(  62), -INT8_C( 115), -INT8_C(  91),
+        -INT8_C(  64),  INT8_C(  71),  INT8_C(  65),  INT8_C(  24),  INT8_C(  11), -INT8_C(  31),  INT8_C( 119),  INT8_C(  78),
+        -INT8_C(  42),  INT8_C(  66), -INT8_C(  84), -INT8_C(  56),  INT8_C(  89), -INT8_C(  18), -INT8_C(  57), -INT8_C( 105) },
+      UINT32_C(4057744408),
+      {  INT8_C( 101),  INT8_C(  47), -INT8_C(  35), -INT8_C(  67),  INT8_C(   8),  INT8_C(  12),  INT8_C( 115), -INT8_C(  29),
+        -INT8_C(  50),  INT8_C(   1), -INT8_C( 120), -INT8_C( 114),  INT8_C(  72), -INT8_C(  55), -INT8_C(  89),  INT8_C(  83),
+        -INT8_C(  86),  INT8_C(  30), -INT8_C(  94),      INT8_MIN,  INT8_C(  96),  INT8_C(  78),  INT8_C(  72), -INT8_C(  71),
+         INT8_C(  60),  INT8_C(  16),  INT8_C(  81),  INT8_C(  85),  INT8_C(  84),  INT8_C(  45),  INT8_C(  70), -INT8_C(  70) },
+      {  INT8_C(  93),  INT8_C(  36),  INT8_C( 119),  INT8_C( 101),  INT8_C(  48), -INT8_C(  22),  INT8_C(  72), -INT8_C(   2),
+        -INT8_C(  21), -INT8_C(  47), -INT8_C( 116),  INT8_C(  52), -INT8_C( 102),  INT8_C(  51), -INT8_C( 121),  INT8_C(  69),
+         INT8_C(  82),  INT8_C(  41), -INT8_C(  59), -INT8_C(  78),  INT8_C( 119),  INT8_C(  14),  INT8_C( 108), -INT8_C(  76),
+         INT8_C(  30), -INT8_C(  67),  INT8_C(   9),  INT8_C( 114), -INT8_C(  22),  INT8_C(  79),  INT8_C(  44),  INT8_C(  71) },
+      {  INT8_C(  62),  INT8_C(  42),  INT8_C( 125),  INT8_C(  79), -INT8_C(  21),  INT8_C(  33),  INT8_C(  83), -INT8_C(  20),
+         INT8_C(  87), -INT8_C(  39), -INT8_C(  21), -INT8_C(  74), -INT8_C(  38), -INT8_C(  62), -INT8_C(   2), -INT8_C(  91),
+        -INT8_C(  64),  INT8_C(  71),  INT8_C( 119),  INT8_C(  93),  INT8_C(  93), -INT8_C(  31), -INT8_C(  21), -INT8_C(  67),
+        -INT8_C(  22),  INT8_C(  66), -INT8_C(  84), -INT8_C(  56),  INT8_C( 119),  INT8_C(  51),  INT8_C(  72),  INT8_C(   9) } },
+    { {  INT8_C( 115), -INT8_C(  93), -INT8_C(  83), -INT8_C(  93), -INT8_C( 114), -INT8_C(  11), -INT8_C(  95),  INT8_C( 121),
+        -INT8_C(  58),  INT8_C(  46), -INT8_C(  83),  INT8_C(  97),  INT8_C(  97),  INT8_C(  53), -INT8_C(  90), -INT8_C(  77),
+         INT8_C(  94),  INT8_C( 107),  INT8_C( 102), -INT8_C(  42),  INT8_C( 121), -INT8_C(  46), -INT8_C( 118), -INT8_C( 105),
+        -INT8_C( 113), -INT8_C( 109),  INT8_C(  10),  INT8_C( 121), -INT8_C(  30),  INT8_C(  54), -INT8_C(  63),  INT8_C(  86) },
+      UINT32_C(1761177306),
+      {  INT8_C(  99), -INT8_C( 101), -INT8_C(  31),  INT8_C(  42), -INT8_C(  55), -INT8_C( 113), -INT8_C( 117),  INT8_C(  42),
+        -INT8_C(  60),  INT8_C(  49), -INT8_C(  34),  INT8_C(  34), -INT8_C( 100),  INT8_C(  68), -INT8_C(   8),  INT8_C(  22),
+         INT8_C(  22), -INT8_C( 126), -INT8_C(  83), -INT8_C(  91),  INT8_C(  21), -INT8_C(  73),  INT8_C(  30), -INT8_C(   8),
+        -INT8_C(  18), -INT8_C(  33),  INT8_C(  78), -INT8_C(  56),  INT8_C(  77),  INT8_C(  71),  INT8_C(  48), -INT8_C(  79) },
+      { -INT8_C(  30),  INT8_C(  17), -INT8_C(  37), -INT8_C(  85), -INT8_C(  96),  INT8_C( 102), -INT8_C(  42),  INT8_C( 100),
+        -INT8_C( 105), -INT8_C(  76), -INT8_C( 121),  INT8_C(  51), -INT8_C(   8),      INT8_MAX,  INT8_C(  73),  INT8_C(  14),
+         INT8_C(   2), -INT8_C(   9), -INT8_C(  77),  INT8_C(  23), -INT8_C(  82), -INT8_C(  47),  INT8_C(  15), -INT8_C( 100),
+        -INT8_C(  79),  INT8_C(  93),  INT8_C( 100), -INT8_C(   2), -INT8_C(  91), -INT8_C( 108), -INT8_C(  81), -INT8_C( 121) },
+      {  INT8_C( 115), -INT8_C(   2), -INT8_C(  83), -INT8_C( 121), -INT8_C(  76), -INT8_C(  11),  INT8_C(  51), -INT8_C( 121),
+        -INT8_C(  58), -INT8_C(   9), -INT8_C(  81), -INT8_C(  37),  INT8_C(  97), -INT8_C(  96), -INT8_C(  79), -INT8_C(  77),
+         INT8_C(  15),  INT8_C( 107),  INT8_C( 102),  INT8_C( 102), -INT8_C(  47), -INT8_C( 100), -INT8_C(  81), -INT8_C(  79),
+        -INT8_C( 113), -INT8_C( 109),  INT8_C(  10), -INT8_C( 105), -INT8_C(  30),  INT8_C( 100),  INT8_C(   2),  INT8_C(  86) } },
+    { { -INT8_C(  90), -INT8_C( 118),  INT8_C(  51),  INT8_C(  70), -INT8_C(  16),  INT8_C(   9), -INT8_C(  85), -INT8_C( 121),
+        -INT8_C(  67),  INT8_C(  50), -INT8_C(  69), -INT8_C(  75), -INT8_C(  79),  INT8_C(   4), -INT8_C(  61), -INT8_C(  77),
+        -INT8_C(   5),  INT8_C( 118), -INT8_C(  53), -INT8_C(  86),  INT8_C(  71), -INT8_C(  38),  INT8_C(  70), -INT8_C(   8),
+         INT8_C(  56), -INT8_C(  85), -INT8_C(   9), -INT8_C(  35),  INT8_C(  63), -INT8_C(  90),  INT8_C( 100), -INT8_C(  27) },
+      UINT32_C( 556570417),
+      { -INT8_C(  96), -INT8_C(  41), -INT8_C(  87),  INT8_C(  93),  INT8_C(   9),  INT8_C( 100),  INT8_C(  18), -INT8_C(  70),
+         INT8_C( 104), -INT8_C(  43),  INT8_C( 110),  INT8_C( 100),  INT8_C(  75),  INT8_C(  57),  INT8_C(  14), -INT8_C( 109),
+         INT8_C(  19),  INT8_C(  84), -INT8_C( 117),  INT8_C(  75), -INT8_C(   1), -INT8_C( 126),  INT8_C(  40),  INT8_C(  63),
+         INT8_C(  41), -INT8_C( 115),  INT8_C(  36),  INT8_C(  90),  INT8_C(  36),  INT8_C(  80),  INT8_C( 123), -INT8_C(  59) },
+      {  INT8_C(  39),  INT8_C(  36),  INT8_C(  34),  INT8_C(  48), -INT8_C( 120),  INT8_C(  53), -INT8_C(  21), -INT8_C(  15),
+         INT8_C(  10),  INT8_C(  89),  INT8_C(  85),  INT8_C(  86), -INT8_C( 110),  INT8_C(  99), -INT8_C(  23), -INT8_C(  91),
+        -INT8_C(  73),  INT8_C( 116), -INT8_C(  15), -INT8_C(  73), -INT8_C(   9),  INT8_C(  25), -INT8_C(  10),  INT8_C(  32),
+        -INT8_C(  90),  INT8_C(  26),  INT8_C( 122), -INT8_C(  53),  INT8_C( 107), -INT8_C(  11), -INT8_C( 112), -INT8_C( 110) },
+      {  INT8_C(  39), -INT8_C( 118),  INT8_C(  51),  INT8_C(  70),  INT8_C(  89), -INT8_C( 120), -INT8_C(  85), -INT8_C( 121),
+         INT8_C(  10),  INT8_C(  25), -INT8_C(  23), -INT8_C(  75),  INT8_C(  86),  INT8_C(   4), -INT8_C(  61), -INT8_C(  73),
+        -INT8_C(   5),  INT8_C( 118),  INT8_C(  86),  INT8_C(  86),  INT8_C(  71),  INT8_C(  34),  INT8_C(  70), -INT8_C(   8),
+         INT8_C(  89), -INT8_C(  85), -INT8_C(   9), -INT8_C(  35),  INT8_C(  63), -INT8_C(  73),  INT8_C( 100), -INT8_C(  27) } },
+    { {  INT8_C(  26), -INT8_C(  78), -INT8_C(  61), -INT8_C(  94), -INT8_C(  25), -INT8_C(  82), -INT8_C( 109), -INT8_C(  14),
+         INT8_C(   7), -INT8_C(  24),  INT8_C(  72), -INT8_C( 103),  INT8_C(  75),  INT8_C(  49),  INT8_C(  62),  INT8_C(   3),
+        -INT8_C(  91),  INT8_C(  47), -INT8_C(  70), -INT8_C( 100),  INT8_C(  73), -INT8_C(  80), -INT8_C(  68), -INT8_C(  17),
+        -INT8_C(  54),  INT8_C(  54), -INT8_C(  70),  INT8_C(  53),  INT8_C(  44),  INT8_C(  74), -INT8_C(  56),  INT8_C(  70) },
+      UINT32_C(3840445437),
+      {  INT8_C(  57),  INT8_C( 124), -INT8_C(  42),  INT8_C(  64),  INT8_C( 100),  INT8_C(  30), -INT8_C(  39), -INT8_C(  80),
+         INT8_C(  79),  INT8_C(  23), -INT8_C(  77), -INT8_C(  11),  INT8_C(  71),  INT8_C( 109), -INT8_C( 111), -INT8_C( 112),
+         INT8_C(  29),  INT8_C(  78),      INT8_MAX, -INT8_C(  25), -INT8_C( 124),  INT8_C(  58),  INT8_C(  29), -INT8_C(  80),
+        -INT8_C( 124), -INT8_C(  27), -INT8_C(  10), -INT8_C( 127),  INT8_C( 112), -INT8_C(  33),  INT8_C( 102), -INT8_C(  87) },
+      {  INT8_C(  91),  INT8_C(  60), -INT8_C(  23), -INT8_C(  65),  INT8_C(  91), -INT8_C(  62),  INT8_C( 111), -INT8_C(  86),
+        -INT8_C(  39),  INT8_C(  34), -INT8_C(  97),  INT8_C(  32), -INT8_C( 113),  INT8_C(  49), -INT8_C(  80), -INT8_C(  84),
+             INT8_MAX,  INT8_C(  48), -INT8_C( 108),  INT8_C(   3),  INT8_C( 106), -INT8_C(  79), -INT8_C(  76), -INT8_C(  18),
+        -INT8_C( 106), -INT8_C(  86),  INT8_C( 112),  INT8_C(   6), -INT8_C( 119), -INT8_C(  42), -INT8_C(  81), -INT8_C(  28) },
+      { -INT8_C(  86), -INT8_C(  78), -INT8_C(  76),  INT8_C(  91),  INT8_C(  91), -INT8_C(  81), -INT8_C(  86),      INT8_MAX,
+        -INT8_C(  84), -INT8_C(  18),  INT8_C(  72), -INT8_C(  79),  INT8_C(  75),  INT8_C(  49),  INT8_C(  62),      INT8_MAX,
+        -INT8_C(  91),  INT8_C(  47), -INT8_C(  70), -INT8_C(  86),  INT8_C(  73),  INT8_C( 112), -INT8_C(  42),      INT8_MAX,
+        -INT8_C(  54),  INT8_C(  54), -INT8_C(  76),  INT8_C(  53),  INT8_C(  44), -INT8_C(  28),  INT8_C( 111),  INT8_C(  34) } },
+    { {  INT8_C(  18), -INT8_C( 104), -INT8_C(  92),  INT8_C( 109),  INT8_C(  90),  INT8_C(  19),  INT8_C(  24),  INT8_C(  51),
+         INT8_C(  54), -INT8_C(  73),  INT8_C(  84), -INT8_C(  59), -INT8_C(  24),  INT8_C(   4),  INT8_C( 114),  INT8_C( 103),
+         INT8_C(  52),  INT8_C(   6),  INT8_C( 107), -INT8_C(  98), -INT8_C(  73),  INT8_C(  31), -INT8_C( 115),  INT8_C(  77),
+        -INT8_C(  55), -INT8_C(   3),  INT8_C(  83),  INT8_C(  83), -INT8_C(  45),  INT8_C(   2),  INT8_C(  55), -INT8_C(  27) },
+      UINT32_C(4099136410),
+      { -INT8_C(  17),  INT8_C( 107),  INT8_C(  39),  INT8_C(  37),  INT8_C(  34),  INT8_C( 123), -INT8_C(  22),  INT8_C(  11),
+             INT8_MIN,  INT8_C(  92),  INT8_C( 114), -INT8_C(  76),  INT8_C(  98), -INT8_C(  35),  INT8_C(  83),  INT8_C(  25),
+        -INT8_C(   4), -INT8_C(  32),  INT8_C( 102), -INT8_C(  58), -INT8_C(  35), -INT8_C(  71),  INT8_C(  25), -INT8_C(  80),
+        -INT8_C(  69),  INT8_C(  80), -INT8_C( 107),  INT8_C(  85),  INT8_C(  44), -INT8_C(  24),  INT8_C(  73),  INT8_C(  27) },
+      {  INT8_C(  83),  INT8_C( 113),  INT8_C(  64),  INT8_C( 118), -INT8_C(  20),  INT8_C(  42), -INT8_C( 127),  INT8_C( 108),
+        -INT8_C( 121), -INT8_C(  13),  INT8_C(  33), -INT8_C(  23), -INT8_C(  47),  INT8_C( 116),  INT8_C(   3), -INT8_C(  51),
+         INT8_C(  84),  INT8_C( 105), -INT8_C( 109),  INT8_C(  49),  INT8_C(  35), -INT8_C(  84), -INT8_C(  31), -INT8_C(  34),
+        -INT8_C(   3),  INT8_C( 118),  INT8_C(  52),  INT8_C(  41),  INT8_C(  95),  INT8_C( 125),  INT8_C(  68), -INT8_C(  78) },
+      {  INT8_C(  18), -INT8_C(  23), -INT8_C(  92),  INT8_C(  42),  INT8_C(  64),  INT8_C(  19),  INT8_C(  24), -INT8_C(  23),
+         INT8_C(  83),  INT8_C(  95),  INT8_C(  84),  INT8_C(  35),  INT8_C(  64),  INT8_C(   4),  INT8_C(  49),  INT8_C( 118),
+         INT8_C(  95),  INT8_C(  83),  INT8_C( 107), -INT8_C(  98),  INT8_C( 125),  INT8_C(  31),  INT8_C( 118),  INT8_C(  77),
+        -INT8_C(  55), -INT8_C(   3), -INT8_C(  84),  INT8_C(  83), -INT8_C(  47), -INT8_C( 121), -INT8_C(  13),  INT8_C(  41) } },
+    { { -INT8_C(  18), -INT8_C( 124),  INT8_C(  40), -INT8_C(  37), -INT8_C(  82), -INT8_C(  87),  INT8_C(  71),  INT8_C(  53),
+        -INT8_C(  99),  INT8_C( 104),  INT8_C(  31),  INT8_C( 110), -INT8_C(  36),  INT8_C(  34),  INT8_C(  59),  INT8_C(  48),
+        -INT8_C( 117), -INT8_C(  49),  INT8_C(  97), -INT8_C(  82),  INT8_C( 123),  INT8_C(  66), -INT8_C( 115),  INT8_C( 120),
+        -INT8_C(  71), -INT8_C(  63), -INT8_C(  95),  INT8_C(  24),  INT8_C(  62), -INT8_C(  27), -INT8_C(  54),  INT8_C(  45) },
+      UINT32_C( 403239785),
+      { -INT8_C( 100),  INT8_C(  79),  INT8_C(  77),  INT8_C(  57), -INT8_C(  72),  INT8_C( 108), -INT8_C(  89), -INT8_C( 108),
+        -INT8_C( 114), -INT8_C(  29), -INT8_C(  59),  INT8_C(  26), -INT8_C(  78),  INT8_C(  38), -INT8_C(  56),  INT8_C(  45),
+         INT8_C( 105),  INT8_C(  85), -INT8_C(  90),  INT8_C(  34),  INT8_C(  22),  INT8_C(  71),  INT8_C(  58),  INT8_C(  85),
+         INT8_C(  45),  INT8_C(   4), -INT8_C( 126), -INT8_C( 106), -INT8_C(   9), -INT8_C( 118), -INT8_C(  82), -INT8_C( 108) },
+      { -INT8_C(  39), -INT8_C(   4), -INT8_C(  51), -INT8_C( 111),  INT8_C( 104),  INT8_C( 117),  INT8_C(  38), -INT8_C(   9),
+         INT8_C(  88), -INT8_C(  21),  INT8_C(  17),  INT8_C(  10),  INT8_C(  17), -INT8_C(  39),  INT8_C(  55),  INT8_C( 122),
+         INT8_C(  47), -INT8_C(  35), -INT8_C( 100),  INT8_C(  69),  INT8_C(  37), -INT8_C(  42), -INT8_C( 102),  INT8_C(  82),
+        -INT8_C(  37),  INT8_C(  28), -INT8_C(  24), -INT8_C(  46), -INT8_C(  90), -INT8_C( 105),  INT8_C( 102),      INT8_MIN },
+      { -INT8_C(  90), -INT8_C( 124),  INT8_C(  40),  INT8_C(  28), -INT8_C(  82),  INT8_C(  17), -INT8_C(   9),  INT8_C(  53),
+         INT8_C(  55), -INT8_C( 111),  INT8_C(  31),  INT8_C( 110), -INT8_C( 100),  INT8_C(  38),  INT8_C(  88), -INT8_C(  39),
+        -INT8_C( 117), -INT8_C(  49),  INT8_C(  97), -INT8_C(  51),  INT8_C( 123),  INT8_C(  66), -INT8_C( 115),  INT8_C( 120),
+        -INT8_C(  71), -INT8_C(  63), -INT8_C(  95), -INT8_C( 102),  INT8_C(  82), -INT8_C(  27), -INT8_C(  54),  INT8_C(  45) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256i src = simde_mm256_loadu_epi8(test_vec[i].src);
+    simde__m256i idx = simde_mm256_loadu_epi8(test_vec[i].idx);
+    simde__m256i a = simde_mm256_loadu_epi8(test_vec[i].a);
+    simde__m256i r = simde_mm256_mask_permutexvar_epi8(src, test_vec[i].k, idx, a);
+    simde_test_x86_assert_equal_i8x32(r, simde_mm256_loadu_epi8(test_vec[i].r));
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__m256i src = simde_test_x86_random_i8x32();
+    simde__mmask32 k = simde_test_x86_random_mmask32();
+    simde__m256i idx = simde_test_x86_random_i8x32();
+    simde__m256i a = simde_test_x86_random_i8x32();
+    simde__m256i r = simde_mm256_mask_permutexvar_epi8(src, k, idx, a);
+
+    simde_test_x86_write_i8x32(2, src, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_mmask32(2, k, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i8x32(2, idx, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i8x32(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i8x32(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_maskz_permutexvar_epi8 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde__mmask32 k;
+    const int8_t idx[32];
+    const int8_t a[32];
+    const int8_t r[32];
+  } test_vec[] = {
+    { UINT32_C(4212208787),
+      { -INT8_C(  87),  INT8_C(  55), -INT8_C(  14),  INT8_C(   1),  INT8_C(  34),  INT8_C(   3),  INT8_C(  11),  INT8_C(  52),
+        -INT8_C(  35),  INT8_C(  66), -INT8_C(  82),  INT8_C(  12),  INT8_C(  32),  INT8_C(  75),  INT8_C(  81),  INT8_C(  69),
+         INT8_C(  33), -INT8_C(  20), -INT8_C( 105), -INT8_C(   4),  INT8_C(   8),      INT8_MAX, -INT8_C(  49), -INT8_C(  81),
+         INT8_C(  22),  INT8_C(  53),  INT8_C(  47), -INT8_C(  87),  INT8_C( 105),  INT8_C(  64), -INT8_C(  91),  INT8_C(  18) },
+      {  INT8_C( 120), -INT8_C( 105),  INT8_C(  19), -INT8_C( 102), -INT8_C( 101),  INT8_C(  30), -INT8_C(  50),  INT8_C( 120),
+         INT8_C(  97),  INT8_C( 125), -INT8_C( 124), -INT8_C( 127), -INT8_C(  56), -INT8_C(  43), -INT8_C(  58), -INT8_C(  23),
+        -INT8_C(  63),  INT8_C(  93), -INT8_C(  26), -INT8_C(  54), -INT8_C(  36), -INT8_C(  75),  INT8_C( 121), -INT8_C(  13),
+        -INT8_C(  22), -INT8_C(  88), -INT8_C( 100),  INT8_C(  84), -INT8_C(  24),  INT8_C(  65),  INT8_C( 102),  INT8_C(  96) },
+      {  INT8_C( 125), -INT8_C(  13),  INT8_C(   0),  INT8_C(   0),  INT8_C(  19),  INT8_C(   0),  INT8_C(   0), -INT8_C(  36),
+         INT8_C(   0),  INT8_C(   0), -INT8_C(  58),  INT8_C(   0),  INT8_C( 120), -INT8_C( 127),  INT8_C(   0),  INT8_C(   0),
+        -INT8_C( 105),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0),  INT8_C(  97),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0),
+         INT8_C( 121), -INT8_C(  75),  INT8_C(   0),  INT8_C( 125),  INT8_C( 125),  INT8_C( 120),  INT8_C(  30), -INT8_C(  26) } },
+    { UINT32_C(1962638041),
+      { -INT8_C( 104), -INT8_C(  55), -INT8_C(  20), -INT8_C(   7),  INT8_C(  70),  INT8_C( 112),  INT8_C( 122),  INT8_C(  14),
+         INT8_C(  69),  INT8_C(  64), -INT8_C(   8),  INT8_C(   7), -INT8_C(  99), -INT8_C(  34), -INT8_C(  47),  INT8_C( 122),
+        -INT8_C( 109),  INT8_C(  74),  INT8_C( 109),  INT8_C( 125), -INT8_C(  14),  INT8_C(   9), -INT8_C(  47), -INT8_C(  38),
+         INT8_C(  75),  INT8_C(  56),  INT8_C(  59),  INT8_C(  36), -INT8_C(  78),  INT8_C(  54), -INT8_C( 104),  INT8_C(  74) },
+      { -INT8_C(   1), -INT8_C( 124),  INT8_C(  68),  INT8_C(  70), -INT8_C(  12), -INT8_C(  66),  INT8_C(  84),  INT8_C(  57),
+        -INT8_C(   1),  INT8_C(  76),  INT8_C(  64), -INT8_C( 100),  INT8_C(  42),  INT8_C(  17),  INT8_C(  22), -INT8_C(  67),
+         INT8_C(  91), -INT8_C( 125),  INT8_C(  59),  INT8_C(  77), -INT8_C( 115),  INT8_C(  12),  INT8_C(  40), -INT8_C(  40),
+         INT8_C(  68),  INT8_C(  99), -INT8_C(   4), -INT8_C(  10), -INT8_C( 103), -INT8_C( 108),  INT8_C(  65), -INT8_C( 104) },
+      {  INT8_C(  68),  INT8_C(   0),  INT8_C(   0),  INT8_C(  99),  INT8_C(  84),  INT8_C(   0), -INT8_C(   4),  INT8_C(  22),
+         INT8_C(   0), -INT8_C(   1),  INT8_C(   0),  INT8_C(  57), -INT8_C( 108),  INT8_C(  65), -INT8_C( 125),  INT8_C(   0),
+         INT8_C(  77),  INT8_C(  64),  INT8_C(   0), -INT8_C( 108),  INT8_C(  59),  INT8_C(  76), -INT8_C( 125), -INT8_C(   4),
+         INT8_C(   0),  INT8_C(   0), -INT8_C(  10),  INT8_C(   0),  INT8_C(  59),  INT8_C(  40),  INT8_C(  68),  INT8_C(   0) } },
+    { UINT32_C( 215909656),
+      {  INT8_C(  67),  INT8_C(  51),  INT8_C(  69),  INT8_C(  66),      INT8_MAX, -INT8_C( 122), -INT8_C(  33), -INT8_C(  86),
+        -INT8_C( 105), -INT8_C(  11),  INT8_C( 103), -INT8_C(  13),  INT8_C( 121), -INT8_C(  94),  INT8_C(  64),  INT8_C(   6),
+        -INT8_C(  81),  INT8_C( 104), -INT8_C(  34), -INT8_C(  13), -INT8_C(  53), -INT8_C(  38), -INT8_C(  22),  INT8_C( 100),
+         INT8_C( 110),  INT8_C(  43), -INT8_C(   3), -INT8_C( 122), -INT8_C(  80), -INT8_C(  37), -INT8_C( 110), -INT8_C(  13) },
+      {  INT8_C(  14), -INT8_C(  41),  INT8_C(  54), -INT8_C( 114),  INT8_C(  93),  INT8_C(  21),  INT8_C(  56), -INT8_C(  11),
+         INT8_C(  10), -INT8_C(  97), -INT8_C(  24), -INT8_C( 125),  INT8_C(  66),  INT8_C(  40), -INT8_C( 119), -INT8_C(  15),
+        -INT8_C( 111),  INT8_C( 103), -INT8_C(  28),  INT8_C(  92),  INT8_C(  65), -INT8_C(  50), -INT8_C(  63), -INT8_C(  81),
+        -INT8_C(   7), -INT8_C(  66),  INT8_C(  53), -INT8_C(  87), -INT8_C( 103), -INT8_C(  57), -INT8_C(  99), -INT8_C(  88) },
+      {  INT8_C(   0),  INT8_C(   0),  INT8_C(   0),  INT8_C(  54), -INT8_C(  88),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0),
+        -INT8_C(  81),  INT8_C(   0), -INT8_C(  11),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0),  INT8_C(  56),
+         INT8_C(   0),  INT8_C(  10), -INT8_C(  99),  INT8_C(  92), -INT8_C( 125),  INT8_C(   0), -INT8_C(  24),  INT8_C(  93),
+         INT8_C(   0),  INT8_C(   0), -INT8_C(  57),  INT8_C(  56),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0) } },
+    { UINT32_C(4231451551),
+      { -INT8_C(  24),  INT8_C( 110), -INT8_C(  15), -INT8_C(  14),  INT8_C(  13), -INT8_C(  39),  INT8_C( 118),  INT8_C(  79),
+         INT8_C(   2), -INT8_C(   1),  INT8_C(  64), -INT8_C( 109),  INT8_C( 103),  INT8_C(  37), -INT8_C(  17), -INT8_C(  88),
+        -INT8_C(  13), -INT8_C(  80),  INT8_C(  88), -INT8_C(  19),  INT8_C( 110), -INT8_C( 115), -INT8_C( 106),  INT8_C(   8),
+         INT8_C(  85),  INT8_C(  51), -INT8_C(  80), -INT8_C(  12),  INT8_C(   6), -INT8_C(  26), -INT8_C(  16), -INT8_C(  18) },
+      {  INT8_C(  84), -INT8_C(  30), -INT8_C(  31),  INT8_C(  97), -INT8_C(  69),  INT8_C(  87), -INT8_C(  79), -INT8_C(  67),
+         INT8_C(  86), -INT8_C(  15),  INT8_C(  80), -INT8_C(  67),  INT8_C(  22),  INT8_C(  64),  INT8_C( 102),  INT8_C(  10),
+        -INT8_C(  16), -INT8_C(  66), -INT8_C(   9),  INT8_C(  95),  INT8_C(  75), -INT8_C( 115),  INT8_C( 103), -INT8_C(  96),
+        -INT8_C(  63),  INT8_C(  23), -INT8_C( 108), -INT8_C(  57), -INT8_C(   3), -INT8_C( 123), -INT8_C(  74),  INT8_C(  81) },
+      {  INT8_C(  86),  INT8_C( 102), -INT8_C(  66), -INT8_C(   9),  INT8_C(  64),  INT8_C(   0),  INT8_C(   0),  INT8_C(  10),
+        -INT8_C(  31),  INT8_C(  81),  INT8_C(   0),  INT8_C(   0), -INT8_C(  67),  INT8_C(   0),  INT8_C(  10),  INT8_C(  86),
+         INT8_C(   0), -INT8_C(  16), -INT8_C(  63),  INT8_C(   0),  INT8_C( 102),  INT8_C(  64),  INT8_C(   0),  INT8_C(   0),
+         INT8_C(   0),  INT8_C(   0), -INT8_C(  16),  INT8_C(  75), -INT8_C(  79), -INT8_C(  79), -INT8_C(  16),  INT8_C( 102) } },
+    { UINT32_C( 582129511),
+      { -INT8_C(  18),  INT8_C(  99), -INT8_C(  32),  INT8_C(  68),  INT8_C(  85),  INT8_C(  48),  INT8_C(   2),  INT8_C( 107),
+         INT8_C( 112),  INT8_C( 104),  INT8_C( 117),  INT8_C(  97),  INT8_C(  38),  INT8_C( 108), -INT8_C(  64),  INT8_C( 113),
+        -INT8_C(   6),  INT8_C(  39),  INT8_C(  18), -INT8_C(  69),  INT8_C(  62), -INT8_C(  90), -INT8_C( 126),  INT8_C(  59),
+         INT8_C(  43),  INT8_C(  56), -INT8_C( 116), -INT8_C( 110), -INT8_C(  49),  INT8_C(  62), -INT8_C(  75), -INT8_C(  67) },
+      { -INT8_C(  94), -INT8_C( 107),  INT8_C(   2), -INT8_C(   9), -INT8_C(  59),  INT8_C(   4),  INT8_C(  98),  INT8_C(  54),
+         INT8_C( 108), -INT8_C(  40), -INT8_C( 105), -INT8_C( 110),  INT8_C(  68),  INT8_C(  87),  INT8_C(   3),  INT8_C(  62),
+         INT8_C( 126),  INT8_C(  21), -INT8_C(   7), -INT8_C(  68), -INT8_C(  68),  INT8_C( 124), -INT8_C(   9), -INT8_C(  25),
+        -INT8_C(  76), -INT8_C( 125),  INT8_C( 122), -INT8_C( 124), -INT8_C(  63),  INT8_C(  47),  INT8_C(  65),  INT8_C(  99) },
+      {  INT8_C(   3), -INT8_C(   9), -INT8_C(  94),  INT8_C(   0),  INT8_C(   0),  INT8_C( 126),  INT8_C(   2),  INT8_C(   0),
+         INT8_C( 126),  INT8_C( 108),  INT8_C( 124),  INT8_C(   0),  INT8_C(  98),  INT8_C(   0),  INT8_C(   0),  INT8_C(  21),
+         INT8_C(   0),  INT8_C(  54),  INT8_C(   0),  INT8_C(   0),  INT8_C(  65),  INT8_C(  98),  INT8_C(   0), -INT8_C( 124),
+         INT8_C(   0), -INT8_C(  76),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0),  INT8_C(  65),  INT8_C(   0),  INT8_C(   0) } },
+    { UINT32_C(2304394180),
+      {  INT8_C(  71), -INT8_C(  67), -INT8_C(  65), -INT8_C(  77), -INT8_C( 107),  INT8_C(  86),  INT8_C(  69), -INT8_C(  39),
+        -INT8_C(  83),  INT8_C(  73),  INT8_C(  24),  INT8_C(  43),  INT8_C(  94),  INT8_C(  17), -INT8_C(  25),  INT8_C(  26),
+        -INT8_C( 115), -INT8_C(  34),  INT8_C(   2),  INT8_C(  66),  INT8_C(  97),  INT8_C( 124), -INT8_C(  58),  INT8_C(  35),
+        -INT8_C(  85),  INT8_C(   7), -INT8_C( 122),  INT8_C( 111),  INT8_C(  75), -INT8_C(  31), -INT8_C(   8), -INT8_C( 110) },
+      { -INT8_C(  98), -INT8_C(  72),  INT8_C(  70),  INT8_C(  51),  INT8_C(  14), -INT8_C( 117),  INT8_C(  12), -INT8_C(  68),
+        -INT8_C(  44),  INT8_C(  36), -INT8_C(  25),  INT8_C(  51),  INT8_C(  54), -INT8_C(  49),  INT8_C(  77), -INT8_C(  61),
+        -INT8_C(  83),  INT8_C(  79),  INT8_C(   5),  INT8_C(  15), -INT8_C(  53), -INT8_C(  53),  INT8_C(  50),  INT8_C( 118),
+        -INT8_C(  45), -INT8_C(  72), -INT8_C(  27),  INT8_C(  30), -INT8_C( 103), -INT8_C(  34), -INT8_C(  80),  INT8_C(  55) },
+      {  INT8_C(   0),  INT8_C(   0),  INT8_C(  55),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0), -INT8_C( 117), -INT8_C(  72),
+        -INT8_C(  49),  INT8_C(  36),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0), -INT8_C(  68),  INT8_C(   0),
+         INT8_C(   0), -INT8_C(  80),  INT8_C(   0),  INT8_C(  70), -INT8_C(  72),  INT8_C(   0),  INT8_C(  12),  INT8_C(   0),
+         INT8_C(  51),  INT8_C(   0),  INT8_C(   0), -INT8_C(  61),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0),  INT8_C(   5) } },
+    { UINT32_C(2758473366),
+      { -INT8_C( 126),  INT8_C( 119),  INT8_C(  96),  INT8_C(  86), -INT8_C( 101),  INT8_C(  72), -INT8_C( 119), -INT8_C(  47),
+         INT8_C(  23), -INT8_C(  41), -INT8_C( 107), -INT8_C(  60),  INT8_C(  38), -INT8_C( 102), -INT8_C(  45), -INT8_C(  14),
+         INT8_C( 102),  INT8_C(   5),  INT8_C( 104),  INT8_C(  57), -INT8_C(  66),  INT8_C(  78),  INT8_C(  87),  INT8_C(  87),
+         INT8_C(  44),  INT8_C(   7), -INT8_C( 113), -INT8_C(  62), -INT8_C(   2), -INT8_C(   7),  INT8_C( 102),      INT8_MIN },
+      {  INT8_C( 112), -INT8_C(  57), -INT8_C(  42),  INT8_C(  12),  INT8_C(  15),  INT8_C(  96), -INT8_C(  35),  INT8_C(  38),
+         INT8_C(  55),  INT8_C( 114), -INT8_C(  22),  INT8_C(  93),  INT8_C(  13), -INT8_C(  66),  INT8_C(  79),  INT8_C( 115),
+        -INT8_C(  61), -INT8_C(  72), -INT8_C(  84), -INT8_C( 127),  INT8_C(   6),  INT8_C(   3), -INT8_C(  39),  INT8_C(  50),
+         INT8_C(  10),  INT8_C( 104), -INT8_C(  12),  INT8_C(   8),  INT8_C(  97),  INT8_C(  90), -INT8_C( 120), -INT8_C(  46) },
+      {  INT8_C(   0),  INT8_C(  50),  INT8_C( 112),  INT8_C(   0),  INT8_C(   8),  INT8_C(   0),  INT8_C(   0), -INT8_C(  72),
+         INT8_C(   0),  INT8_C(  50),  INT8_C(   3),  INT8_C(   0), -INT8_C(  35), -INT8_C(  12), -INT8_C( 127), -INT8_C(  84),
+         INT8_C(   0),  INT8_C(  96),  INT8_C(   0),  INT8_C( 104),  INT8_C(   0),  INT8_C(  79),  INT8_C(  50),  INT8_C(   0),
+         INT8_C(   0),  INT8_C(   0),  INT8_C( 115),  INT8_C(   0),  INT8_C(   0),  INT8_C( 104),  INT8_C(   0),  INT8_C( 112) } },
+    { UINT32_C( 819879713),
+      { -INT8_C(  65), -INT8_C(  69),  INT8_C(  86), -INT8_C(  10),  INT8_C(  46),  INT8_C(  65),  INT8_C(  83),  INT8_C(  59),
+        -INT8_C(   1), -INT8_C(  93), -INT8_C(  82), -INT8_C(  62),  INT8_C(  91),  INT8_C(  90),  INT8_C(  68),  INT8_C(  97),
+         INT8_C(  93),  INT8_C(  29), -INT8_C( 109),  INT8_C( 103), -INT8_C( 123), -INT8_C( 121),  INT8_C( 112), -INT8_C(  26),
+        -INT8_C(  31), -INT8_C(   8), -INT8_C(  72),  INT8_C(   3),  INT8_C(  87), -INT8_C( 106),  INT8_C(  51),  INT8_C(  22) },
+      {  INT8_C(  82), -INT8_C( 118),  INT8_C(  12),      INT8_MIN, -INT8_C(  53),  INT8_C(  96), -INT8_C(  69), -INT8_C(  54),
+         INT8_C(   3),  INT8_C( 105), -INT8_C( 116),  INT8_C(  94), -INT8_C(  61), -INT8_C(  48), -INT8_C(  65),  INT8_C(  32),
+        -INT8_C(  19),  INT8_C(  82), -INT8_C( 121),  INT8_C( 114), -INT8_C(  39), -INT8_C(   9),  INT8_C(  89), -INT8_C(  70),
+        -INT8_C(  16),  INT8_C(  17), -INT8_C(  67),  INT8_C(  71), -INT8_C(  88), -INT8_C(  15),  INT8_C(  94), -INT8_C(   6) },
+      { -INT8_C(   6),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0), -INT8_C( 118),  INT8_C(   0),  INT8_C(   0),
+        -INT8_C(   6),      INT8_MIN, -INT8_C(  65),  INT8_C(  12),  INT8_C(  71),  INT8_C(   0), -INT8_C(  53),  INT8_C(   0),
+         INT8_C(   0), -INT8_C(  15),  INT8_C( 114), -INT8_C(  54),  INT8_C(  96),  INT8_C(   0), -INT8_C(  19), -INT8_C(  69),
+         INT8_C(   0),  INT8_C(   0),  INT8_C(   0),  INT8_C(   0), -INT8_C(  70),  INT8_C(  89),  INT8_C(   0),  INT8_C(   0) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256i idx = simde_mm256_loadu_epi8(test_vec[i].idx);
+    simde__m256i a = simde_mm256_loadu_epi8(test_vec[i].a);
+    simde__m256i r = simde_mm256_maskz_permutexvar_epi8(test_vec[i].k, idx, a);
+    simde_test_x86_assert_equal_i8x32(r, simde_mm256_loadu_epi8(test_vec[i].r));
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__mmask32 k = simde_test_x86_random_mmask32();
+    simde__m256i idx = simde_test_x86_random_i8x32();
+    simde__m256i a = simde_test_x86_random_i8x32();
+    simde__m256i r = simde_mm256_maskz_permutexvar_epi8(k, idx, a);
+
+    simde_test_x86_write_mmask32(2, k, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_i8x32(2, idx, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i8x32(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i8x32(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_permutexvar_pd(SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  const struct {
+    const int64_t idx[4];
+    const simde_float64 a[4];
+    const simde_float64 r[4];
+  } test_vec[8] = {
+    { { -INT64_C( 6723175484270992638), -INT64_C( 4563869859770635283),  INT64_C(  651974606270245935), -INT64_C( 8302155520550445577) },
+      { SIMDE_FLOAT64_C(  -770.65), SIMDE_FLOAT64_C(    51.51), SIMDE_FLOAT64_C(  -565.74), SIMDE_FLOAT64_C(   -26.48) },
+      { SIMDE_FLOAT64_C(  -565.74), SIMDE_FLOAT64_C(    51.51), SIMDE_FLOAT64_C(   -26.48), SIMDE_FLOAT64_C(   -26.48) } },
+    { { -INT64_C( 3631628342071142227), -INT64_C( 2150787199714573635), -INT64_C( 7382396981396950491),  INT64_C( 3653346760470123590) },
+      { SIMDE_FLOAT64_C(   723.79), SIMDE_FLOAT64_C(   211.57), SIMDE_FLOAT64_C(  -703.04), SIMDE_FLOAT64_C(   319.79) },
+      { SIMDE_FLOAT64_C(   211.57), SIMDE_FLOAT64_C(   211.57), SIMDE_FLOAT64_C(   211.57), SIMDE_FLOAT64_C(  -703.04) } },
+    { {  INT64_C( 1789830837432444459),  INT64_C( 4531154689147468959),  INT64_C( 5070206288598101338), -INT64_C( 8515948049036931256) },
+      { SIMDE_FLOAT64_C(   745.53), SIMDE_FLOAT64_C(  -121.69), SIMDE_FLOAT64_C(   436.39), SIMDE_FLOAT64_C(  -375.64) },
+      { SIMDE_FLOAT64_C(  -375.64), SIMDE_FLOAT64_C(  -375.64), SIMDE_FLOAT64_C(   436.39), SIMDE_FLOAT64_C(   745.53) } },
+    { {  INT64_C( 8298558806840658118),  INT64_C( 4127699110275910476),  INT64_C( 1241015148471100549), -INT64_C( 3152505381425837762) },
+      { SIMDE_FLOAT64_C(   290.53), SIMDE_FLOAT64_C(   233.57), SIMDE_FLOAT64_C(  -508.59), SIMDE_FLOAT64_C(  -457.88) },
+      { SIMDE_FLOAT64_C(  -508.59), SIMDE_FLOAT64_C(   290.53), SIMDE_FLOAT64_C(   233.57), SIMDE_FLOAT64_C(  -508.59) } },
+    { { -INT64_C( 1870754788895005931), -INT64_C( 6297545250883808953), -INT64_C( 1530847991345524073), -INT64_C( 4227763291079966366) },
+      { SIMDE_FLOAT64_C(   157.81), SIMDE_FLOAT64_C(  -884.15), SIMDE_FLOAT64_C(    58.01), SIMDE_FLOAT64_C(  -253.60) },
+      { SIMDE_FLOAT64_C(  -884.15), SIMDE_FLOAT64_C(  -253.60), SIMDE_FLOAT64_C(  -253.60), SIMDE_FLOAT64_C(    58.01) } },
+    { {  INT64_C( 8517097999991582751),  INT64_C( 8925246739055561838),  INT64_C( 5640797697215929645),  INT64_C( 1963352818527214362) },
+      { SIMDE_FLOAT64_C(   338.84), SIMDE_FLOAT64_C(  -454.50), SIMDE_FLOAT64_C(  -481.79), SIMDE_FLOAT64_C(   868.84) },
+      { SIMDE_FLOAT64_C(   868.84), SIMDE_FLOAT64_C(  -481.79), SIMDE_FLOAT64_C(  -454.50), SIMDE_FLOAT64_C(  -481.79) } },
+    { {  INT64_C( 2248280827481928638),  INT64_C( 5338454049758515032), -INT64_C(  742341901610885598), -INT64_C( 7045158274482507291) },
+      { SIMDE_FLOAT64_C(   669.60), SIMDE_FLOAT64_C(   -19.61), SIMDE_FLOAT64_C(   253.69), SIMDE_FLOAT64_C(   272.69) },
+      { SIMDE_FLOAT64_C(   253.69), SIMDE_FLOAT64_C(   669.60), SIMDE_FLOAT64_C(   253.69), SIMDE_FLOAT64_C(   -19.61) } },
+    { { -INT64_C( 5046144786224579045),  INT64_C( 7339632008068599421),  INT64_C( 6808716401325083976),  INT64_C( 7928525928940812285) },
+      { SIMDE_FLOAT64_C(  -743.17), SIMDE_FLOAT64_C(   904.38), SIMDE_FLOAT64_C(   600.61), SIMDE_FLOAT64_C(  -731.72) },
+      { SIMDE_FLOAT64_C(  -731.72), SIMDE_FLOAT64_C(   904.38), SIMDE_FLOAT64_C(  -743.17), SIMDE_FLOAT64_C(   904.38) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256i idx = simde_mm256_loadu_epi64(test_vec[i].idx);
+    simde__m256d a = simde_mm256_loadu_pd(test_vec[i].a);
+    simde__m256d r = simde_mm256_permutexvar_pd(idx, a);
+    simde_test_x86_assert_equal_f64x4(r, simde_mm256_loadu_pd(test_vec[i].r), 1);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__m256i idx = simde_test_x86_random_i64x4();
+    simde__m256d a = simde_test_x86_random_f64x4(SIMDE_FLOAT64_C(-1000.0), SIMDE_FLOAT64_C(1000.0));
+    simde__m256d r = simde_mm256_permutexvar_pd(idx, a);
+
+    simde_test_x86_write_i64x4(2, idx, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_f64x4(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f64x4(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_mask_permutexvar_pd(SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  const struct {
+    const simde_float64 src[4];
+    const simde__mmask8 k;
+    const int64_t idx[4];
+    const simde_float64 a[4];
+    const simde_float64 r[4];
+  } test_vec[8] = {
+    { { SIMDE_FLOAT64_C(  -749.78), SIMDE_FLOAT64_C(   320.61), SIMDE_FLOAT64_C(  -674.06), SIMDE_FLOAT64_C(  -589.15) },
+      UINT8_C(231),
+      { -INT64_C( 1263618822685620846), -INT64_C( 2847177519672810476), -INT64_C( 5739950126254014776),  INT64_C( 5493265346248387706) },
+      { SIMDE_FLOAT64_C(  -516.97), SIMDE_FLOAT64_C(  -674.45), SIMDE_FLOAT64_C(  -986.75), SIMDE_FLOAT64_C(  -900.24) },
+      { SIMDE_FLOAT64_C(  -986.75), SIMDE_FLOAT64_C(  -516.97), SIMDE_FLOAT64_C(  -516.97), SIMDE_FLOAT64_C(  -589.15) } },
+    { { SIMDE_FLOAT64_C(  -673.90), SIMDE_FLOAT64_C(  -543.83), SIMDE_FLOAT64_C(  -527.91), SIMDE_FLOAT64_C(   493.44) },
+      UINT8_C(149),
+      {  INT64_C( 1644533322731674431), -INT64_C( 1815358867884973126), -INT64_C( 1429070044781862234),  INT64_C( 2444769474548862823) },
+      { SIMDE_FLOAT64_C(  -140.49), SIMDE_FLOAT64_C(  -448.35), SIMDE_FLOAT64_C(   133.99), SIMDE_FLOAT64_C(   549.40) },
+      { SIMDE_FLOAT64_C(   549.40), SIMDE_FLOAT64_C(  -543.83), SIMDE_FLOAT64_C(   133.99), SIMDE_FLOAT64_C(   493.44) } },
+    { { SIMDE_FLOAT64_C(  -678.26), SIMDE_FLOAT64_C(   381.11), SIMDE_FLOAT64_C(   667.04), SIMDE_FLOAT64_C(   575.51) },
+      UINT8_C( 97),
+      {  INT64_C( 3452292845339951030), -INT64_C( 4037906182301774173), -INT64_C( 2401883995933946195), -INT64_C(   47292980296388873) },
+      { SIMDE_FLOAT64_C(   948.31), SIMDE_FLOAT64_C(   488.58), SIMDE_FLOAT64_C(   153.16), SIMDE_FLOAT64_C(   778.73) },
+      { SIMDE_FLOAT64_C(   153.16), SIMDE_FLOAT64_C(   381.11), SIMDE_FLOAT64_C(   667.04), SIMDE_FLOAT64_C(   575.51) } },
+    { { SIMDE_FLOAT64_C(  -963.94), SIMDE_FLOAT64_C(   996.32), SIMDE_FLOAT64_C(   531.49), SIMDE_FLOAT64_C(  -945.52) },
+      UINT8_C(185),
+      { -INT64_C( 1357490459819988989),  INT64_C( 9197765586491828195),  INT64_C( 7227652815215696407),  INT64_C( 1075782015956718601) },
+      { SIMDE_FLOAT64_C(   437.45), SIMDE_FLOAT64_C(  -523.92), SIMDE_FLOAT64_C(  -270.27), SIMDE_FLOAT64_C(  -213.44) },
+      { SIMDE_FLOAT64_C(  -213.44), SIMDE_FLOAT64_C(   996.32), SIMDE_FLOAT64_C(   531.49), SIMDE_FLOAT64_C(  -523.92) } },
+    { { SIMDE_FLOAT64_C(  -557.45), SIMDE_FLOAT64_C(  -121.42), SIMDE_FLOAT64_C(   881.29), SIMDE_FLOAT64_C(   967.43) },
+      UINT8_C( 27),
+      {  INT64_C( 7596636677954349646),  INT64_C( 6936880209947492212), -INT64_C( 4240568522068232039), -INT64_C( 3111184124717670653) },
+      { SIMDE_FLOAT64_C(  -412.42), SIMDE_FLOAT64_C(   611.71), SIMDE_FLOAT64_C(   321.78), SIMDE_FLOAT64_C(   605.43) },
+      { SIMDE_FLOAT64_C(   321.78), SIMDE_FLOAT64_C(  -412.42), SIMDE_FLOAT64_C(   881.29), SIMDE_FLOAT64_C(   605.43) } },
+    { { SIMDE_FLOAT64_C(  -459.52), SIMDE_FLOAT64_C(  -808.78), SIMDE_FLOAT64_C(  -336.07), SIMDE_FLOAT64_C(   279.61) },
+      UINT8_C( 21),
+      {  INT64_C( 1580835613247101335),  INT64_C(  156008206567177389), -INT64_C( 5657545105993047650),  INT64_C( 2535661328087666565) },
+      { SIMDE_FLOAT64_C(   650.97), SIMDE_FLOAT64_C(   966.14), SIMDE_FLOAT64_C(   607.62), SIMDE_FLOAT64_C(  -257.27) },
+      { SIMDE_FLOAT64_C(  -257.27), SIMDE_FLOAT64_C(  -808.78), SIMDE_FLOAT64_C(   607.62), SIMDE_FLOAT64_C(   279.61) } },
+    { { SIMDE_FLOAT64_C(   110.41), SIMDE_FLOAT64_C(  -827.61), SIMDE_FLOAT64_C(  -943.00), SIMDE_FLOAT64_C(  -461.29) },
+      UINT8_C(231),
+      {  INT64_C( 3594026778983278082),  INT64_C( 2591424474769545236),  INT64_C( 5999024786878894578),  INT64_C( 4295772386389045835) },
+      { SIMDE_FLOAT64_C(   829.81), SIMDE_FLOAT64_C(   151.31), SIMDE_FLOAT64_C(  -948.92), SIMDE_FLOAT64_C(   823.99) },
+      { SIMDE_FLOAT64_C(  -948.92), SIMDE_FLOAT64_C(   829.81), SIMDE_FLOAT64_C(  -948.92), SIMDE_FLOAT64_C(  -461.29) } },
+    { { SIMDE_FLOAT64_C(   -83.93), SIMDE_FLOAT64_C(   443.69), SIMDE_FLOAT64_C(   453.64), SIMDE_FLOAT64_C(  -121.53) },
+      UINT8_C(181),
+      {  INT64_C( 4664511156021966899),  INT64_C( 1907227610614736986), -INT64_C( 1013434392324657796), -INT64_C( 8134225108301181685) },
+      { SIMDE_FLOAT64_C(  -243.67), SIMDE_FLOAT64_C(   980.91), SIMDE_FLOAT64_C(  -312.16), SIMDE_FLOAT64_C(   981.49) },
+      { SIMDE_FLOAT64_C(   981.49), SIMDE_FLOAT64_C(   443.69), SIMDE_FLOAT64_C(  -243.67), SIMDE_FLOAT64_C(  -121.53) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256d src = simde_mm256_loadu_pd(test_vec[i].src);
+    simde__m256i idx = simde_mm256_loadu_epi64(test_vec[i].idx);
+    simde__m256d a = simde_mm256_loadu_pd(test_vec[i].a);
+    simde__m256d r = simde_mm256_mask_permutexvar_pd(src, test_vec[i].k, idx, a);
+    simde_test_x86_assert_equal_f64x4(r, simde_mm256_loadu_pd(test_vec[i].r), 1);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__m256d src = simde_test_x86_random_f64x4(SIMDE_FLOAT64_C(-1000.0), SIMDE_FLOAT64_C(1000.0));
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m256i idx = simde_test_x86_random_i64x4();
+    simde__m256d a = simde_test_x86_random_f64x4(SIMDE_FLOAT64_C(-1000.0), SIMDE_FLOAT64_C(1000.0));
+    simde__m256d r = simde_mm256_mask_permutexvar_pd(src, k, idx, a);
+
+    simde_test_x86_write_f64x4(2, src, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i64x4(2, idx, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f64x4(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f64x4(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_maskz_permutexvar_pd(SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  const struct {
+    const simde__mmask8 k;
+    const int64_t idx[4];
+    const simde_float64 a[4];
+    const simde_float64 r[4];
+  } test_vec[8] = {
+    { UINT8_C( 82),
+      {  INT64_C( 7756845172501845012), -INT64_C( 6825194156430213296),  INT64_C( 5503985742234073849),  INT64_C( 6858073262148153907) },
+      { SIMDE_FLOAT64_C(   348.35), SIMDE_FLOAT64_C(   624.29), SIMDE_FLOAT64_C(  -664.85), SIMDE_FLOAT64_C(   199.21) },
+      { SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(   348.35), SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(     0.00) } },
+    { UINT8_C(178),
+      { -INT64_C( 3741505294702552255),  INT64_C( 8638691756592248265), -INT64_C( 1915010472295649745), -INT64_C( 6324410229484237904) },
+      { SIMDE_FLOAT64_C(  -819.48), SIMDE_FLOAT64_C(   -45.29), SIMDE_FLOAT64_C(  -250.63), SIMDE_FLOAT64_C(  -204.86) },
+      { SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(   -45.29), SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(     0.00) } },
+    { UINT8_C(190),
+      {  INT64_C( 3085962307915192508),  INT64_C( 8771176944555871084), -INT64_C( 8423505512529027354),  INT64_C( 2875934750950081261) },
+      { SIMDE_FLOAT64_C(   493.35), SIMDE_FLOAT64_C(  -846.35), SIMDE_FLOAT64_C(  -448.39), SIMDE_FLOAT64_C(  -858.20) },
+      { SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(   493.35), SIMDE_FLOAT64_C(  -448.39), SIMDE_FLOAT64_C(  -846.35) } },
+    { UINT8_C(250),
+      {  INT64_C( 6101534005241741420),  INT64_C(  195321988682229433),  INT64_C( 3689323120464773126),  INT64_C( 6948633058193660420) },
+      { SIMDE_FLOAT64_C(  -979.67), SIMDE_FLOAT64_C(    -4.00), SIMDE_FLOAT64_C(   936.36), SIMDE_FLOAT64_C(  -772.83) },
+      { SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(    -4.00), SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(  -979.67) } },
+    { UINT8_C(212),
+      {  INT64_C( 6141754755641061060),  INT64_C( 5237162096522378650), -INT64_C( 8240250253156228522), -INT64_C( 2245492898981346258) },
+      { SIMDE_FLOAT64_C(   244.04), SIMDE_FLOAT64_C(   477.58), SIMDE_FLOAT64_C(  -396.44), SIMDE_FLOAT64_C(   196.16) },
+      { SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(  -396.44), SIMDE_FLOAT64_C(     0.00) } },
+    { UINT8_C( 73),
+      { -INT64_C( 3354690591741684986), -INT64_C( 4153207234733033107), -INT64_C( 2333999889224701572),  INT64_C( 5511126413861026766) },
+      { SIMDE_FLOAT64_C(   527.73), SIMDE_FLOAT64_C(  -488.23), SIMDE_FLOAT64_C(    -9.01), SIMDE_FLOAT64_C(  -402.49) },
+      { SIMDE_FLOAT64_C(    -9.01), SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(    -9.01) } },
+    { UINT8_C( 30),
+      {  INT64_C( 5170372545627244289),  INT64_C( 8329200236232935222),  INT64_C( 6962692482878502622),  INT64_C( 9109829307771383279) },
+      { SIMDE_FLOAT64_C(  -972.26), SIMDE_FLOAT64_C(   204.27), SIMDE_FLOAT64_C(   393.26), SIMDE_FLOAT64_C(   414.79) },
+      { SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(   393.26), SIMDE_FLOAT64_C(   393.26), SIMDE_FLOAT64_C(   414.79) } },
+    { UINT8_C(209),
+      { -INT64_C( 6774496452643677191),  INT64_C( 2603319939733352382),  INT64_C( 5036258758730416250), -INT64_C( 7811635825436106034) },
+      { SIMDE_FLOAT64_C(  -877.39), SIMDE_FLOAT64_C(   290.97), SIMDE_FLOAT64_C(   735.30), SIMDE_FLOAT64_C(  -604.30) },
+      { SIMDE_FLOAT64_C(   290.97), SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(     0.00) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256i idx = simde_mm256_loadu_epi64(test_vec[i].idx);
+    simde__m256d a = simde_mm256_loadu_pd(test_vec[i].a);
+    simde__m256d r = simde_mm256_maskz_permutexvar_pd(test_vec[i].k, idx, a);
+    simde_test_x86_assert_equal_f64x4(r, simde_mm256_loadu_pd(test_vec[i].r), 1);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m256i idx = simde_test_x86_random_i64x4();
+    simde__m256d a = simde_test_x86_random_f64x4(SIMDE_FLOAT64_C(-1000.0), SIMDE_FLOAT64_C(1000.0));
+    simde__m256d r = simde_mm256_maskz_permutexvar_pd(k, idx, a);
+
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_i64x4(2, idx, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f64x4(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f64x4(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_permutexvar_ps(SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  const struct {
+    const int32_t idx[8];
+    const simde_float32 a[8];
+    const simde_float32 r[8];
+  } test_vec[8] = {
+    { { -INT32_C(  1003465647), -INT32_C(   514585522),  INT32_C(  1936858576), -INT32_C(  2075224162),  INT32_C(  1915012941),  INT32_C(  1612493475),  INT32_C(  2023952200), -INT32_C(  1918079684) },
+      { SIMDE_FLOAT32_C(  -948.78), SIMDE_FLOAT32_C(  -410.03), SIMDE_FLOAT32_C(  -879.71), SIMDE_FLOAT32_C(   201.10),
+        SIMDE_FLOAT32_C(   452.67), SIMDE_FLOAT32_C(   820.53), SIMDE_FLOAT32_C(   280.22), SIMDE_FLOAT32_C(   700.21) },
+      { SIMDE_FLOAT32_C(  -410.03), SIMDE_FLOAT32_C(   280.22), SIMDE_FLOAT32_C(  -948.78), SIMDE_FLOAT32_C(   280.22),
+        SIMDE_FLOAT32_C(   820.53), SIMDE_FLOAT32_C(   201.10), SIMDE_FLOAT32_C(  -948.78), SIMDE_FLOAT32_C(   452.67) } },
+    { {  INT32_C(  1630364355),  INT32_C(  1206221817), -INT32_C(   440858046),  INT32_C(    71751100),  INT32_C(   561834469),  INT32_C(   414067030), -INT32_C(   282656762),  INT32_C(  1772689574) },
+      { SIMDE_FLOAT32_C(   591.13), SIMDE_FLOAT32_C(  -529.69), SIMDE_FLOAT32_C(  -654.92), SIMDE_FLOAT32_C(   391.52),
+        SIMDE_FLOAT32_C(    -8.88), SIMDE_FLOAT32_C(  -562.27), SIMDE_FLOAT32_C(   -53.46), SIMDE_FLOAT32_C(   344.19) },
+      { SIMDE_FLOAT32_C(   391.52), SIMDE_FLOAT32_C(  -529.69), SIMDE_FLOAT32_C(  -654.92), SIMDE_FLOAT32_C(    -8.88),
+        SIMDE_FLOAT32_C(  -562.27), SIMDE_FLOAT32_C(   -53.46), SIMDE_FLOAT32_C(   -53.46), SIMDE_FLOAT32_C(   -53.46) } },
+    { {  INT32_C(  1987736762),  INT32_C(   796573770),  INT32_C(     5306281),  INT32_C(   639172128), -INT32_C(  1525334017), -INT32_C(   770719913), -INT32_C(   398009706),  INT32_C(  1165820298) },
+      { SIMDE_FLOAT32_C(   502.30), SIMDE_FLOAT32_C(  -922.61), SIMDE_FLOAT32_C(  -408.74), SIMDE_FLOAT32_C(   423.84),
+        SIMDE_FLOAT32_C(  -781.34), SIMDE_FLOAT32_C(   645.58), SIMDE_FLOAT32_C(  -578.41), SIMDE_FLOAT32_C(  -100.81) },
+      { SIMDE_FLOAT32_C(  -408.74), SIMDE_FLOAT32_C(  -408.74), SIMDE_FLOAT32_C(  -922.61), SIMDE_FLOAT32_C(   502.30),
+        SIMDE_FLOAT32_C(  -100.81), SIMDE_FLOAT32_C(  -100.81), SIMDE_FLOAT32_C(  -578.41), SIMDE_FLOAT32_C(  -408.74) } },
+    { {  INT32_C(  1298284077),  INT32_C(  1014200893),  INT32_C(   299993273), -INT32_C(   572264377),  INT32_C(  1439050186), -INT32_C(  1617280214), -INT32_C(   195078853), -INT32_C(  1202303605) },
+      { SIMDE_FLOAT32_C(   114.38), SIMDE_FLOAT32_C(  -407.95), SIMDE_FLOAT32_C(  -190.09), SIMDE_FLOAT32_C(  -913.09),
+        SIMDE_FLOAT32_C(  -594.00), SIMDE_FLOAT32_C(  -805.95), SIMDE_FLOAT32_C(   896.02), SIMDE_FLOAT32_C(   706.50) },
+      { SIMDE_FLOAT32_C(  -805.95), SIMDE_FLOAT32_C(  -805.95), SIMDE_FLOAT32_C(  -407.95), SIMDE_FLOAT32_C(   706.50),
+        SIMDE_FLOAT32_C(  -190.09), SIMDE_FLOAT32_C(  -190.09), SIMDE_FLOAT32_C(  -913.09), SIMDE_FLOAT32_C(  -913.09) } },
+    { {  INT32_C(  1224533505), -INT32_C(  1591287849),  INT32_C(   855043080),  INT32_C(  1808961583),  INT32_C(  1902064102),  INT32_C(   170571134), -INT32_C(  1613549715), -INT32_C(  1450518360) },
+      { SIMDE_FLOAT32_C(   408.50), SIMDE_FLOAT32_C(   -14.37), SIMDE_FLOAT32_C(  -881.14), SIMDE_FLOAT32_C(  -158.53),
+        SIMDE_FLOAT32_C(  -555.96), SIMDE_FLOAT32_C(  -372.25), SIMDE_FLOAT32_C(    52.25), SIMDE_FLOAT32_C(   336.52) },
+      { SIMDE_FLOAT32_C(   -14.37), SIMDE_FLOAT32_C(   336.52), SIMDE_FLOAT32_C(   408.50), SIMDE_FLOAT32_C(   336.52),
+        SIMDE_FLOAT32_C(    52.25), SIMDE_FLOAT32_C(    52.25), SIMDE_FLOAT32_C(  -372.25), SIMDE_FLOAT32_C(   408.50) } },
+    { {  INT32_C(   866201091), -INT32_C(  1533119554),  INT32_C(   588709284),  INT32_C(   523059378),  INT32_C(   398328175), -INT32_C(  1732228903),  INT32_C(   909030095), -INT32_C(   844798263) },
+      { SIMDE_FLOAT32_C(  -302.01), SIMDE_FLOAT32_C(  -152.55), SIMDE_FLOAT32_C(  -912.35), SIMDE_FLOAT32_C(  -238.55),
+        SIMDE_FLOAT32_C(   120.82), SIMDE_FLOAT32_C(  -497.21), SIMDE_FLOAT32_C(  -204.10), SIMDE_FLOAT32_C(  -635.30) },
+      { SIMDE_FLOAT32_C(  -238.55), SIMDE_FLOAT32_C(  -204.10), SIMDE_FLOAT32_C(   120.82), SIMDE_FLOAT32_C(  -912.35),
+        SIMDE_FLOAT32_C(  -635.30), SIMDE_FLOAT32_C(  -152.55), SIMDE_FLOAT32_C(  -635.30), SIMDE_FLOAT32_C(  -152.55) } },
+    { {  INT32_C(  1300303259), -INT32_C(  1133727923), -INT32_C(  1982584144),  INT32_C(  1109562482),  INT32_C(   276320326),  INT32_C(  1256005046),  INT32_C(   496885091),  INT32_C(   377263227) },
+      { SIMDE_FLOAT32_C(  -910.92), SIMDE_FLOAT32_C(    41.77), SIMDE_FLOAT32_C(  -614.35), SIMDE_FLOAT32_C(   -51.13),
+        SIMDE_FLOAT32_C(   612.93), SIMDE_FLOAT32_C(   716.33), SIMDE_FLOAT32_C(  -728.68), SIMDE_FLOAT32_C(  -652.05) },
+      { SIMDE_FLOAT32_C(   -51.13), SIMDE_FLOAT32_C(   716.33), SIMDE_FLOAT32_C(  -910.92), SIMDE_FLOAT32_C(  -614.35),
+        SIMDE_FLOAT32_C(  -728.68), SIMDE_FLOAT32_C(  -728.68), SIMDE_FLOAT32_C(   -51.13), SIMDE_FLOAT32_C(   -51.13) } },
+    { {  INT32_C(  1810267897),  INT32_C(  1504512019),  INT32_C(   258549080), -INT32_C(  1504098750), -INT32_C(  1631324637),  INT32_C(   733233034), -INT32_C(   384231619), -INT32_C(   549010202) },
+      { SIMDE_FLOAT32_C(  -556.70), SIMDE_FLOAT32_C(  -412.20), SIMDE_FLOAT32_C(  -513.11), SIMDE_FLOAT32_C(   461.90),
+        SIMDE_FLOAT32_C(  -797.86), SIMDE_FLOAT32_C(  -380.85), SIMDE_FLOAT32_C(  -514.89), SIMDE_FLOAT32_C(  -402.18) },
+      { SIMDE_FLOAT32_C(  -412.20), SIMDE_FLOAT32_C(   461.90), SIMDE_FLOAT32_C(  -556.70), SIMDE_FLOAT32_C(  -513.11),
+        SIMDE_FLOAT32_C(   461.90), SIMDE_FLOAT32_C(  -513.11), SIMDE_FLOAT32_C(  -380.85), SIMDE_FLOAT32_C(  -514.89) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256i idx = simde_mm256_loadu_epi32(test_vec[i].idx);
+    simde__m256 a = simde_mm256_loadu_ps(test_vec[i].a);
+    simde__m256 r = simde_mm256_permutexvar_ps(idx, a);
+    simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[i].r), 1);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__m256i idx = simde_test_x86_random_i32x8();
+    simde__m256 a = simde_test_x86_random_f32x8(SIMDE_FLOAT64_C(-1000.0), SIMDE_FLOAT64_C(1000.0));
+    simde__m256 r = simde_mm256_permutexvar_ps(idx, a);
+
+    simde_test_x86_write_i32x8(2, idx, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_f32x8(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x8(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_mask_permutexvar_ps(SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde_float32 src[8];
+    const simde__mmask8 k;
+    const int32_t idx[8];
+    const simde_float32 a[8];
+    const simde_float32 r[8];
+  } test_vec[] = {
+    { { SIMDE_FLOAT32_C(    -2.13), SIMDE_FLOAT32_C(  -740.45), SIMDE_FLOAT32_C(   -30.00), SIMDE_FLOAT32_C(   497.57),
+        SIMDE_FLOAT32_C(   218.90), SIMDE_FLOAT32_C(  -632.82), SIMDE_FLOAT32_C(  -495.65), SIMDE_FLOAT32_C(   553.04) },
+      UINT8_C(  9),
+      { -INT32_C(   806795204),  INT32_C(   982691045), -INT32_C(   417966830), -INT32_C(    75699523),  INT32_C(   241326701),  INT32_C(  1998051949), -INT32_C(  2006706479), -INT32_C(   795763308) },
+      { SIMDE_FLOAT32_C(  -328.16), SIMDE_FLOAT32_C(  -360.93), SIMDE_FLOAT32_C(   935.10), SIMDE_FLOAT32_C(  -329.17),
+        SIMDE_FLOAT32_C(  -862.40), SIMDE_FLOAT32_C(   392.03), SIMDE_FLOAT32_C(   803.30), SIMDE_FLOAT32_C(    62.01) },
+      { SIMDE_FLOAT32_C(  -862.40), SIMDE_FLOAT32_C(  -740.45), SIMDE_FLOAT32_C(   -30.00), SIMDE_FLOAT32_C(   392.03),
+        SIMDE_FLOAT32_C(   218.90), SIMDE_FLOAT32_C(  -632.82), SIMDE_FLOAT32_C(  -495.65), SIMDE_FLOAT32_C(   553.04) } },
+    { { SIMDE_FLOAT32_C(    71.98), SIMDE_FLOAT32_C(   655.74), SIMDE_FLOAT32_C(  -706.91), SIMDE_FLOAT32_C(  -789.78),
+        SIMDE_FLOAT32_C(  -487.45), SIMDE_FLOAT32_C(   980.26), SIMDE_FLOAT32_C(   767.91), SIMDE_FLOAT32_C(  -611.76) },
+      UINT8_C(247),
+      {  INT32_C(  2070184353), -INT32_C(  1370694504), -INT32_C(   565979840), -INT32_C(   507243674), -INT32_C(   452423757), -INT32_C(  1335082604), -INT32_C(    21581727), -INT32_C(  1862981137) },
+      { SIMDE_FLOAT32_C(   667.85), SIMDE_FLOAT32_C(   476.90), SIMDE_FLOAT32_C(  -690.52), SIMDE_FLOAT32_C(  -472.40),
+        SIMDE_FLOAT32_C(  -496.30), SIMDE_FLOAT32_C(     3.74), SIMDE_FLOAT32_C(   619.63), SIMDE_FLOAT32_C(  -839.28) },
+      { SIMDE_FLOAT32_C(   476.90), SIMDE_FLOAT32_C(   667.85), SIMDE_FLOAT32_C(   667.85), SIMDE_FLOAT32_C(  -789.78),
+        SIMDE_FLOAT32_C(  -472.40), SIMDE_FLOAT32_C(  -496.30), SIMDE_FLOAT32_C(   476.90), SIMDE_FLOAT32_C(  -839.28) } },
+    { { SIMDE_FLOAT32_C(   681.67), SIMDE_FLOAT32_C(   448.27), SIMDE_FLOAT32_C(  -999.01), SIMDE_FLOAT32_C(   -32.65),
+        SIMDE_FLOAT32_C(   871.55), SIMDE_FLOAT32_C(  -486.89), SIMDE_FLOAT32_C(  -107.91), SIMDE_FLOAT32_C(  -770.07) },
+      UINT8_C(167),
+      { -INT32_C(  1103371907), -INT32_C(    31462579), -INT32_C(   890430047),  INT32_C(  1819639314), -INT32_C(   492717942), -INT32_C(   569370711), -INT32_C(  2094619541), -INT32_C(  1775623911) },
+      { SIMDE_FLOAT32_C(   366.81), SIMDE_FLOAT32_C(   789.20), SIMDE_FLOAT32_C(   755.17), SIMDE_FLOAT32_C(  -830.47),
+        SIMDE_FLOAT32_C(   113.51), SIMDE_FLOAT32_C(   251.44), SIMDE_FLOAT32_C(  -995.14), SIMDE_FLOAT32_C(   592.37) },
+      { SIMDE_FLOAT32_C(   251.44), SIMDE_FLOAT32_C(   251.44), SIMDE_FLOAT32_C(   789.20), SIMDE_FLOAT32_C(   -32.65),
+        SIMDE_FLOAT32_C(   871.55), SIMDE_FLOAT32_C(   789.20), SIMDE_FLOAT32_C(  -107.91), SIMDE_FLOAT32_C(   789.20) } },
+    { { SIMDE_FLOAT32_C(  -854.58), SIMDE_FLOAT32_C(  -359.30), SIMDE_FLOAT32_C(   614.00), SIMDE_FLOAT32_C(   -99.17),
+        SIMDE_FLOAT32_C(  -491.72), SIMDE_FLOAT32_C(   303.49), SIMDE_FLOAT32_C(   133.14), SIMDE_FLOAT32_C(  -314.65) },
+      UINT8_C(234),
+      { -INT32_C(   929814863), -INT32_C(   634097098), -INT32_C(  1175210088),  INT32_C(  1220315618),  INT32_C(  1352207581), -INT32_C(  1780380582),  INT32_C(  2085586250),  INT32_C(  1164415636) },
+      { SIMDE_FLOAT32_C(  -573.04), SIMDE_FLOAT32_C(  -528.28), SIMDE_FLOAT32_C(  -222.24), SIMDE_FLOAT32_C(   155.58),
+        SIMDE_FLOAT32_C(   114.00), SIMDE_FLOAT32_C(  -558.66), SIMDE_FLOAT32_C(   714.03), SIMDE_FLOAT32_C(   -87.19) },
+      { SIMDE_FLOAT32_C(  -854.58), SIMDE_FLOAT32_C(   714.03), SIMDE_FLOAT32_C(   614.00), SIMDE_FLOAT32_C(  -222.24),
+        SIMDE_FLOAT32_C(  -491.72), SIMDE_FLOAT32_C(  -222.24), SIMDE_FLOAT32_C(  -222.24), SIMDE_FLOAT32_C(   114.00) } },
+    { { SIMDE_FLOAT32_C(   515.75), SIMDE_FLOAT32_C(    -5.60), SIMDE_FLOAT32_C(  -901.90), SIMDE_FLOAT32_C(   697.05),
+        SIMDE_FLOAT32_C(   951.14), SIMDE_FLOAT32_C(  -349.81), SIMDE_FLOAT32_C(   667.55), SIMDE_FLOAT32_C(  -336.95) },
+      UINT8_C(134),
+      {  INT32_C(  1239446205), -INT32_C(   661424557),  INT32_C(  1466765509),  INT32_C(  1913696887),  INT32_C(    48234176), -INT32_C(  2097355577),  INT32_C(   499636130), -INT32_C(  1197217541) },
+      { SIMDE_FLOAT32_C(   433.29), SIMDE_FLOAT32_C(   143.53), SIMDE_FLOAT32_C(  -821.67), SIMDE_FLOAT32_C(  -831.55),
+        SIMDE_FLOAT32_C(  -391.00), SIMDE_FLOAT32_C(   896.63), SIMDE_FLOAT32_C(   913.22), SIMDE_FLOAT32_C(   949.92) },
+      { SIMDE_FLOAT32_C(   515.75), SIMDE_FLOAT32_C(  -831.55), SIMDE_FLOAT32_C(   896.63), SIMDE_FLOAT32_C(   697.05),
+        SIMDE_FLOAT32_C(   951.14), SIMDE_FLOAT32_C(  -349.81), SIMDE_FLOAT32_C(   667.55), SIMDE_FLOAT32_C(  -831.55) } },
+    { { SIMDE_FLOAT32_C(   208.80), SIMDE_FLOAT32_C(   800.73), SIMDE_FLOAT32_C(   851.65), SIMDE_FLOAT32_C(   635.40),
+        SIMDE_FLOAT32_C(   700.13), SIMDE_FLOAT32_C(  -819.67), SIMDE_FLOAT32_C(  -466.27), SIMDE_FLOAT32_C(  -622.72) },
+      UINT8_C( 37),
+      {  INT32_C(  1374447981),  INT32_C(  1022586469),  INT32_C(   506925109),  INT32_C(   947449780), -INT32_C(  2043533583), -INT32_C(  1607732819),  INT32_C(   776357639),  INT32_C(  1112780245) },
+      { SIMDE_FLOAT32_C(  -104.78), SIMDE_FLOAT32_C(   475.03), SIMDE_FLOAT32_C(  -319.30), SIMDE_FLOAT32_C(    25.24),
+        SIMDE_FLOAT32_C(  -469.36), SIMDE_FLOAT32_C(   175.13), SIMDE_FLOAT32_C(   486.55), SIMDE_FLOAT32_C(   730.10) },
+      { SIMDE_FLOAT32_C(   175.13), SIMDE_FLOAT32_C(   800.73), SIMDE_FLOAT32_C(   175.13), SIMDE_FLOAT32_C(   635.40),
+        SIMDE_FLOAT32_C(   700.13), SIMDE_FLOAT32_C(   175.13), SIMDE_FLOAT32_C(  -466.27), SIMDE_FLOAT32_C(  -622.72) } },
+    { { SIMDE_FLOAT32_C(   342.99), SIMDE_FLOAT32_C(   946.71), SIMDE_FLOAT32_C(   736.44), SIMDE_FLOAT32_C(  -443.90),
+        SIMDE_FLOAT32_C(   157.26), SIMDE_FLOAT32_C(   176.08), SIMDE_FLOAT32_C(   -87.27), SIMDE_FLOAT32_C(  -453.86) },
+      UINT8_C(160),
+      { -INT32_C(  1504881227), -INT32_C(   944902784), -INT32_C(   509813964),  INT32_C(  1844960814), -INT32_C(   132418959),  INT32_C(   412089897),  INT32_C(  2029509375),  INT32_C(   303613533) },
+      { SIMDE_FLOAT32_C(   -62.11), SIMDE_FLOAT32_C(  -141.29), SIMDE_FLOAT32_C(   668.54), SIMDE_FLOAT32_C(   263.85),
+        SIMDE_FLOAT32_C(  -513.77), SIMDE_FLOAT32_C(   229.65), SIMDE_FLOAT32_C(   719.52), SIMDE_FLOAT32_C(   135.92) },
+      { SIMDE_FLOAT32_C(   342.99), SIMDE_FLOAT32_C(   946.71), SIMDE_FLOAT32_C(   736.44), SIMDE_FLOAT32_C(  -443.90),
+        SIMDE_FLOAT32_C(   157.26), SIMDE_FLOAT32_C(  -141.29), SIMDE_FLOAT32_C(   -87.27), SIMDE_FLOAT32_C(   229.65) } },
+    { { SIMDE_FLOAT32_C(   738.29), SIMDE_FLOAT32_C(  -161.36), SIMDE_FLOAT32_C(   185.05), SIMDE_FLOAT32_C(  -140.93),
+        SIMDE_FLOAT32_C(   167.26), SIMDE_FLOAT32_C(  -870.60), SIMDE_FLOAT32_C(   454.87), SIMDE_FLOAT32_C(  -823.43) },
+      UINT8_C(209),
+      { -INT32_C(   151369480), -INT32_C(  1309338665), -INT32_C(   804360950), -INT32_C(   336846714),  INT32_C(  1044285912), -INT32_C(   310393363), -INT32_C(  1932726739), -INT32_C(  1017307701) },
+      { SIMDE_FLOAT32_C(    89.09), SIMDE_FLOAT32_C(   802.57), SIMDE_FLOAT32_C(  -187.53), SIMDE_FLOAT32_C(   -22.46),
+        SIMDE_FLOAT32_C(  -239.46), SIMDE_FLOAT32_C(  -156.70), SIMDE_FLOAT32_C(   -50.47), SIMDE_FLOAT32_C(  -721.38) },
+      { SIMDE_FLOAT32_C(    89.09), SIMDE_FLOAT32_C(  -161.36), SIMDE_FLOAT32_C(   185.05), SIMDE_FLOAT32_C(  -140.93),
+        SIMDE_FLOAT32_C(    89.09), SIMDE_FLOAT32_C(  -870.60), SIMDE_FLOAT32_C(  -156.70), SIMDE_FLOAT32_C(   -22.46) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256 src = simde_mm256_loadu_ps(test_vec[i].src);
+    simde__m256i idx = simde_mm256_loadu_epi32(test_vec[i].idx);
+    simde__m256 a = simde_mm256_loadu_ps(test_vec[i].a);
+    simde__m256 r = simde_mm256_mask_permutexvar_ps(src, test_vec[i].k, idx, a);
+    simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[i].r), 1);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__m256 src = simde_test_x86_random_f32x8(SIMDE_FLOAT64_C(-1000.0), SIMDE_FLOAT64_C(1000.0));
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m256i idx = simde_test_x86_random_i32x8();
+    simde__m256 a = simde_test_x86_random_f32x8(SIMDE_FLOAT64_C(-1000.0), SIMDE_FLOAT64_C(1000.0));
+    simde__m256 r = simde_mm256_mask_permutexvar_ps(src, k, idx, a);
+
+    simde_test_x86_write_f32x8(2, src, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x8(2, idx, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x8(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x8(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_maskz_permutexvar_ps(SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  const struct {
+    const simde__mmask8 k;
+    const int32_t idx[8];
+    const simde_float32 a[8];
+    const simde_float32 r[8];
+  } test_vec[8] = {
+    { UINT8_C( 70),
+      { -INT32_C(   451449221),  INT32_C(   638291178), -INT32_C(  1683155451),  INT32_C(  1763935515), -INT32_C(  1057453855),  INT32_C(   204563644),  INT32_C(   641593323),  INT32_C(  1265392848) },
+      { SIMDE_FLOAT32_C(  -564.32), SIMDE_FLOAT32_C(  -573.78), SIMDE_FLOAT32_C(   632.73), SIMDE_FLOAT32_C(   965.26),
+        SIMDE_FLOAT32_C(   840.88), SIMDE_FLOAT32_C(   -46.96), SIMDE_FLOAT32_C(   249.88), SIMDE_FLOAT32_C(   458.77) },
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   632.73), SIMDE_FLOAT32_C(   -46.96), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   965.26), SIMDE_FLOAT32_C(     0.00) } },
+    { UINT8_C( 81),
+      {  INT32_C(   225292424),  INT32_C(  1542379219),  INT32_C(   840478414), -INT32_C(   836950817), -INT32_C(  1113701279),  INT32_C(   881322416),  INT32_C(  1413692441), -INT32_C(  1616488425) },
+      { SIMDE_FLOAT32_C(  -724.50), SIMDE_FLOAT32_C(    39.62), SIMDE_FLOAT32_C(   808.79), SIMDE_FLOAT32_C(  -136.37),
+        SIMDE_FLOAT32_C(   834.12), SIMDE_FLOAT32_C(   972.60), SIMDE_FLOAT32_C(  -952.76), SIMDE_FLOAT32_C(  -309.86) },
+      { SIMDE_FLOAT32_C(  -724.50), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(    39.62), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(    39.62), SIMDE_FLOAT32_C(     0.00) } },
+    { UINT8_C( 73),
+      {  INT32_C(  1932061263),  INT32_C(  1272248071),  INT32_C(  2147258773),  INT32_C(  1436037145), -INT32_C(   865211021), -INT32_C(  1496052589),  INT32_C(  1401925817),  INT32_C(   932988648) },
+      { SIMDE_FLOAT32_C(   220.62), SIMDE_FLOAT32_C(  -582.61), SIMDE_FLOAT32_C(   -37.83), SIMDE_FLOAT32_C(   328.48),
+        SIMDE_FLOAT32_C(  -771.08), SIMDE_FLOAT32_C(  -354.91), SIMDE_FLOAT32_C(   -96.61), SIMDE_FLOAT32_C(  -734.93) },
+      { SIMDE_FLOAT32_C(  -734.93), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -582.61),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -582.61), SIMDE_FLOAT32_C(     0.00) } },
+    { UINT8_C( 17),
+      { -INT32_C(  1356148609),  INT32_C(  1445166953), -INT32_C(   102109204),  INT32_C(  1957859267),  INT32_C(  1683752222),  INT32_C(  1737855906), -INT32_C(  1104949954), -INT32_C(   791710640) },
+      { SIMDE_FLOAT32_C(   550.64), SIMDE_FLOAT32_C(   877.66), SIMDE_FLOAT32_C(   194.12), SIMDE_FLOAT32_C(    80.38),
+        SIMDE_FLOAT32_C(   546.98), SIMDE_FLOAT32_C(  -364.43), SIMDE_FLOAT32_C(  -575.59), SIMDE_FLOAT32_C(   188.77) },
+      { SIMDE_FLOAT32_C(   188.77), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(  -575.59), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00) } },
+    { UINT8_C(145),
+      {  INT32_C(  2085969645),  INT32_C(   362465552), -INT32_C(  1195901403),  INT32_C(  1626807955), -INT32_C(  1229867711),  INT32_C(  2113634692), -INT32_C(  1544181504), -INT32_C(  1707844947) },
+      { SIMDE_FLOAT32_C(   669.10), SIMDE_FLOAT32_C(    62.35), SIMDE_FLOAT32_C(   322.64), SIMDE_FLOAT32_C(   659.77),
+        SIMDE_FLOAT32_C(  -547.87), SIMDE_FLOAT32_C(   -17.71), SIMDE_FLOAT32_C(  -408.07), SIMDE_FLOAT32_C(   710.86) },
+      { SIMDE_FLOAT32_C(   -17.71), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(    62.35), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   -17.71) } },
+    { UINT8_C(174),
+      { -INT32_C(  1270730603), -INT32_C(   587881945), -INT32_C(   731862189),  INT32_C(  1339415974),  INT32_C(   771520722),  INT32_C(   921015980),  INT32_C(  1552461484),  INT32_C(   554369164) },
+      { SIMDE_FLOAT32_C(  -536.25), SIMDE_FLOAT32_C(   201.89), SIMDE_FLOAT32_C(   308.61), SIMDE_FLOAT32_C(  -264.78),
+        SIMDE_FLOAT32_C(  -918.21), SIMDE_FLOAT32_C(    87.10), SIMDE_FLOAT32_C(   915.83), SIMDE_FLOAT32_C(   129.09) },
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   129.09), SIMDE_FLOAT32_C(  -264.78), SIMDE_FLOAT32_C(   915.83),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -918.21), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -918.21) } },
+    { UINT8_C(118),
+      {  INT32_C(  1880954771),  INT32_C(  1682074860), -INT32_C(    15634583),  INT32_C(    61622101), -INT32_C(   812709681),  INT32_C(  1627369491),  INT32_C(  1364219526),  INT32_C(   482841481) },
+      { SIMDE_FLOAT32_C(  -554.85), SIMDE_FLOAT32_C(   513.70), SIMDE_FLOAT32_C(  -876.79), SIMDE_FLOAT32_C(   468.50),
+        SIMDE_FLOAT32_C(  -252.10), SIMDE_FLOAT32_C(  -307.53), SIMDE_FLOAT32_C(   168.50), SIMDE_FLOAT32_C(  -616.11) },
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -252.10), SIMDE_FLOAT32_C(   513.70), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(  -616.11), SIMDE_FLOAT32_C(   468.50), SIMDE_FLOAT32_C(   168.50), SIMDE_FLOAT32_C(     0.00) } },
+    { UINT8_C( 62),
+      {  INT32_C(  1402190092),  INT32_C(  1847826021), -INT32_C(   696126939),  INT32_C(  1214046962), -INT32_C(   976048846),  INT32_C(  1500507764),  INT32_C(  1252656763),  INT32_C(   243819522) },
+      { SIMDE_FLOAT32_C(   673.48), SIMDE_FLOAT32_C(  -869.39), SIMDE_FLOAT32_C(   -10.67), SIMDE_FLOAT32_C(    -6.27),
+        SIMDE_FLOAT32_C(   502.41), SIMDE_FLOAT32_C(  -652.01), SIMDE_FLOAT32_C(   919.28), SIMDE_FLOAT32_C(  -434.77) },
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -652.01), SIMDE_FLOAT32_C(  -652.01), SIMDE_FLOAT32_C(   -10.67),
+        SIMDE_FLOAT32_C(   -10.67), SIMDE_FLOAT32_C(   502.41), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00) } },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    simde__m256i idx = simde_mm256_loadu_epi32(test_vec[i].idx);
+    simde__m256 a = simde_mm256_loadu_ps(test_vec[i].a);
+    simde__m256 r = simde_mm256_maskz_permutexvar_ps(test_vec[i].k, idx, a);
+    simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[i].r), 1);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m256i idx = simde_test_x86_random_i32x8();
+    simde__m256 a = simde_test_x86_random_f32x8(SIMDE_FLOAT64_C(-1000.0), SIMDE_FLOAT64_C(1000.0));
+    simde__m256 r = simde_mm256_maskz_permutexvar_ps(k, idx, a);
+
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_i32x8(2, idx, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x8(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x8(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
 
 static int
 test_simde_mm512_permutexvar_epi16 (SIMDE_MUNIT_TEST_ARGS) {
@@ -2803,6 +4898,38 @@ test_simde_mm512_maskz_permutexvar_ps(SIMDE_MUNIT_TEST_ARGS) {
 }
 
 SIMDE_TEST_FUNC_LIST_BEGIN
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_permutexvar_epi16)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_mask_permutexvar_epi16)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_maskz_permutexvar_epi16)
+
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_permutexvar_epi8)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_mask_permutexvar_epi8)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_maskz_permutexvar_epi8)
+
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_permutexvar_epi16)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_mask_permutexvar_epi16)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_maskz_permutexvar_epi16)
+
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_permutexvar_epi32)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_mask_permutexvar_epi32)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_maskz_permutexvar_epi32)
+
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_permutexvar_epi64)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_mask_permutexvar_epi64)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_maskz_permutexvar_epi64)
+
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_permutexvar_epi8)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_mask_permutexvar_epi8)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_maskz_permutexvar_epi8)
+
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_permutexvar_pd)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_mask_permutexvar_pd)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_maskz_permutexvar_pd)
+
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_permutexvar_ps)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_mask_permutexvar_ps)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_maskz_permutexvar_ps)
+
   SIMDE_TEST_FUNC_LIST_ENTRY(mm512_permutexvar_epi16)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm512_mask_permutexvar_epi16)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm512_maskz_permutexvar_epi16)


### PR DESCRIPTION
Add the following intrinsics to permutexvar.[ch] :-
- _mm_{,mask_,maskz_}permutexvar_epi{8,16}
- _mm256_{,mask_,maskz_}permutexvar_epi{8,16,32,64}
- _mm256_{,mask_,maskz_}permutexvar_{pd,ps}

Add AVX, SSE, NEON, Altivec and WASM translations
Note that the WASM translations currently only pass tests with -O1