### PR TITLE
neon/st2,st1: use zip + st1 to implement st2

### DIFF
--- a/simde/arm/neon/st1.h
+++ b/simde/arm/neon/st1.h
@@ -192,7 +192,11 @@ simde_vst1q_f32(simde_float32_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_float32x4_t va
     vec_st(val, 0, ptr);
   #else
     simde_float32x4_private val_ = simde_float32x4_to_private(val);
-    simde_memcpy(ptr, &val_, sizeof(val_));
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      wasm_v128_store(ptr, val_.v128);
+    #else
+      simde_memcpy(ptr, &val_, sizeof(val_));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -207,7 +211,11 @@ simde_vst1q_f64(simde_float64_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_float64x2_t va
     vst1q_f64(ptr, val);
   #else
     simde_float64x2_private val_ = simde_float64x2_to_private(val);
-    simde_memcpy(ptr, &val_, sizeof(val_));
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      wasm_v128_store(ptr, val_.v128);
+    #else
+      simde_memcpy(ptr, &val_, sizeof(val_));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
@@ -224,7 +232,11 @@ simde_vst1q_s8(int8_t ptr[HEDLEY_ARRAY_PARAM(16)], simde_int8x16_t val) {
     vec_st(val, 0, ptr);
   #else
     simde_int8x16_private val_ = simde_int8x16_to_private(val);
-    simde_memcpy(ptr, &val_, sizeof(val_));
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      wasm_v128_store(ptr, val_.v128);
+    #else
+      simde_memcpy(ptr, &val_, sizeof(val_));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -241,7 +253,11 @@ simde_vst1q_s16(int16_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_int16x8_t val) {
     vec_st(val, 0, ptr);
   #else
     simde_int16x8_private val_ = simde_int16x8_to_private(val);
-    simde_memcpy(ptr, &val_, sizeof(val_));
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      wasm_v128_store(ptr, val_.v128);
+    #else
+      simde_memcpy(ptr, &val_, sizeof(val_));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -258,7 +274,11 @@ simde_vst1q_s32(int32_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_int32x4_t val) {
     vec_st(val, 0, ptr);
   #else
     simde_int32x4_private val_ = simde_int32x4_to_private(val);
-    simde_memcpy(ptr, &val_, sizeof(val_));
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      wasm_v128_store(ptr, val_.v128);
+    #else
+      simde_memcpy(ptr, &val_, sizeof(val_));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -273,7 +293,11 @@ simde_vst1q_s64(int64_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_int64x2_t val) {
     vst1q_s64(ptr, val);
   #else
     simde_int64x2_private val_ = simde_int64x2_to_private(val);
-    simde_memcpy(ptr, &val_, sizeof(val_));
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      wasm_v128_store(ptr, val_.v128);
+    #else
+      simde_memcpy(ptr, &val_, sizeof(val_));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -290,7 +314,11 @@ simde_vst1q_u8(uint8_t ptr[HEDLEY_ARRAY_PARAM(16)], simde_uint8x16_t val) {
     vec_st(val, 0, ptr);
   #else
     simde_uint8x16_private val_ = simde_uint8x16_to_private(val);
-    simde_memcpy(ptr, &val_, sizeof(val_));
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      wasm_v128_store(ptr, val_.v128);
+    #else
+      simde_memcpy(ptr, &val_, sizeof(val_));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -307,7 +335,11 @@ simde_vst1q_u16(uint16_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_uint16x8_t val) {
     vec_st(val, 0, ptr);
   #else
     simde_uint16x8_private val_ = simde_uint16x8_to_private(val);
-    simde_memcpy(ptr, &val_, sizeof(val_));
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      wasm_v128_store(ptr, val_.v128);
+    #else
+      simde_memcpy(ptr, &val_, sizeof(val_));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -324,7 +356,11 @@ simde_vst1q_u32(uint32_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_uint32x4_t val) {
     vec_st(val, 0, ptr);
   #else
     simde_uint32x4_private val_ = simde_uint32x4_to_private(val);
-    simde_memcpy(ptr, &val_, sizeof(val_));
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      wasm_v128_store(ptr, val_.v128);
+    #else
+      simde_memcpy(ptr, &val_, sizeof(val_));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -339,7 +375,11 @@ simde_vst1q_u64(uint64_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_uint64x2_t val) {
     vst1q_u64(ptr, val);
   #else
     simde_uint64x2_private val_ = simde_uint64x2_to_private(val);
-    simde_memcpy(ptr, &val_, sizeof(val_));
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      wasm_v128_store(ptr, val_.v128);
+    #else
+      simde_memcpy(ptr, &val_, sizeof(val_));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)

--- a/simde/arm/neon/st2.h
+++ b/simde/arm/neon/st2.h
@@ -29,6 +29,7 @@
 #define SIMDE_ARM_NEON_ST2_H
 
 #include "types.h"
+#include "zip.h"
 
 HEDLEY_DIAGNOSTIC_PUSH
 SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
@@ -182,13 +183,9 @@ simde_vst2q_f32(simde_float32_t *ptr, simde_float32x4x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_f32(ptr, val);
   #else
-    simde_float32_t buf[8];
-    simde_float32x4_private a_[2] = {simde_float32x4_to_private(val.val[0]),
-                                     simde_float32x4_to_private(val.val[1])};
-    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    simde_float32x4x2_t r = simde_vzipq_f32(val.val[0], val.val[1]);
+    simde_vst1q_f32(ptr, r.val[0]);
+    simde_vst1q_f32(ptr+4, r.val[1]);
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -202,13 +199,9 @@ simde_vst2q_s8(int8_t *ptr, simde_int8x16x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_s8(ptr, val);
   #else
-    int8_t buf[32];
-    simde_int8x16_private a_[2] = {simde_int8x16_to_private(val.val[0]),
-                                   simde_int8x16_to_private(val.val[1])};
-    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    simde_int8x16x2_t r = simde_vzipq_s8(val.val[0], val.val[1]);
+    simde_vst1q_s8(ptr, r.val[0]);
+    simde_vst1q_s8(ptr+16, r.val[1]);
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -222,13 +215,9 @@ simde_vst2q_s16(int16_t *ptr, simde_int16x8x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_s16(ptr, val);
   #else
-    int16_t buf[16];
-    simde_int16x8_private a_[2] = {simde_int16x8_to_private(val.val[0]),
-                                   simde_int16x8_to_private(val.val[1])};
-    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    simde_int16x8x2_t r = simde_vzipq_s16(val.val[0], val.val[1]);
+    simde_vst1q_s16(ptr, r.val[0]);
+    simde_vst1q_s16(ptr+8, r.val[1]);
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -242,13 +231,9 @@ simde_vst2q_s32(int32_t *ptr, simde_int32x4x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_s32(ptr, val);
   #else
-    int32_t buf[8];
-    simde_int32x4_private a_[2] = {simde_int32x4_to_private(val.val[0]),
-                                   simde_int32x4_to_private(val.val[1])};
-    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    simde_int32x4x2_t r = simde_vzipq_s32(val.val[0], val.val[1]);
+    simde_vst1q_s32(ptr, r.val[0]);
+    simde_vst1q_s32(ptr+4, r.val[1]);
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -262,13 +247,9 @@ simde_vst2q_u8(uint8_t *ptr, simde_uint8x16x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_u8(ptr, val);
   #else
-    uint8_t buf[32];
-    simde_uint8x16_private a_[2] = {simde_uint8x16_to_private(val.val[0]),
-                                    simde_uint8x16_to_private(val.val[1])};
-    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    simde_uint8x16x2_t r = simde_vzipq_u8(val.val[0], val.val[1]);
+    simde_vst1q_u8(ptr, r.val[0]);
+    simde_vst1q_u8(ptr+16, r.val[1]);
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -282,13 +263,9 @@ simde_vst2q_u16(uint16_t *ptr, simde_uint16x8x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_u16(ptr, val);
   #else
-    uint16_t buf[16];
-    simde_uint16x8_private a_[2] = {simde_uint16x8_to_private(val.val[0]),
-                                    simde_uint16x8_to_private(val.val[1])};
-    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    simde_uint16x8x2_t r = simde_vzipq_u16(val.val[0], val.val[1]);
+    simde_vst1q_u16(ptr, r.val[0]);
+    simde_vst1q_u16(ptr+8, r.val[1]);
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -302,13 +279,9 @@ simde_vst2q_u32(uint32_t *ptr, simde_uint32x4x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_u32(ptr, val);
   #else
-    uint32_t buf[8];
-    simde_uint32x4_private a_[2] = {simde_uint32x4_to_private(val.val[0]),
-                                    simde_uint32x4_to_private(val.val[1])};
-    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    simde_uint32x4x2_t r = simde_vzipq_u32(val.val[0], val.val[1]);
+    simde_vst1q_u32(ptr, r.val[0]);
+    simde_vst1q_u32(ptr+4, r.val[1]);
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)


### PR DESCRIPTION
This seems lightly better in tests, because it is hard to vectorize the original code, and this optimized version stays in the vectorized realm.