### PR TITLE
Workaround for GCC with missing NEON intrinsic

### DIFF
--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -2627,7 +2627,7 @@ simde_mm_cvtps_epi32 (simde__m128 a) {
 
     #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_FAST_CONVERSION_RANGE)
       r_.neon_i32 = vcvtnq_s32_f32(a_.neon_f32);
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_FAST_CONVERSION_RANGE) && defined(SIMDE_FAST_ROUND_TIES)
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_FAST_CONVERSION_RANGE) && defined(SIMDE_FAST_ROUND_TIES) && !defined(SIMDE_BUG_GCC_95399)
       r_.neon_i32 = vcvtnq_s32_f32(a_.neon_f32);
     #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && defined(SIMDE_FAST_CONVERSION_RANGE) && defined(SIMDE_FAST_ROUND_TIES)
       HEDLEY_DIAGNOSTIC_PUSH

--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -7238,8 +7238,8 @@ simde_mm_unpacklo_epi64 (simde__m128i a, simde__m128i b) {
       b_ = simde__m128i_to_private(b);
 
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      int64x1_t a_l = vget_low_s64(a_.i64);
-      int64x1_t b_l = vget_low_s64(b_.i64);
+      int64x1_t a_l = vget_low_s64(a_.neon_i64);
+      int64x1_t b_l = vget_low_s64(b_.neon_i64);
       r_.neon_i64 = vcombine_s64(a_l, b_l);
     #elif defined(SIMDE_SHUFFLE_VECTOR_)
       r_.i64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.i64, b_.i64, 0, 2);


### PR DESCRIPTION
Should fix GCC A32 without `vcvtnq_s32_f32` intrinsic.
As seen also in `simde_mm_cvt_ss2si`