### PR TITLE
fix apple silicon gcc-10 requiring -flax-vector-conversions to compile

### DIFF
--- a/simde/x86/sse4.1.h
+++ b/simde/x86/sse4.1.h
@@ -321,7 +321,7 @@ simde_x_mm_blendv_epi64 (simde__m128i a, simde__m128i b, simde__m128i mask) {
       mask_ = simde__m128i_to_private(mask);
 
     #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      mask_.u64 = vcltq_s64(mask_.i64, vdupq_n_s64(UINT64_C(0)));
+      mask_.neon_u64 = vcltq_s64(mask_.neon_i64, vdupq_n_s64(UINT64_C(0)));
       r_.neon_i64 = vbslq_s64(mask_.neon_u64, b_.neon_i64, a_.neon_i64);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       v128_t m = wasm_i64x2_shr(mask_.wasm_v128, 63);


### PR DESCRIPTION
I finally have access to an apple silicon machine. MMseqs2 compiled without much issues on clang however it needed this small fix to compile on homebrew gcc-10 without having to add `-flax-vector-conversions`.