### PR TITLE
docker: fix script exiting bug

### DIFF
--- a/docker/simde-dev.sh
+++ b/docker/simde-dev.sh
@@ -9,6 +9,12 @@ VOLUME_OPTIONS=""
 CAPABILITIES=""
 RELEASE="testing"
 
+if [ "$(basename "${DOCKER}")" = "podman" ]; then
+  IS_DOCKER=false
+else
+  IS_DOCKER=true
+fi
+
 if [ "${OSTYPE}" == "linux-gnu" ] && [ "$(basename "${DOCKER}")" = "podman" ]; then
   CAPABILITIES="--cap-add=CAP_SYS_PTRACE";
 fi
@@ -22,7 +28,24 @@ IMAGE_NAME="simde-dev-${RELEASE}"
 # (Re)build image
 # We only do this if the current image is older than a week (if jq is installed)
 BUILD_IMAGE=auto
-if command -v jq >/dev/null; then
+if [ "$IS_DOCKER" = true ]; then
+  BUILD_CUTOFF_TIME="$(expr $(date +%s) - \( 60 \* 60 \* 24 \* 7 \))"
+  DATE="$(docker images "${IMAGE_NAME}" --format '{{ .CreatedAt }}' | awk '{ print $1 " " $2 }')"
+
+  if [ "$(uname)" == "Darwin" ]; then
+    CURRENT_IMAGE_CREATED="$(date -jf "%Y-%m-%d %H:%M:%S" "$DATE" +%s)"
+  else
+    CURRENT_IMAGE_CREATED="$(date +"%s" -d "$DATE")"
+  fi
+
+  if [ -z "${CURRENT_IMAGE_CREATED}" ]; then
+    BUILD_IMAGE=y
+  elif [ ${CURRENT_IMAGE_CREATED} -lt ${BUILD_CUTOFF_TIME} ]; then
+    BUILD_IMAGE=y
+  else
+    BUILD_IMAGE=n
+  fi
+elif command -v jq >/dev/null; then
   BUILD_CUTOFF_TIME="$(expr $(date +%s) - \( 60 \* 60 \* 24 \* 7 \))"
   CURRENT_IMAGE_CREATED="$(${DOCKER} images "${IMAGE_NAME}" --format json | jq '.[].Created')"
 

--- a/docker/simde-dev.sh
+++ b/docker/simde-dev.sh
@@ -22,8 +22,7 @@ IMAGE_NAME="simde-dev-${RELEASE}"
 # (Re)build image
 # We only do this if the current image is older than a week (if jq is installed)
 BUILD_IMAGE=auto
-command -v jq >/dev/null
-if [ 0 = $? ]; then
+if command -v jq >/dev/null; then
   BUILD_CUTOFF_TIME="$(expr $(date +%s) - \( 60 \* 60 \* 24 \* 7 \))"
   CURRENT_IMAGE_CREATED="$(${DOCKER} images "${IMAGE_NAME}" --format json | jq '.[].Created')"
 


### PR DESCRIPTION
In the shebang on line 1, the "-e" flag is passed. Which causes the script to terminate if any pipeline exits with a non-zero status. Because of this, the script always terminates on line 25 when jq is not installed. Hence never reaching the if/else block on line 26. 

Committing a minor change which allows checking for jq while retaining the -e flag.