### PR TITLE
NEON, SSSE3, AVX512: More Integer Absolute Value Implementations

### DIFF
--- a/simde/arm/neon/abs.h
+++ b/simde/arm/neon/abs.h
@@ -275,6 +275,8 @@ simde_vabsq_s8(simde_int8x16_t a) {
     return vabsq_s8(a);
   #elif defined(SIMDE_X86_SSSE3_NATIVE)
     return _mm_abs_epi8(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_min_epu8(a, _mm_sub_epi8(_mm_setzero_si128(), a));
   #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_abs(a);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
@@ -309,6 +311,8 @@ simde_vabsq_s16(simde_int16x8_t a) {
     return vabsq_s16(a);
   #elif defined(SIMDE_X86_SSSE3_NATIVE)
     return _mm_abs_epi16(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_max_epi16(a, _mm_sub_epi16(_mm_setzero_si128(), a));
   #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_abs(a);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
@@ -343,6 +347,9 @@ simde_vabsq_s32(simde_int32x4_t a) {
     return vabsq_s32(a);
   #elif defined(SIMDE_X86_SSSE3_NATIVE)
     return _mm_abs_epi32(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    const __m128i m = _mm_cmpgt_epi32(_mm_setzero_si128(), a);
+    return _mm_sub_epi32(_mm_xor_si128(a, m), m);
   #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_abs(a);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
@@ -377,8 +384,15 @@ simde_vabsq_s64(simde_int64x2_t a) {
     return vabsq_s64(a);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vbslq_s64(vreinterpretq_u64_s64(vshrq_n_s64(a, 63)), vsubq_s64(vdupq_n_s64(0), a), a);
+  #elif defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_abs_epi64(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    const __m128i m = _mm_srai_epi32(_mm_shuffle_epi32(a, 0xF5), 31);
+    return _mm_sub_epi64(_mm_xor_si128(a, m), m);
   #elif defined(SIMDE_POWER_ALTIVEC_P64_NATIVE) && !defined(HEDLEY_IBM_VERSION)
     return vec_abs(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i64x2_abs(a);
   #else
     simde_int64x2_private
       r_,

--- a/simde/arm/neon/abs.h
+++ b/simde/arm/neon/abs.h
@@ -391,7 +391,7 @@ simde_vabsq_s64(simde_int64x2_t a) {
     return _mm_sub_epi64(_mm_xor_si128(a, m), m);
   #elif defined(SIMDE_POWER_ALTIVEC_P64_NATIVE) && !defined(HEDLEY_IBM_VERSION)
     return vec_abs(a);
-  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE) && 0
     return wasm_i64x2_abs(a);
   #else
     simde_int64x2_private

--- a/simde/x86/avx512/abs.h
+++ b/simde/x86/avx512/abs.h
@@ -125,6 +125,9 @@ simde__m128i
 simde_mm_abs_epi64(simde__m128i a) {
   #if defined(SIMDE_X86_AVX512VL_NATIVE)
     return _mm_abs_epi64(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    const __m128i m = _mm_srai_epi32(_mm_shuffle_epi32(a, 0xF5), 31);
+    return _mm_sub_epi64(_mm_xor_si128(a, m), m);
   #else
     simde__m128i_private
       r_,
@@ -132,8 +135,13 @@ simde_mm_abs_epi64(simde__m128i a) {
 
     #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
       r_.neon_i64 = vabsq_s64(a_.neon_i64);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      const int64x2_t m = vshrq_n_s64(a_.neon_i64, 63);
+      r_.neon_i64 = vsubq_s64(veorq_s64(a_.neon_i64, m), m);
     #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && !defined(HEDLEY_IBM_VERSION)
       r_.altivec_i64 = vec_abs(a_.altivec_i64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i64x2_abs(a_.wasm_v128);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {

--- a/simde/x86/avx512/abs.h
+++ b/simde/x86/avx512/abs.h
@@ -140,7 +140,7 @@ simde_mm_abs_epi64(simde__m128i a) {
       r_.neon_i64 = vsubq_s64(veorq_s64(a_.neon_i64, m), m);
     #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && !defined(HEDLEY_IBM_VERSION)
       r_.altivec_i64 = vec_abs(a_.altivec_i64);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE) && 0
       r_.wasm_v128 = wasm_i64x2_abs(a_.wasm_v128);
     #else
       SIMDE_VECTORIZE

--- a/simde/x86/ssse3.h
+++ b/simde/x86/ssse3.h
@@ -38,6 +38,8 @@ simde__m128i
 simde_mm_abs_epi8 (simde__m128i a) {
   #if defined(SIMDE_X86_SSSE3_NATIVE)
     return _mm_abs_epi8(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_min_epu8(a, _mm_sub_epi8(_mm_setzero_si128(), a));
   #else
     simde__m128i_private
       r_,
@@ -47,6 +49,8 @@ simde_mm_abs_epi8 (simde__m128i a) {
       r_.neon_i8 = vabsq_s8(a_.neon_i8);
     #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
       r_.altivec_i8 = vec_abs(a_.altivec_i8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x16_abs(a_.wasm_v128);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
@@ -66,6 +70,8 @@ simde__m128i
 simde_mm_abs_epi16 (simde__m128i a) {
   #if defined(SIMDE_X86_SSSE3_NATIVE)
     return _mm_abs_epi16(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_max_epi16(a, _mm_sub_epi16(_mm_setzero_si128(), a));
   #else
     simde__m128i_private
       r_,
@@ -75,6 +81,8 @@ simde_mm_abs_epi16 (simde__m128i a) {
       r_.neon_i16 = vabsq_s16(a_.neon_i16);
     #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
       r_.altivec_i16 = vec_abs(a_.altivec_i16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_abs(a_.wasm_v128);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
@@ -94,6 +102,9 @@ simde__m128i
 simde_mm_abs_epi32 (simde__m128i a) {
   #if defined(SIMDE_X86_SSSE3_NATIVE)
     return _mm_abs_epi32(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    const __m128i m = _mm_cmpgt_epi32(_mm_setzero_si128(), a);
+    return _mm_sub_epi32(_mm_xor_si128(a, m), m);
   #else
     simde__m128i_private
       r_,
@@ -103,6 +114,8 @@ simde_mm_abs_epi32 (simde__m128i a) {
       r_.neon_i32 = vabsq_s32(a_.neon_i32);
     #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
       r_.altivec_i32 = vec_abs(a_.altivec_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_abs(a_.wasm_v128);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {


### PR DESCRIPTION
Add SSE2 implementations and sometimes add WASM_SIMD128, AVX512VL, or ARMv7 NEON implementations.