### PR TITLE
Fix git_id when amalgamating from another git repo

### DIFF
--- a/amalgamate.py
+++ b/amalgamate.py
@@ -30,6 +30,11 @@ def amalgamate(filename, stream):
   full_path = os.path.realpath(os.path.realpath(filename))
   srcdir = os.path.dirname(full_path)
 
+  print('/* AUTOMATICALLY GENERATED FILE, DO NOT MODIFY */')
+
+  git_id = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=srcdir).decode().strip()
+  print("/* {:s} */".format(git_id))
+
   if full_path not in already_included:
     already_included.insert(-1, full_path)
     with open(filename) as input_file:
@@ -50,10 +55,5 @@ if len(sys.argv) != 2:
   sys.stderr.write("all '#include AMALGAMATE(file)' lines with copies of file.\n")
 
   sys.exit(1)
-
-print('/* AUTOMATICALLY GENERATED FILE, DO NOT MODIFY */')
-
-git_id = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
-print("/* {:s} */".format(git_id))
 
 amalgamate(sys.argv[1], sys.stdout)


### PR DESCRIPTION
To update the amalgamated SIMDe header included in Emscripten, we run a wrapper
script around amalgamate.py. Since this wrapper script is typically run from the
Emscripten directory, the git id picked up by amalgamate.py was Emscripten's git
id rather than SIMDe's git id as intended. This PR changes the working directory
of the git command run by amalgamate.py so that it correctly reads SIMDe's git
id even when run from a different git repo.