### PR TITLE
docker: skip date check when building image for the first time

### DIFF
--- a/docker/simde-dev.sh
+++ b/docker/simde-dev.sh
@@ -38,7 +38,7 @@ if [ "$IS_DOCKER" = true ]; then
     CURRENT_IMAGE_CREATED="$(date +"%s" -d "$DATE")"
   fi
 
-  if [ -z "${CURRENT_IMAGE_CREATED}" ]; then
+  if [[ -z "${CURRENT_IMAGE_CREATED}" || -z "${DATE}" ]]; then
     BUILD_IMAGE=y
   elif [ ${CURRENT_IMAGE_CREATED} -lt ${BUILD_CUTOFF_TIME} ]; then
     BUILD_IMAGE=y


### PR DESCRIPTION
The script was still checking for the date even if simde-dev-testing did not exist.
This would result in the DATE string being empty and BUILD_IMAGE always evaluating to 'n'.
This is fixed by adding a non-empty check for DATE.