### PR TITLE
common,X86,NEON: everything involving pd or si128 needs at least SSE2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - 'master'
       - 'ci/**'
       - '!ci/gha**'
+  pull_request:
+    branches:
+      - 'master'
 
 jobs:
   formatting:

--- a/simde/arm/neon/uzp1.h
+++ b/simde/arm/neon/uzp1.h
@@ -427,7 +427,7 @@ simde_vuzp1q_s32(simde_int32x4_t a, simde_int32x4_t b) {
     return t.val[0];
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v32x4_shuffle(a, b, 0, 2, 4, 6);
-  #elif defined(SIMDE_X86_SSE_NATIVE)
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps(a), _mm_castsi128_ps(b), 0x88));
   #else
     simde_int32x4_private
@@ -573,7 +573,7 @@ simde_vuzp1q_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
     return t.val[0];
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v32x4_shuffle(a, b, 0, 2, 4, 6);
-  #elif defined(SIMDE_X86_SSE_NATIVE)
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps(a), _mm_castsi128_ps(b), 0x88));
   #else
     simde_uint32x4_private

--- a/simde/arm/neon/uzp2.h
+++ b/simde/arm/neon/uzp2.h
@@ -429,7 +429,7 @@ simde_vuzp2q_s32(simde_int32x4_t a, simde_int32x4_t b) {
     return t.val[1];
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v32x4_shuffle(a, b, 1, 3, 5, 7);
-  #elif defined(SIMDE_X86_SSE_NATIVE)
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps(a), _mm_castsi128_ps(b), 0xdd));
   #else
     simde_int32x4_private
@@ -576,7 +576,7 @@ simde_vuzp2q_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
     return t.val[1];
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v32x4_shuffle(a, b, 1, 3, 5, 7);
-  #elif defined(SIMDE_X86_SSE_NATIVE)
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps(a), _mm_castsi128_ps(b), 0xdd));
   #else
     simde_uint32x4_private

--- a/simde/simde-common.h
+++ b/simde/simde-common.h
@@ -496,7 +496,7 @@ typedef SIMDE_FLOAT32_TYPE simde_float32;
 #  define SIMDE_FLOAT64_TYPE double
 #  define SIMDE_FLOAT64_C(value) value
 #else
-#  define SIMDE_FLOAT32_C(value) ((SIMDE_FLOAT64_TYPE) value)
+#  define SIMDE_FLOAT64_C(value) ((SIMDE_FLOAT64_TYPE) value)
 #endif
 typedef SIMDE_FLOAT64_TYPE simde_float64;
 

--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -7290,7 +7290,7 @@ simde_mm_unpacklo_pd (simde__m128d a, simde__m128d b) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128d
 simde_x_mm_negate_pd(simde__m128d a) {
-  #if defined(SIMDE_X86_SSE_NATIVE)
+  #if defined(SIMDE_X86_SSE2_NATIVE)
     return simde_mm_xor_pd(a, _mm_set1_pd(SIMDE_FLOAT64_C(-0.0)));
   #else
     simde__m128d_private


### PR DESCRIPTION
Correct SSE to SSE2 in sse2.h, uzp1.h and uzp2.h
Also correct C&P error in simde-common.h