### PR TITLE
neon: fix implementations of all the dot_lane functions

### DIFF
--- a/docker/cross-files/aarch64-clang-11.cross
+++ b/docker/cross-files/aarch64-clang-11.cross
@@ -8,8 +8,8 @@ ld = '/usr/bin/llvm-ld-11'
 exe_wrapper = 'qemu-aarch64-static'
 
 [properties]
-c_args = ['--target=aarch64-linux-gnu', '-march=armv8-a+simd+sha3', '-isystem=/usr/aarch64-linux-gnu/include', '-Weverything', '-Werror']
-cpp_args = ['--target=aarch64-linux-gnu', '-march=armv8-a+simd+sha3', '-isystem=/usr/aarch64-linux-gnu/include', '-Weverything', '-Werror']
+c_args = ['--target=aarch64-linux-gnu', '-march=armv8-a+simd+sha3+dotprod', '-isystem=/usr/aarch64-linux-gnu/include', '-Weverything', '-Werror']
+cpp_args = ['--target=aarch64-linux-gnu', '-march=armv8-a+simd+sha3+dotprod', '-isystem=/usr/aarch64-linux-gnu/include', '-Weverything', '-Werror']
 c_link_args = ['--target=aarch64-linux-gnu']
 cpp_link_args = ['--target=aarch64-linux-gnu']
 

--- a/simde/arm/neon/dot_lane.h
+++ b/simde/arm/neon/dot_lane.h
@@ -31,10 +31,7 @@
 #include "types.h"
 
 #include "add.h"
-#include "combine.h"
-#include "dup_n.h"
-#include "get_low.h"
-#include "get_high.h"
+#include "dup_lane.h"
 #include "paddl.h"
 #include "movn.h"
 #include "mull.h"
@@ -51,14 +48,19 @@ simde_vdot_lane_s32(simde_int32x2_t r, simde_int8x8_t a, simde_int8x8_t b, const
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
     SIMDE_CONSTIFY_2_(vdot_lane_s32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    int32_t element;
-    SIMDE_CONSTIFY_2_(vget_lane_s32, element, (HEDLEY_UNREACHABLE(), element), lane,
-                      HEDLEY_STATIC_CAST(simde_int32x2_t, b));
-    simde_int8x8_t b_lane = HEDLEY_STATIC_CAST(simde_int8x8_t, vdup_n_s32(element));
-
-    result = vadd_s32(r, vmovn_s64(
-                         vpaddlq_s32(vpaddlq_s16(
-                         vmull_s8(a, b_lane)))));
+    simde_int32x2_t b_lane, b_32 = HEDLEY_STATIC_CAST(simde_int32x2_t, b);
+    SIMDE_CONSTIFY_2_(vdup_lane_s32, b_lane, (HEDLEY_UNREACHABLE(), b_lane), lane, b_32);
+    result =
+      vadd_s32(
+        r,
+        vmovn_s64(
+          vpaddlq_s32(
+            vpaddlq_s16(
+              vmull_s8(a,HEDLEY_STATIC_CAST(simde_int8x8_t, b_lane))
+            )
+          )
+        )
+      );
   #else
     simde_int32x2_private r_ = simde_int32x2_to_private(r);
     simde_int8x8_private
@@ -93,14 +95,19 @@ simde_vdot_lane_u32(simde_uint32x2_t r, simde_uint8x8_t a, simde_uint8x8_t b, co
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
     SIMDE_CONSTIFY_2_(vdot_lane_u32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    uint32_t element;
-    SIMDE_CONSTIFY_2_(vget_lane_u32, element, (HEDLEY_UNREACHABLE(), element), lane,
-                      HEDLEY_STATIC_CAST(simde_uint32x2_t, b));
-    simde_uint8x8_t b_lane = HEDLEY_STATIC_CAST(simde_uint8x8_t, vdup_n_u32(element));
-
-    result = vadd_u32(r, vmovn_u64(
-                         vpaddlq_u32(vpaddlq_u16(
-                         vmull_u8(a, b_lane)))));
+    simde_uint32x2_t b_lane, b_32 = HEDLEY_STATIC_CAST(simde_uint32x2_t, b);
+    SIMDE_CONSTIFY_2_(vdup_lane_u32, b_lane, (HEDLEY_UNREACHABLE(), b_lane), lane, b_32);
+    result =
+      vadd_u32(
+        r,
+        vmovn_u64(
+          vpaddlq_u32(
+            vpaddlq_u16(
+              vmull_u8(a,HEDLEY_STATIC_CAST(simde_uint8x8_t, b_lane))
+            )
+          )
+        )
+      );
   #else
     simde_uint32x2_private r_ = simde_uint32x2_to_private(r);
     simde_uint8x8_private
@@ -135,14 +142,20 @@ simde_vdot_laneq_s32(simde_int32x2_t r, simde_int8x8_t a, simde_int8x16_t b, con
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
     SIMDE_CONSTIFY_4_(vdot_laneq_s32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-     int32_t element;
-     SIMDE_CONSTIFY_4_(vgetq_lane_s32, element, (HEDLEY_UNREACHABLE(), element), lane,
-                       HEDLEY_STATIC_CAST(simde_int32x4_t, b));
-     simde_int8x8_t b_lane = HEDLEY_STATIC_CAST(simde_int8x8_t, vdup_n_s32(element));
-
-     result = vadd_s32(r, vmovn_s64(
-                          vpaddlq_s32(vpaddlq_s16(
-                          vmull_s8(a, b_lane)))));
+    simde_int32x2_t b_lane;
+    simde_int32x4_t b_32 = HEDLEY_STATIC_CAST(simde_int32x4_t, b);
+    SIMDE_CONSTIFY_4_(simde_vdup_laneq_s32, b_lane, (HEDLEY_UNREACHABLE(), b_lane), lane, b_32);
+    result =
+      vadd_s32(
+        r,
+        vmovn_s64(
+          vpaddlq_s32(
+            vpaddlq_s16(
+              vmull_s8(a, HEDLEY_STATIC_CAST(simde_int8x8_t, b_lane))
+            )
+          )
+        )
+      );
   #else
     simde_int32x2_private r_ = simde_int32x2_to_private(r);
     simde_int8x8_private a_ = simde_int8x8_to_private(a);
@@ -176,14 +189,20 @@ simde_vdot_laneq_u32(simde_uint32x2_t r, simde_uint8x8_t a, simde_uint8x16_t b, 
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
     SIMDE_CONSTIFY_4_(vdot_laneq_u32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-     uint32_t element;
-     SIMDE_CONSTIFY_4_(vgetq_lane_u32, element, (HEDLEY_UNREACHABLE(), element), lane,
-                       HEDLEY_STATIC_CAST(simde_uint32x4_t, b));
-     simde_uint8x8_t b_lane = HEDLEY_STATIC_CAST(simde_uint8x8_t, vdup_n_u32(element));
-
-     result = vadd_u32(r, vmovn_u64(
-                          vpaddlq_u32(vpaddlq_u16(
-                          vmull_u8(a, b_lane)))));
+    simde_uint32x2_t b_lane;
+    simde_uint32x4_t b_32 = HEDLEY_STATIC_CAST(simde_uint32x4_t, b);
+    SIMDE_CONSTIFY_4_(simde_vdup_laneq_u32, b_lane, (HEDLEY_UNREACHABLE(), b_lane), lane, b_32);
+    result =
+      vadd_u32(
+        r,
+        vmovn_u64(
+          vpaddlq_u32(
+            vpaddlq_u16(
+              vmull_u8(a, HEDLEY_STATIC_CAST(simde_uint8x8_t, b_lane))
+            )
+          )
+        )
+      );
   #else
     simde_uint32x2_private r_ = simde_uint32x2_to_private(r);
     simde_uint8x8_private a_ = simde_uint8x8_to_private(a);

--- a/simde/arm/neon/dot_lane.h
+++ b/simde/arm/neon/dot_lane.h
@@ -62,6 +62,7 @@ simde_vdot_lane_s32(simde_int32x2_t r, simde_int8x8_t a, simde_int8x8_t b, const
       a_ = simde_int8x8_to_private(a),
       b_ = simde_int8x8_to_private(b);
 
+    SIMDE_VECTORIZE
     for (int i = 0 ; i < 2 ; i++) {
       int32_t acc = 0;
       SIMDE_VECTORIZE_REDUCTION(+:acc)
@@ -101,6 +102,7 @@ simde_vdot_lane_u32(simde_uint32x2_t r, simde_uint8x8_t a, simde_uint8x8_t b, co
       a_ = simde_uint8x8_to_private(a),
       b_ = simde_uint8x8_to_private(b);
 
+    SIMDE_VECTORIZE
     for (int i = 0 ; i < 2 ; i++) {
       uint32_t acc = 0;
       SIMDE_VECTORIZE_REDUCTION(+:acc)
@@ -140,6 +142,7 @@ simde_vdot_laneq_s32(simde_int32x2_t r, simde_int8x8_t a, simde_int8x16_t b, con
     simde_int8x8_private a_ = simde_int8x8_to_private(a);
     simde_int8x16_private b_ = simde_int8x16_to_private(b);
 
+    SIMDE_VECTORIZE
     for (int i = 0 ; i < 2 ; i++) {
       int32_t acc = 0;
       SIMDE_VECTORIZE_REDUCTION(+:acc)
@@ -179,6 +182,7 @@ simde_vdot_laneq_u32(simde_uint32x2_t r, simde_uint8x8_t a, simde_uint8x16_t b, 
     simde_uint8x8_private a_ = simde_uint8x8_to_private(a);
     simde_uint8x16_private b_ = simde_uint8x16_to_private(b);
 
+    SIMDE_VECTORIZE
     for (int i = 0 ; i < 2 ; i++) {
       uint32_t acc = 0;
       SIMDE_VECTORIZE_REDUCTION(+:acc)

--- a/simde/arm/neon/dot_lane.h
+++ b/simde/arm/neon/dot_lane.h
@@ -62,7 +62,6 @@ simde_vdot_lane_s32(simde_int32x2_t r, simde_int8x8_t a, simde_int8x8_t b, const
       a_ = simde_int8x8_to_private(a),
       b_ = simde_int8x8_to_private(b);
 
-    SIMDE_VECTORIZE
     for (int i = 0 ; i < 2 ; i++) {
       int32_t acc = 0;
       SIMDE_VECTORIZE_REDUCTION(+:acc)
@@ -102,7 +101,6 @@ simde_vdot_lane_u32(simde_uint32x2_t r, simde_uint8x8_t a, simde_uint8x8_t b, co
       a_ = simde_uint8x8_to_private(a),
       b_ = simde_uint8x8_to_private(b);
 
-    SIMDE_VECTORIZE
     for (int i = 0 ; i < 2 ; i++) {
       uint32_t acc = 0;
       SIMDE_VECTORIZE_REDUCTION(+:acc)
@@ -142,7 +140,6 @@ simde_vdot_laneq_s32(simde_int32x2_t r, simde_int8x8_t a, simde_int8x16_t b, con
     simde_int8x8_private a_ = simde_int8x8_to_private(a);
     simde_int8x16_private b_ = simde_int8x16_to_private(b);
 
-    SIMDE_VECTORIZE
     for (int i = 0 ; i < 2 ; i++) {
       int32_t acc = 0;
       SIMDE_VECTORIZE_REDUCTION(+:acc)
@@ -182,7 +179,6 @@ simde_vdot_laneq_u32(simde_uint32x2_t r, simde_uint8x8_t a, simde_uint8x16_t b, 
     simde_uint8x8_private a_ = simde_uint8x8_to_private(a);
     simde_uint8x16_private b_ = simde_uint8x16_to_private(b);
 
-    SIMDE_VECTORIZE
     for (int i = 0 ; i < 2 ; i++) {
       uint32_t acc = 0;
       SIMDE_VECTORIZE_REDUCTION(+:acc)

--- a/simde/arm/neon/dot_lane.h
+++ b/simde/arm/neon/dot_lane.h
@@ -48,7 +48,7 @@ simde_int32x2_t
 simde_vdot_lane_s32(simde_int32x2_t r, simde_int8x8_t a, simde_int8x8_t b, const int lane)
     SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
   simde_int32x2_t result;
-  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
     SIMDE_CONSTIFY_2_(vdot_lane_s32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     simde_uint32x2_t mask;
@@ -57,21 +57,24 @@ simde_vdot_lane_s32(simde_int32x2_t r, simde_int8x8_t a, simde_int8x8_t b, const
                       vadd_s32(r, vmovn_s64(vpaddlq_s32(vpaddlq_s16(vmull_s8(a, b))))),
                       r);
   #else
-    simde_int32x2_private r_ = simde_int32x2_to_private(simde_vdup_n_s32(0));
+    simde_int32x2_private r_ = simde_int32x2_to_private(r);
     simde_int8x8_private
       a_ = simde_int8x8_to_private(a),
       b_ = simde_int8x8_to_private(b);
 
-    int32_t acc = 0;
-    SIMDE_VECTORIZE_REDUCTION(+:acc)
-    for (int j = 0 ; j < 4 ; j++) {
-      const int idx = j + (lane << 2);
-      acc += HEDLEY_STATIC_CAST(int32_t, a_.values[idx]) * HEDLEY_STATIC_CAST(int32_t, b_.values[idx]);
+    for (int i = 0 ; i < 2 ; i++) {
+      int32_t acc = 0;
+      SIMDE_VECTORIZE_REDUCTION(+:acc)
+      for (int j = 0 ; j < 4 ; j++) {
+        const int idx_b = j + (lane << 2);
+        const int idx_a = j + (i << 2);
+        acc += HEDLEY_STATIC_CAST(int32_t, a_.values[idx_a]) * HEDLEY_STATIC_CAST(int32_t, b_.values[idx_b]);
+      }
+      r_.values[i] += acc;
     }
-    r_.values[lane] = acc;
 
-    result = simde_vadd_s32(r, simde_int32x2_from_private(r_));
-    #endif
+    result = simde_int32x2_from_private(r_);
+  #endif
   return result;
 }
 #if defined(SIMDE_ARM_NEON_A32V8_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(__ARM_FEATURE_DOTPROD))
@@ -84,7 +87,7 @@ simde_uint32x2_t
 simde_vdot_lane_u32(simde_uint32x2_t r, simde_uint8x8_t a, simde_uint8x8_t b, const int lane)
     SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
   simde_uint32x2_t result;
-  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
     SIMDE_CONSTIFY_2_(vdot_lane_u32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     simde_uint32x2_t mask;
@@ -93,20 +96,23 @@ simde_vdot_lane_u32(simde_uint32x2_t r, simde_uint8x8_t a, simde_uint8x8_t b, co
                       vadd_u32(r, vmovn_u64(vpaddlq_u32(vpaddlq_u16(vmull_u8(a, b))))),
                       r);
   #else
-    simde_uint32x2_private r_ = simde_uint32x2_to_private(simde_vdup_n_u32(0));
+    simde_uint32x2_private r_ = simde_uint32x2_to_private(r);
     simde_uint8x8_private
       a_ = simde_uint8x8_to_private(a),
       b_ = simde_uint8x8_to_private(b);
 
-    uint32_t acc = 0;
-    SIMDE_VECTORIZE_REDUCTION(+:acc)
-    for (int j = 0 ; j < 4 ; j++) {
-      const int idx = j + (lane << 2);
-      acc += HEDLEY_STATIC_CAST(uint32_t, a_.values[idx]) * HEDLEY_STATIC_CAST(uint32_t, b_.values[idx]);
+    for (int i = 0 ; i < 2 ; i++) {
+      uint32_t acc = 0;
+      SIMDE_VECTORIZE_REDUCTION(+:acc)
+      for (int j = 0 ; j < 4 ; j++) {
+        const int idx_b = j + (lane << 2);
+        const int idx_a = j + (i << 2);
+        acc += HEDLEY_STATIC_CAST(uint32_t, a_.values[idx_a]) * HEDLEY_STATIC_CAST(uint32_t, b_.values[idx_b]);
+      }
+      r_.values[i] += acc;
     }
-    r_.values[lane] = acc;
 
-    result = simde_vadd_u32(r, simde_uint32x2_from_private(r_));
+    result = simde_uint32x2_from_private(r_);
     #endif
   return result;
 }
@@ -116,11 +122,11 @@ simde_vdot_lane_u32(simde_uint32x2_t r, simde_uint8x8_t a, simde_uint8x8_t b, co
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde_int32x4_t
-simde_vdot_laneq_s32(simde_int32x4_t r, simde_int8x16_t a, simde_int8x16_t b, const int lane)
+simde_int32x2_t
+simde_vdot_laneq_s32(simde_int32x2_t r, simde_int8x8_t a, simde_int8x16_t b, const int lane)
     SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
-  simde_int32x4_t result;
-  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
+  simde_int32x2_t result;
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
     SIMDE_CONSTIFY_4_(vdot_laneq_s32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     simde_uint32x4_t mask;
@@ -130,21 +136,23 @@ simde_vdot_laneq_s32(simde_int32x4_t r, simde_int8x16_t a, simde_int8x16_t b, co
                                                 vmovn_s64(vpaddlq_s32(vpaddlq_s16(vmull_s8(vget_high_s8(a), vget_high_s8(b))))))),
                        r);
   #else
-    simde_int32x4_private r_ = simde_int32x4_to_private(simde_vdupq_n_s32(0));
-    simde_int8x16_private
-      a_ = simde_int8x16_to_private(a),
-      b_ = simde_int8x16_to_private(b);
+    simde_int32x2_private r_ = simde_int32x2_to_private(r);
+    simde_int8x8_private a_ = simde_int8x8_to_private(a);
+    simde_int8x16_private b_ = simde_int8x16_to_private(b);
 
-    int32_t acc = 0;
-    SIMDE_VECTORIZE_REDUCTION(+:acc)
-    for (int j = 0 ; j < 4 ; j++) {
-      const int idx = j + (lane << 2);
-      acc += HEDLEY_STATIC_CAST(int32_t, a_.values[idx]) * HEDLEY_STATIC_CAST(int32_t, b_.values[idx]);
+    for (int i = 0 ; i < 2 ; i++) {
+      int32_t acc = 0;
+      SIMDE_VECTORIZE_REDUCTION(+:acc)
+      for (int j = 0 ; j < 4 ; j++) {
+        const int idx_b = j + (lane << 2);
+        const int idx_a = j + (i << 2);
+        acc += HEDLEY_STATIC_CAST(int32_t, a_.values[idx_a]) * HEDLEY_STATIC_CAST(int32_t, b_.values[idx_b]);
+      }
+      r_.values[i] += acc;
     }
-    r_.values[lane] = acc;
 
-    result = simde_vaddq_s32(r, simde_int32x4_from_private(r_));
-    #endif
+    result = simde_int32x2_from_private(r_);
+  #endif
   return result;
 }
 #if defined(SIMDE_ARM_NEON_A32V8_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(__ARM_FEATURE_DOTPROD))
@@ -153,11 +161,11 @@ simde_vdot_laneq_s32(simde_int32x4_t r, simde_int8x16_t a, simde_int8x16_t b, co
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde_uint32x4_t
-simde_vdot_laneq_u32(simde_uint32x4_t r, simde_uint8x16_t a, simde_uint8x16_t b, const int lane)
+simde_uint32x2_t
+simde_vdot_laneq_u32(simde_uint32x2_t r, simde_uint8x8_t a, simde_uint8x16_t b, const int lane)
     SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
-  simde_uint32x4_t result;
-  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
+  simde_uint32x2_t result;
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
     SIMDE_CONSTIFY_4_(vdot_laneq_u32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     simde_uint32x4_t mask;
@@ -167,20 +175,22 @@ simde_vdot_laneq_u32(simde_uint32x4_t r, simde_uint8x16_t a, simde_uint8x16_t b,
                                                  vmovn_u64(vpaddlq_u32(vpaddlq_u16(vmull_u8(vget_high_u8(a), vget_high_u8(b))))))),
                        r);
   #else
-    simde_uint32x4_private r_ = simde_uint32x4_to_private(simde_vdupq_n_u32(0));
-    simde_uint8x16_private
-      a_ = simde_uint8x16_to_private(a),
-      b_ = simde_uint8x16_to_private(b);
+    simde_uint32x2_private r_ = simde_uint32x2_to_private(r);
+    simde_uint8x8_private a_ = simde_uint8x8_to_private(a);
+    simde_uint8x16_private b_ = simde_uint8x16_to_private(b);
 
-    uint32_t acc = 0;
-    SIMDE_VECTORIZE_REDUCTION(+:acc)
-    for (int j = 0 ; j < 4 ; j++) {
-      const int idx = j + (lane << 2);
-      acc += HEDLEY_STATIC_CAST(uint32_t, a_.values[idx]) * HEDLEY_STATIC_CAST(uint32_t, b_.values[idx]);
+    for (int i = 0 ; i < 2 ; i++) {
+      uint32_t acc = 0;
+      SIMDE_VECTORIZE_REDUCTION(+:acc)
+      for (int j = 0 ; j < 4 ; j++) {
+        const int idx_b = j + (lane << 2);
+        const int idx_a = j + (i << 2);
+        acc += HEDLEY_STATIC_CAST(uint32_t, a_.values[idx_a]) * HEDLEY_STATIC_CAST(uint32_t, b_.values[idx_b]);
+      }
+      r_.values[i] += acc;
     }
-    r_.values[lane] = acc;
 
-    result = simde_vaddq_u32(r, simde_uint32x4_from_private(r_));
+    result = simde_uint32x2_from_private(r_);
     #endif
   return result;
 }

--- a/simde/arm/neon/dot_lane.h
+++ b/simde/arm/neon/dot_lane.h
@@ -51,11 +51,14 @@ simde_vdot_lane_s32(simde_int32x2_t r, simde_int8x8_t a, simde_int8x8_t b, const
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
     SIMDE_CONSTIFY_2_(vdot_lane_s32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    simde_uint32x2_t mask;
-    SIMDE_CONSTIFY_2_(vset_lane_u32, mask, (HEDLEY_UNREACHABLE(), mask), lane, UINT32_MAX, vdup_n_u32(0));
-    result = vbsl_s32(mask,
-                      vadd_s32(r, vmovn_s64(vpaddlq_s32(vpaddlq_s16(vmull_s8(a, b))))),
-                      r);
+    int32_t element;
+    SIMDE_CONSTIFY_2_(vget_lane_s32, element, (HEDLEY_UNREACHABLE(), element), lane,
+                      HEDLEY_STATIC_CAST(simde_int32x2_t, b));
+    simde_int8x8_t b_lane = HEDLEY_STATIC_CAST(simde_int8x8_t, vdup_n_s32(element));
+
+    result = vadd_s32(r, vmovn_s64(
+                         vpaddlq_s32(vpaddlq_s16(
+                         vmull_s8(a, b_lane)))));
   #else
     simde_int32x2_private r_ = simde_int32x2_to_private(r);
     simde_int8x8_private
@@ -90,11 +93,14 @@ simde_vdot_lane_u32(simde_uint32x2_t r, simde_uint8x8_t a, simde_uint8x8_t b, co
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
     SIMDE_CONSTIFY_2_(vdot_lane_u32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    simde_uint32x2_t mask;
-    SIMDE_CONSTIFY_2_(vset_lane_u32, mask, (HEDLEY_UNREACHABLE(), mask), lane, UINT32_MAX, vdup_n_u32(0));
-    result = vbsl_u32(mask,
-                      vadd_u32(r, vmovn_u64(vpaddlq_u32(vpaddlq_u16(vmull_u8(a, b))))),
-                      r);
+    uint32_t element;
+    SIMDE_CONSTIFY_2_(vget_lane_u32, element, (HEDLEY_UNREACHABLE(), element), lane,
+                      HEDLEY_STATIC_CAST(simde_uint32x2_t, b));
+    simde_uint8x8_t b_lane = HEDLEY_STATIC_CAST(simde_uint8x8_t, vdup_n_u32(element));
+
+    result = vadd_u32(r, vmovn_u64(
+                         vpaddlq_u32(vpaddlq_u16(
+                         vmull_u8(a, b_lane)))));
   #else
     simde_uint32x2_private r_ = simde_uint32x2_to_private(r);
     simde_uint8x8_private
@@ -129,12 +135,14 @@ simde_vdot_laneq_s32(simde_int32x2_t r, simde_int8x8_t a, simde_int8x16_t b, con
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
     SIMDE_CONSTIFY_4_(vdot_laneq_s32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    simde_uint32x4_t mask;
-    SIMDE_CONSTIFY_4_(vsetq_lane_u32, mask, (HEDLEY_UNREACHABLE(), mask), lane, UINT32_MAX, vdupq_n_u32(0));
-    result = vbslq_s32(mask,
-                       vaddq_s32(r, vcombine_s32(vmovn_s64(vpaddlq_s32(vpaddlq_s16(vmull_s8(vget_low_s8(a), vget_low_s8(b))))),
-                                                vmovn_s64(vpaddlq_s32(vpaddlq_s16(vmull_s8(vget_high_s8(a), vget_high_s8(b))))))),
-                       r);
+     int32_t element;
+     SIMDE_CONSTIFY_4_(vgetq_lane_s32, element, (HEDLEY_UNREACHABLE(), element), lane,
+                       HEDLEY_STATIC_CAST(simde_int32x4_t, b));
+     simde_int8x8_t b_lane = HEDLEY_STATIC_CAST(simde_int8x8_t, vdup_n_s32(element));
+
+     result = vadd_s32(r, vmovn_s64(
+                          vpaddlq_s32(vpaddlq_s16(
+                          vmull_s8(a, b_lane)))));
   #else
     simde_int32x2_private r_ = simde_int32x2_to_private(r);
     simde_int8x8_private a_ = simde_int8x8_to_private(a);
@@ -168,12 +176,14 @@ simde_vdot_laneq_u32(simde_uint32x2_t r, simde_uint8x8_t a, simde_uint8x16_t b, 
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
     SIMDE_CONSTIFY_4_(vdot_laneq_u32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    simde_uint32x4_t mask;
-    SIMDE_CONSTIFY_4_(vsetq_lane_u32, mask, (HEDLEY_UNREACHABLE(), mask), lane, UINT32_MAX, vdupq_n_u32(0));
-    result = vbslq_u32(mask,
-                       vaddq_u32(r, vcombine_u32(vmovn_u64(vpaddlq_u32(vpaddlq_u16(vmull_u8(vget_low_u8(a), vget_low_u8(b))))),
-                                                 vmovn_u64(vpaddlq_u32(vpaddlq_u16(vmull_u8(vget_high_u8(a), vget_high_u8(b))))))),
-                       r);
+     uint32_t element;
+     SIMDE_CONSTIFY_4_(vgetq_lane_u32, element, (HEDLEY_UNREACHABLE(), element), lane,
+                       HEDLEY_STATIC_CAST(simde_uint32x4_t, b));
+     simde_uint8x8_t b_lane = HEDLEY_STATIC_CAST(simde_uint8x8_t, vdup_n_u32(element));
+
+     result = vadd_u32(r, vmovn_u64(
+                          vpaddlq_u32(vpaddlq_u16(
+                          vmull_u8(a, b_lane)))));
   #else
     simde_uint32x2_private r_ = simde_uint32x2_to_private(r);
     simde_uint8x8_private a_ = simde_uint8x8_to_private(a);

--- a/simde/arm/neon/dot_lane.h
+++ b/simde/arm/neon/dot_lane.h
@@ -48,7 +48,7 @@ simde_vdot_lane_s32(simde_int32x2_t r, simde_int8x8_t a, simde_int8x8_t b, const
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
     SIMDE_CONSTIFY_2_(vdot_lane_s32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    simde_int32x2_t b_lane, b_32 = HEDLEY_STATIC_CAST(simde_int32x2_t, b);
+    simde_int32x2_t b_lane, b_32 = vreinterpret_s32_s8(b);
     SIMDE_CONSTIFY_2_(vdup_lane_s32, b_lane, (HEDLEY_UNREACHABLE(), b_lane), lane, b_32);
     result =
       vadd_s32(
@@ -56,7 +56,7 @@ simde_vdot_lane_s32(simde_int32x2_t r, simde_int8x8_t a, simde_int8x8_t b, const
         vmovn_s64(
           vpaddlq_s32(
             vpaddlq_s16(
-              vmull_s8(a,HEDLEY_STATIC_CAST(simde_int8x8_t, b_lane))
+              vmull_s8(a, vreinterpret_s8_s32(b_lane))
             )
           )
         )
@@ -95,7 +95,7 @@ simde_vdot_lane_u32(simde_uint32x2_t r, simde_uint8x8_t a, simde_uint8x8_t b, co
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
     SIMDE_CONSTIFY_2_(vdot_lane_u32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    simde_uint32x2_t b_lane, b_32 = HEDLEY_STATIC_CAST(simde_uint32x2_t, b);
+    simde_uint32x2_t b_lane, b_32 = vreinterpret_u32_u8(b);
     SIMDE_CONSTIFY_2_(vdup_lane_u32, b_lane, (HEDLEY_UNREACHABLE(), b_lane), lane, b_32);
     result =
       vadd_u32(
@@ -103,7 +103,7 @@ simde_vdot_lane_u32(simde_uint32x2_t r, simde_uint8x8_t a, simde_uint8x8_t b, co
         vmovn_u64(
           vpaddlq_u32(
             vpaddlq_u16(
-              vmull_u8(a,HEDLEY_STATIC_CAST(simde_uint8x8_t, b_lane))
+              vmull_u8(a, vreinterpret_u8_u32(b_lane))
             )
           )
         )
@@ -143,7 +143,7 @@ simde_vdot_laneq_s32(simde_int32x2_t r, simde_int8x8_t a, simde_int8x16_t b, con
     SIMDE_CONSTIFY_4_(vdot_laneq_s32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     simde_int32x2_t b_lane;
-    simde_int32x4_t b_32 = HEDLEY_STATIC_CAST(simde_int32x4_t, b);
+    simde_int32x4_t b_32 = vreinterpretq_s32_s8(b);
     SIMDE_CONSTIFY_4_(simde_vdup_laneq_s32, b_lane, (HEDLEY_UNREACHABLE(), b_lane), lane, b_32);
     result =
       vadd_s32(
@@ -151,7 +151,7 @@ simde_vdot_laneq_s32(simde_int32x2_t r, simde_int8x8_t a, simde_int8x16_t b, con
         vmovn_s64(
           vpaddlq_s32(
             vpaddlq_s16(
-              vmull_s8(a, HEDLEY_STATIC_CAST(simde_int8x8_t, b_lane))
+              vmull_s8(a, vreinterpret_s8_s32(b_lane))
             )
           )
         )
@@ -190,7 +190,7 @@ simde_vdot_laneq_u32(simde_uint32x2_t r, simde_uint8x8_t a, simde_uint8x16_t b, 
     SIMDE_CONSTIFY_4_(vdot_laneq_u32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     simde_uint32x2_t b_lane;
-    simde_uint32x4_t b_32 = HEDLEY_STATIC_CAST(simde_uint32x4_t, b);
+    simde_uint32x4_t b_32 = vreinterpretq_u32_u8(b);
     SIMDE_CONSTIFY_4_(simde_vdup_laneq_u32, b_lane, (HEDLEY_UNREACHABLE(), b_lane), lane, b_32);
     result =
       vadd_u32(
@@ -198,7 +198,7 @@ simde_vdot_laneq_u32(simde_uint32x2_t r, simde_uint8x8_t a, simde_uint8x16_t b, 
         vmovn_u64(
           vpaddlq_u32(
             vpaddlq_u16(
-              vmull_u8(a, HEDLEY_STATIC_CAST(simde_uint8x8_t, b_lane))
+              vmull_u8(a, vreinterpret_u8_u32(b_lane))
             )
           )
         )

--- a/simde/arm/neon/dot_lane.h
+++ b/simde/arm/neon/dot_lane.h
@@ -48,8 +48,8 @@ simde_int32x2_t
 simde_vdot_lane_s32(simde_int32x2_t r, simde_int8x8_t a, simde_int8x8_t b, const int lane)
     SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
   simde_int32x2_t result;
-  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOT_PROD)
-    SIMDE_CONSTIFY_2_(vdot_lane_s32, result, (HEDLEY_UNCREACHABLE(), result), lane, r, a, b);
+  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
+    SIMDE_CONSTIFY_2_(vdot_lane_s32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     simde_uint32x2_t mask;
     SIMDE_CONSTIFY_2_(vset_lane_u32, mask, (HEDLEY_UNREACHABLE(), mask), lane, UINT32_MAX, vdup_n_u32(0));
@@ -84,8 +84,8 @@ simde_uint32x2_t
 simde_vdot_lane_u32(simde_uint32x2_t r, simde_uint8x8_t a, simde_uint8x8_t b, const int lane)
     SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
   simde_uint32x2_t result;
-  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOT_PROD)
-    SIMDE_CONSTIFY_2_(vdot_lane_u32, result, (HEDLEY_UNCREACHABLE(), result), lane, r, a, b);
+  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
+    SIMDE_CONSTIFY_2_(vdot_lane_u32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     simde_uint32x2_t mask;
     SIMDE_CONSTIFY_2_(vset_lane_u32, mask, (HEDLEY_UNREACHABLE(), mask), lane, UINT32_MAX, vdup_n_u32(0));
@@ -120,8 +120,8 @@ simde_int32x4_t
 simde_vdot_laneq_s32(simde_int32x4_t r, simde_int8x16_t a, simde_int8x16_t b, const int lane)
     SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
   simde_int32x4_t result;
-  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOT_PROD)
-    SIMDE_CONSTIFY_4_(vdot_laneq_s32, result, (HEDLEY_UNCREACHABLE(), result), lane, r, a, b);
+  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
+    SIMDE_CONSTIFY_4_(vdot_laneq_s32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     simde_uint32x4_t mask;
     SIMDE_CONSTIFY_4_(vsetq_lane_u32, mask, (HEDLEY_UNREACHABLE(), mask), lane, UINT32_MAX, vdupq_n_u32(0));
@@ -157,8 +157,8 @@ simde_uint32x4_t
 simde_vdot_laneq_u32(simde_uint32x4_t r, simde_uint8x16_t a, simde_uint8x16_t b, const int lane)
     SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
   simde_uint32x4_t result;
-  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOT_PROD)
-    SIMDE_CONSTIFY_4_(vdot_laneq_u32, result, (HEDLEY_UNCREACHABLE(), result), lane, r, a, b);
+  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
+    SIMDE_CONSTIFY_4_(vdot_laneq_u32, result, (HEDLEY_UNREACHABLE(), result), lane, r, a, b);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     simde_uint32x4_t mask;
     SIMDE_CONSTIFY_4_(vsetq_lane_u32, mask, (HEDLEY_UNREACHABLE(), mask), lane, UINT32_MAX, vdupq_n_u32(0));

--- a/test/arm/neon/dot_lane.c
+++ b/test/arm/neon/dot_lane.c
@@ -13,47 +13,46 @@ test_simde_vdot_lane_s32 (SIMDE_MUNIT_TEST_ARGS) {
     const int lane;
     int32_t r[2];
   } test_vec[] = {
-    { { -INT32_C(   253147047), -INT32_C(  1800313358) },
-      {  INT8_C(   3),  INT8_C(  41), -INT8_C(  81), -INT8_C(  37), -INT8_C(  11), -INT8_C( 115), -INT8_C( 125), -INT8_C(   7) },
-      { -INT8_C(  94),  INT8_C(  14), -INT8_C(  74), -INT8_C(  94), -INT8_C(  39), -INT8_C( 125), -INT8_C(  38),  INT8_C(  93) },
+    { { -INT32_C(  1695142189),  INT32_C(   606253494) },
+      { -INT8_C(   8),  INT8_C( 126), -INT8_C(  89), -INT8_C(   2),  INT8_C(  86),  INT8_C(  74),  INT8_C( 126),  INT8_C(  50) },
+      { -INT8_C(  85), -INT8_C(  18), -INT8_C( 109),  INT8_C(  56),      INT8_MIN, -INT8_C( 104), -INT8_C(  65), -INT8_C(  22) },
        INT32_C(           0),
-      { -INT32_C(   253137283), -INT32_C(  1800313358) } },
-    { {  INT32_C(   732178250),  INT32_C(   154436016) },
-      { -INT8_C(  55),  INT8_C(  29), -INT8_C(   7), -INT8_C(  69), -INT8_C( 126), -INT8_C(  86),  INT8_C(  80), -INT8_C( 122) },
-      { -INT8_C(  45), -INT8_C(   1),  INT8_C(  97), -INT8_C(  56), -INT8_C( 116), -INT8_C(  28), -INT8_C(  63),  INT8_C(  47) },
+      { -INT32_C(  1695134188),  INT32_C(   606233918) } },
+    { { -INT32_C(   475476306), -INT32_C(  1248166687) },
+      { -INT8_C(  86), -INT8_C( 112),  INT8_C(  79),  INT8_C(  96),  INT8_C(  66),  INT8_C( 113), -INT8_C( 123),  INT8_C(  58) },
+      { -INT8_C(  17),  INT8_C(  44),  INT8_C(  56),  INT8_C(  69),  INT8_C( 119), -INT8_C(  74),  INT8_C( 119),  INT8_C(  34) },
        INT32_C(           1),
-      {  INT32_C(   732178250),  INT32_C(   154442266) } },
-    { { -INT32_C(   858687501),  INT32_C(  1160358906) },
-      { -INT8_C(  46), -INT8_C(  51),  INT8_C( 112), -INT8_C( 126),  INT8_C(  78), -INT8_C(  92), -INT8_C( 116),  INT8_C(  24) },
-      { -INT8_C(  63), -INT8_C( 123), -INT8_C(  45),  INT8_C(  68),  INT8_C(  48),  INT8_C(  35), -INT8_C(  54),  INT8_C(   3) },
+      { -INT32_C(   475465587), -INT32_C(  1248179860) } },
+    { {  INT32_C(   609880740),  INT32_C(  1359944354) },
+      { -INT8_C(  24), -INT8_C(  73),  INT8_C(  52), -INT8_C(  54),  INT8_C(  51), -INT8_C(  50),      INT8_MAX, -INT8_C(  34) },
+      {  INT8_C(  95), -INT8_C(  50),  INT8_C(  62), -INT8_C(  95),  INT8_C(  63), -INT8_C(  61), -INT8_C(  37),  INT8_C(  46) },
        INT32_C(           0),
-      { -INT32_C(   858691938),  INT32_C(  1160358906) } },
-    { { -INT32_C(  1345574110),  INT32_C(    64916752) },
-      {  INT8_C(   5), -INT8_C(  81), -INT8_C(  49), -INT8_C(   1),  INT8_C(  90), -INT8_C(   8),  INT8_C(  68),  INT8_C(  44) },
-      { -INT8_C(  59), -INT8_C(  76), -INT8_C(  82),  INT8_C(  19),  INT8_C(  88),  INT8_C(  58),  INT8_C(  43),  INT8_C(  26) },
+      {  INT32_C(   609890464),  INT32_C(  1359962803) } },
+    { {  INT32_C(  1735660528),  INT32_C(  1837755337) },
+      { -INT8_C(  10), -INT8_C(  28), -INT8_C( 110), -INT8_C( 104), -INT8_C(   2), -INT8_C(  95), -INT8_C(  23), -INT8_C(  26) },
+      {  INT8_C(  88),  INT8_C(  29), -INT8_C(  80), -INT8_C( 117), -INT8_C(  20),  INT8_C(  47),  INT8_C( 105),  INT8_C(  75) },
        INT32_C(           1),
-      { -INT32_C(  1345574110),  INT32_C(    64928276) } },
-    { { -INT32_C(   262209600),  INT32_C(  1173563426) },
-      {  INT8_C(  83), -INT8_C(  65), -INT8_C(  12),  INT8_C(  99),  INT8_C(  77), -INT8_C(  46),  INT8_C( 102),  INT8_C(  82) },
-      { -INT8_C( 127),  INT8_C(  53),  INT8_C(  81), -INT8_C(  37),  INT8_C(  45), -INT8_C( 106),  INT8_C(   7), -INT8_C(  14) },
+      {  INT32_C(  1735640062),  INT32_C(  1837746547) } },
+    { {  INT32_C(  1022142717),  INT32_C(  1533790059) },
+      { -INT8_C(  38), -INT8_C(  33), -INT8_C(  62), -INT8_C(  93), -INT8_C(  54),  INT8_C(  76),  INT8_C(  16), -INT8_C(  64) },
+      {  INT8_C(  48), -INT8_C(  94),  INT8_C(  89),  INT8_C(  46),  INT8_C(  67),  INT8_C(  66),  INT8_C(  20), -INT8_C( 101) },
        INT32_C(           0),
-      { -INT32_C(   262228221),  INT32_C(  1173563426) } },
-    { { -INT32_C(  1559841462), -INT32_C(  1329778192) },
-      {  INT8_C(  48),  INT8_C(  27), -INT8_C(  96),  INT8_C(  83),  INT8_C(  67), -INT8_C( 109), -INT8_C( 104), -INT8_C( 106) },
-      {  INT8_C(  83), -INT8_C( 116), -INT8_C(   6), -INT8_C(  96),  INT8_C(  94),  INT8_C(  96), -INT8_C(  14), -INT8_C(  33) },
+      {  INT32_C(  1022134199),  INT32_C(  1533778803) } },
+    { {  INT32_C(  1277674848), -INT32_C(   224947980) },
+      {  INT8_C(  56), -INT8_C( 125),  INT8_C(  46), -INT8_C(  92),  INT8_C(  74), -INT8_C( 103), -INT8_C(   1),  INT8_C(  36) },
+      {  INT8_C( 120), -INT8_C(  62), -INT8_C(  57),  INT8_C(  67),  INT8_C(  14), -INT8_C(  41),  INT8_C(   3),  INT8_C(  62) },
        INT32_C(           1),
-      { -INT32_C(  1559841462), -INT32_C(  1329777404) } },
-    { { -INT32_C(  1011203178),  INT32_C(   615956953) },
-      {  INT8_C( 118), -INT8_C(  68), -INT8_C(  57),  INT8_C( 102), -INT8_C(  19), -INT8_C( 124),  INT8_C(  22),  INT8_C(  30) },
-      { -INT8_C(  97), -INT8_C(  74),  INT8_C( 113), -INT8_C(  30),  INT8_C(  74),  INT8_C(   9),  INT8_C( 120), -INT8_C(  99) },
+      {  INT32_C(  1277675191), -INT32_C(   224940492) } },
+    { { -INT32_C(  1116971910), -INT32_C(    10911585) },
+      {  INT8_C(  69),      INT8_MIN,  INT8_C(  75),  INT8_C(  58),  INT8_C(  16), -INT8_C(  30),  INT8_C(  44),  INT8_C(  73) },
+      {  INT8_C( 101),  INT8_C(  90), -INT8_C(  19), -INT8_C(  81), -INT8_C(  12), -INT8_C(  20), -INT8_C(  45),  INT8_C( 108) },
        INT32_C(           0),
-      { -INT32_C(  1011219093),  INT32_C(   615956953) } },
-    { { -INT32_C(   214076779),  INT32_C(  1775382483) },
-      {  INT8_C( 114), -INT8_C( 116),  INT8_C(  44),  INT8_C(  76),  INT8_C(  77), -INT8_C(  30),  INT8_C( 112), -INT8_C(  61) },
-      { -INT8_C(  98),  INT8_C(  55),  INT8_C(  42), -INT8_C( 116), -INT8_C(  69),  INT8_C(  64), -INT8_C(  86),  INT8_C(  90) },
+      { -INT32_C(  1116982584), -INT32_C(    10919418) } },
+    { { -INT32_C(  1129342290), -INT32_C(   335891599) },
+      {  INT8_C(  15),  INT8_C( 102), -INT8_C(  87), -INT8_C(  82), -INT8_C(  25),  INT8_C(   2), -INT8_C(  83),  INT8_C(  44) },
+      { -INT8_C( 126), -INT8_C(   8),  INT8_C( 102), -INT8_C( 110), -INT8_C(  38), -INT8_C( 110), -INT8_C(  37),  INT8_C(  63) },
        INT32_C(           1),
-      { -INT32_C(   214076779),  INT32_C(  1775360128) } },
-
+      { -INT32_C(  1129356027), -INT32_C(   335885026) } }
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
@@ -95,47 +94,46 @@ test_simde_vdot_lane_u32 (SIMDE_MUNIT_TEST_ARGS) {
     const int lane;
     uint32_t r[2];
   } test_vec[] = {
-    { { UINT32_C(2273751440), UINT32_C(3884166093) },
-      { UINT8_C(198), UINT8_C(167), UINT8_C( 73), UINT8_C(199), UINT8_C(230), UINT8_C(240), UINT8_C(  5), UINT8_C( 49) },
-      { UINT8_C(237), UINT8_C(126), UINT8_C( 64), UINT8_C( 41), UINT8_C(234), UINT8_C( 92), UINT8_C(119), UINT8_C(208) },
+    { { UINT32_C(2004636215), UINT32_C(1447988795) },
+      { UINT8_C(252), UINT8_C( 39), UINT8_C( 82), UINT8_C( 17), UINT8_C(244), UINT8_C(247), UINT8_C( 33), UINT8_C( 22) },
+      { UINT8_C(166), UINT8_C(124), UINT8_C(170), UINT8_C(109), UINT8_C(174), UINT8_C( 87), UINT8_C(102), UINT8_C( 37) },
        INT32_C(           0),
-      { UINT32_C(2273832239), UINT32_C(3884166093) } },
-    { { UINT32_C(3927977934), UINT32_C(1271200699) },
-      { UINT8_C(172), UINT8_C( 74), UINT8_C(210), UINT8_C(122), UINT8_C(245), UINT8_C( 86), UINT8_C( 97), UINT8_C(187) },
-      { UINT8_C(253), UINT8_C(170), UINT8_C(130), UINT8_C(227), UINT8_C(155), UINT8_C(135), UINT8_C( 20), UINT8_C(136) },
+      { UINT32_C(2004698676), UINT32_C(1448067935) } },
+    { { UINT32_C(1203385153), UINT32_C( 129883856) },
+      { UINT8_C( 48), UINT8_C( 58), UINT8_C(127), UINT8_C(107), UINT8_C(200), UINT8_C(205), UINT8_C(193), UINT8_C(196) },
+      { UINT8_C(244), UINT8_C( 19), UINT8_C(213), UINT8_C(232), UINT8_C( 10), UINT8_C(247), UINT8_C(254), UINT8_C(177) },
        INT32_C(           1),
-      { UINT32_C(3927977934), UINT32_C(1271277656) } },
-    { { UINT32_C(4038153478), UINT32_C(2143300017) },
-      { UINT8_C( 88), UINT8_C(224), UINT8_C(105), UINT8_C( 19), UINT8_C(219), UINT8_C( 45), UINT8_C( 94), UINT8_C(136) },
-      { UINT8_C(119), UINT8_C( 48), UINT8_C(  2), UINT8_C(109), UINT8_C(134), UINT8_C( 99), UINT8_C( 40), UINT8_C(131) },
+      { UINT32_C(1203451156), UINT32_C( 130020205) } },
+    { { UINT32_C( 555657587), UINT32_C(1095205888) },
+      { UINT8_C(183), UINT8_C(  1), UINT8_C(136), UINT8_C(136), UINT8_C(223), UINT8_C( 70), UINT8_C(143), UINT8_C( 15) },
+      { UINT8_C(128), UINT8_C( 14), UINT8_C(123), UINT8_C( 72), UINT8_C(219), UINT8_C( 60), UINT8_C( 12), UINT8_C(207) },
        INT32_C(           0),
-      { UINT32_C(4038176983), UINT32_C(2143300017) } },
-    { { UINT32_C(2842143502), UINT32_C( 942766898) },
-      { UINT8_C(208), UINT8_C(227), UINT8_C( 40), UINT8_C(130), UINT8_C( 12), UINT8_C(233), UINT8_C(  1), UINT8_C(100) },
-      { UINT8_C(201), UINT8_C(107), UINT8_C(119), UINT8_C(165), UINT8_C(152), UINT8_C(213), UINT8_C( 45), UINT8_C( 16) },
+      { UINT32_C( 555707545), UINT32_C(1095254081) } },
+    { { UINT32_C(1522000208), UINT32_C(1259058904) },
+      { UINT8_C( 95), UINT8_C( 41), UINT8_C(109), UINT8_C( 95), UINT8_C(173), UINT8_C(180), UINT8_C(160), UINT8_C(101) },
+      { UINT8_C(181), UINT8_C( 40), UINT8_C(237), UINT8_C(149), UINT8_C(110), UINT8_C(124), UINT8_C(164), UINT8_C(238) },
        INT32_C(           1),
-      { UINT32_C(2842143502), UINT32_C( 942819996) } },
-    { { UINT32_C(2357014277), UINT32_C(2685379986) },
-      { UINT8_C( 80), UINT8_C(118), UINT8_C( 73), UINT8_C(131), UINT8_C(242), UINT8_C(123), UINT8_C(187), UINT8_C(194) },
-      { UINT8_C( 94), UINT8_C(228), UINT8_C( 68), UINT8_C(106), UINT8_C(205), UINT8_C( 70), UINT8_C(206), UINT8_C(150) },
+      { UINT32_C(1522056228), UINT32_C(1259150532) } },
+    { { UINT32_C(1714823051), UINT32_C(2889237084) },
+      { UINT8_C( 36), UINT8_C(237), UINT8_C(  6), UINT8_C(252), UINT8_C(163), UINT8_C( 18), UINT8_C( 72), UINT8_C(  2) },
+      { UINT8_C( 59), UINT8_C(181), UINT8_C( 97), UINT8_C(233), UINT8_C(105), UINT8_C(  1), UINT8_C( 78), UINT8_C( 30) },
        INT32_C(           0),
-      { UINT32_C(2357067551), UINT32_C(2685379986) } },
-    { { UINT32_C(1228621233), UINT32_C( 525953050) },
-      { UINT8_C(151), UINT8_C(214), UINT8_C(171), UINT8_C( 42), UINT8_C(124), UINT8_C(187), UINT8_C(202), UINT8_C(204) },
-      { UINT8_C( 49), UINT8_C( 20), UINT8_C( 79), UINT8_C( 35), UINT8_C(143), UINT8_C( 11), UINT8_C(230), UINT8_C(237) },
+      { UINT32_C(1714927370), UINT32_C(2889257409) } },
+    { { UINT32_C(2561882922), UINT32_C(1116166327) },
+      { UINT8_C(119), UINT8_C(189), UINT8_C(169), UINT8_C(211), UINT8_C(  0), UINT8_C(223), UINT8_C(127), UINT8_C( 36) },
+      { UINT8_C(204), UINT8_C(134), UINT8_C( 32), UINT8_C(112), UINT8_C(152), UINT8_C(104), UINT8_C(114), UINT8_C(211) },
        INT32_C(           1),
-      { UINT32_C(1228621233), UINT32_C( 526067647) } },
-    { { UINT32_C(3159829231), UINT32_C( 559031664) },
-      { UINT8_C(106), UINT8_C(142), UINT8_C(107), UINT8_C(132), UINT8_C(246), UINT8_C(196), UINT8_C(163), UINT8_C(142) },
-      { UINT8_C(155), UINT8_C( 79), UINT8_C(184), UINT8_C( 23), UINT8_C( 10), UINT8_C(130), UINT8_C(227), UINT8_C( 59) },
+      { UINT32_C(2561984453), UINT32_C(1116211593) } },
+    { { UINT32_C(2260522013), UINT32_C(4289006293) },
+      { UINT8_C( 69), UINT8_C( 88), UINT8_C(152), UINT8_C(253), UINT8_C(176), UINT8_C( 31), UINT8_C( 63), UINT8_C( 40) },
+      { UINT8_C(220), UINT8_C(232), UINT8_C(251), UINT8_C(220), UINT8_C(199), UINT8_C(123), UINT8_C(  0), UINT8_C(148) },
        INT32_C(           0),
-      { UINT32_C(3159879603), UINT32_C( 559031664) } },
-    { { UINT32_C( 626996118), UINT32_C( 756172094) },
-      { UINT8_C(111), UINT8_C(105), UINT8_C(233), UINT8_C(224), UINT8_C(142), UINT8_C( 59), UINT8_C(  1), UINT8_C(248) },
-      { UINT8_C(201), UINT8_C(108), UINT8_C(124), UINT8_C(192), UINT8_C( 49), UINT8_C( 32), UINT8_C( 78), UINT8_C(204) },
+      { UINT32_C(2260651421), UINT32_C(4289076818) } },
+    { { UINT32_C(2567184641), UINT32_C(2808903305) },
+      { UINT8_C( 74), UINT8_C( 41), UINT8_C( 45), UINT8_C( 32), UINT8_C( 51), UINT8_C(210), UINT8_C( 31), UINT8_C(121) },
+      { UINT8_C( 43), UINT8_C(183), UINT8_C(118), UINT8_C(219), UINT8_C(214), UINT8_C(181), UINT8_C(  3), UINT8_C(179) },
        INT32_C(           1),
-      { UINT32_C( 626996118), UINT32_C( 756231610) } },
-
+      { UINT32_C(2567213761), UINT32_C(2808973981) } }
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
@@ -170,77 +168,68 @@ static int
 test_simde_vdot_laneq_s32 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   static const struct {
-    int32_t r_[4];
-    int8_t a[16];
+    int32_t r_[2];
+    int8_t a[8];
     int8_t b[16];
     const int lane;
-    int32_t r[4];
+    int32_t r[2];
   } test_vec[] = {
-    { {  INT32_C(  1560176901), -INT32_C(   161233256), -INT32_C(   535959529), -INT32_C(  1508750539) },
-      { -INT8_C( 123),  INT8_C(  76),  INT8_C(   7),  INT8_C(  87),  INT8_C(  63), -INT8_C( 119), -INT8_C(  16), -INT8_C(  85),
-        -INT8_C( 127), -INT8_C( 126), -INT8_C(  28),  INT8_C(  81), -INT8_C( 117),  INT8_C(  86),  INT8_C( 102), -INT8_C( 112) },
-      { -INT8_C(  64),  INT8_C( 100), -INT8_C(  19),  INT8_C(  88),  INT8_C(  42),  INT8_C(  80),  INT8_C(  79),  INT8_C(  65),
-         INT8_C(  56),  INT8_C(  92),  INT8_C(  33),  INT8_C( 109), -INT8_C(  89),  INT8_C(  51),  INT8_C(  20),  INT8_C(  44) },
+    { { -INT32_C(  1265596150),  INT32_C(  1757209770) },
+      {  INT8_C(   2), -INT8_C(  13),  INT8_C( 103), -INT8_C(  48),  INT8_C(  83), -INT8_C(  69),  INT8_C(  75), -INT8_C( 110) },
+      {  INT8_C(  77), -INT8_C( 127),  INT8_C(  43), -INT8_C( 101),  INT8_C(  73),  INT8_C(  30), -INT8_C( 106),  INT8_C(  50),
+        -INT8_C(   7), -INT8_C(  72), -INT8_C( 114),  INT8_C( 102),  INT8_C(  94),  INT8_C( 122),  INT8_C(  21),  INT8_C( 104) },
        INT32_C(           0),
-      {  INT32_C(  1560199896), -INT32_C(   161233256), -INT32_C(   535959529), -INT32_C(  1508750539) } },
-    { { -INT32_C(  1098638465),  INT32_C(   644445349), -INT32_C(  2106110218),  INT32_C(  1678957988) },
-      {  INT8_C(  65), -INT8_C(   1), -INT8_C(  67),  INT8_C( 107),  INT8_C(  79),  INT8_C(  12), -INT8_C(  83), -INT8_C( 121),
-         INT8_C( 104), -INT8_C(  50), -INT8_C(  11),  INT8_C(  15),  INT8_C(   2),  INT8_C(   9),  INT8_C(  60), -INT8_C( 127) },
-      {  INT8_C(  36), -INT8_C(  64),  INT8_C(  64), -INT8_C(  55),  INT8_C(  52), -INT8_C(  87), -INT8_C(  17),  INT8_C(  43),
-        -INT8_C(   9),  INT8_C( 103), -INT8_C(  83), -INT8_C( 100),  INT8_C(  68), -INT8_C(  65),  INT8_C(   0), -INT8_C( 122) },
+      { -INT32_C(  1265585068),  INT32_C(  1757239259) } },
+    { { -INT32_C(  1390566141), -INT32_C(  1944659575) },
+      { -INT8_C(  52),  INT8_C( 125),  INT8_C(  92),  INT8_C(  32),  INT8_C(  56), -INT8_C(  89), -INT8_C(  78), -INT8_C( 123) },
+      {  INT8_C(  40), -INT8_C(  35),  INT8_C(  32),  INT8_C( 114), -INT8_C(   5), -INT8_C(  74), -INT8_C(  92), -INT8_C(  11),
+         INT8_C( 111),  INT8_C(  50),  INT8_C(  91), -INT8_C(  51), -INT8_C(  84),  INT8_C( 112),  INT8_C(  54), -INT8_C(  80) },
        INT32_C(           1),
-      { -INT32_C(  1098638465),  INT32_C(   644444621), -INT32_C(  2106110218),  INT32_C(  1678957988) } },
-    { {  INT32_C(   250723775),  INT32_C(   831954633),  INT32_C(  1866566509), -INT32_C(  1192198764) },
-      {  INT8_C(  61),  INT8_C(  48), -INT8_C( 126),  INT8_C( 113), -INT8_C(  38),  INT8_C( 113), -INT8_C( 100), -INT8_C(  47),
-        -INT8_C(  40),  INT8_C(  73),  INT8_C( 109),  INT8_C(  29),  INT8_C(   9),  INT8_C( 110), -INT8_C(  93), -INT8_C(  56) },
-      {  INT8_C(  43), -INT8_C( 108), -INT8_C(  42), -INT8_C(  11),  INT8_C(  51),  INT8_C( 108),  INT8_C(  38), -INT8_C(  96),
-        -INT8_C(   9),  INT8_C( 103),  INT8_C(  15), -INT8_C( 117), -INT8_C(  28), -INT8_C(   1),  INT8_C(  68),  INT8_C(  33) },
+      { -INT32_C(  1390583947), -INT32_C(  1944644740) } },
+    { { -INT32_C(  1621273834), -INT32_C(   131370196) },
+      { -INT8_C(  15), -INT8_C( 120),  INT8_C(  24),  INT8_C(  41),  INT8_C(  47), -INT8_C(  53), -INT8_C(  81),  INT8_C(  88) },
+      { -INT8_C(  88), -INT8_C(  49), -INT8_C(  54), -INT8_C(  92), -INT8_C( 122),  INT8_C( 110), -INT8_C( 103), -INT8_C(  11),
+        -INT8_C(  96), -INT8_C(  12), -INT8_C(  62),  INT8_C(  77),  INT8_C( 100), -INT8_C(   8), -INT8_C(   3),  INT8_C( 122) },
        INT32_C(           2),
-      {  INT32_C(   250723775),  INT32_C(   831954633),  INT32_C(  1866572630), -INT32_C(  1192198764) } },
-    { {  INT32_C(   177456688),  INT32_C(   282799927), -INT32_C(  2110961287), -INT32_C(   498413385) },
-      {  INT8_C( 100),  INT8_C(  32), -INT8_C(  41), -INT8_C( 105), -INT8_C( 115), -INT8_C(   2),  INT8_C(  55), -INT8_C( 124),
-         INT8_C( 101),  INT8_C(  70),  INT8_C(  16),  INT8_C(  74),  INT8_C(  70),  INT8_C(  84),  INT8_C( 107),  INT8_C( 118) },
-      {  INT8_C(  26), -INT8_C(   2),      INT8_MIN,  INT8_C(  81),  INT8_C(  46),  INT8_C(  91),  INT8_C(  97), -INT8_C(  89),
-        -INT8_C(  92), -INT8_C( 114),  INT8_C(  41),  INT8_C(  91),  INT8_C(  94),  INT8_C( 115),  INT8_C(  62), -INT8_C(  61) },
+      { -INT32_C(  1621269285), -INT32_C(   131362274) } },
+    { {  INT32_C(  1998215755), -INT32_C(  1083161138) },
+      { -INT8_C(  51), -INT8_C( 120), -INT8_C(  24), -INT8_C(   3),  INT8_C(  83), -INT8_C( 105),  INT8_C(  85), -INT8_C(   4) },
+      {  INT8_C( 103),  INT8_C(  31), -INT8_C(  96), -INT8_C(  19), -INT8_C( 115),  INT8_C(  57), -INT8_C(  30),  INT8_C(  45),
+         INT8_C(  45), -INT8_C(  92),  INT8_C( 122), -INT8_C( 111), -INT8_C(  99),  INT8_C( 119),  INT8_C(  12), -INT8_C(  24) },
        INT32_C(           3),
-      {  INT32_C(   177456688),  INT32_C(   282799927), -INT32_C(  2110961287), -INT32_C(   498397709) } },
-    { {  INT32_C(   542774675),  INT32_C(  2040893971),  INT32_C(   516142552),  INT32_C(   596913673) },
-      {  INT8_C(  45),  INT8_C(  20),  INT8_C( 116),  INT8_C(  91),  INT8_C( 112), -INT8_C(  42),  INT8_C(   2),  INT8_C(  20),
-         INT8_C( 100),  INT8_C(  43),  INT8_C( 112), -INT8_C(  61), -INT8_C(  98), -INT8_C(  82), -INT8_C( 122),  INT8_C(  49) },
-      { -INT8_C(  61), -INT8_C(  32),  INT8_C(  82), -INT8_C(  41),  INT8_C( 114), -INT8_C(   9),  INT8_C(  80),  INT8_C(  75),
-        -INT8_C(  84),  INT8_C(  19),  INT8_C( 105), -INT8_C(  75),  INT8_C(  65), -INT8_C(   2), -INT8_C(  40),  INT8_C( 110) },
+      {  INT32_C(  1998206308), -INT32_C(  1083180734) } },
+    { { -INT32_C(  1604311342),  INT32_C(   962580587) },
+      {  INT8_C(  88),  INT8_C(  71),  INT8_C(  54), -INT8_C(  84), -INT8_C(  33), -INT8_C( 117), -INT8_C(  88),  INT8_C(  70) },
+      { -INT8_C(  86),  INT8_C(  72),  INT8_C(  51),  INT8_C(  55), -INT8_C( 127),  INT8_C(  21),  INT8_C( 100), -INT8_C(  82),
+        -INT8_C(  71), -INT8_C(  33),  INT8_C(  63),  INT8_C(  86),  INT8_C(  86),  INT8_C(  75),  INT8_C(  63),  INT8_C(  40) },
        INT32_C(           0),
-      {  INT32_C(   542777071),  INT32_C(  2040893971),  INT32_C(   516142552),  INT32_C(   596913673) } },
-    { { -INT32_C(  2100737006), -INT32_C(  2020095198), -INT32_C(  1807087626),  INT32_C(  2026295477) },
-      { -INT8_C(  80),  INT8_C(  24),  INT8_C(  79),  INT8_C(  35),  INT8_C(  15), -INT8_C(  97),  INT8_C( 110), -INT8_C(  69),
-        -INT8_C(  78), -INT8_C(  41),  INT8_C( 112), -INT8_C(  12), -INT8_C(  43),  INT8_C(  72),  INT8_C(  98), -INT8_C(  24) },
-      { -INT8_C( 108),  INT8_C(  44),  INT8_C( 106), -INT8_C(  73), -INT8_C(   9),  INT8_C(   1),  INT8_C(  62), -INT8_C(  18),
-         INT8_C(   8), -INT8_C( 120), -INT8_C( 126), -INT8_C(  67),  INT8_C(  88),  INT8_C(  72),  INT8_C(  54),  INT8_C(   8) },
+      { -INT32_C(  1604315664),  INT32_C(   962574363) } },
+    { { -INT32_C(   574054543), -INT32_C(   954849425) },
+      {  INT8_C( 111),  INT8_C(  76),  INT8_C( 115),  INT8_C(  78), -INT8_C(  41),  INT8_C(  27), -INT8_C( 108), -INT8_C( 127) },
+      {  INT8_C(  99), -INT8_C(  57), -INT8_C(  72), -INT8_C(  28), -INT8_C(  36),  INT8_C(  28), -INT8_C( 110), -INT8_C( 107),
+        -INT8_C(   5), -INT8_C(  46), -INT8_C(  20),  INT8_C(  82),  INT8_C(  29),  INT8_C(  43),  INT8_C( 122), -INT8_C( 113) },
        INT32_C(           1),
-      { -INT32_C(  2100737006), -INT32_C(  2020087368), -INT32_C(  1807087626),  INT32_C(  2026295477) } },
-    { {  INT32_C(  1865123168), -INT32_C(   685074139),  INT32_C(  1187748465),  INT32_C(  1999515362) },
-      {  INT8_C(  90), -INT8_C( 103),  INT8_C(  46),  INT8_C(  81), -INT8_C( 102),  INT8_C( 108),  INT8_C(  63), -INT8_C(  93),
-        -INT8_C(  12), -INT8_C(  62),  INT8_C(  96),  INT8_C(  76),  INT8_C(  10), -INT8_C( 106),  INT8_C(  84),  INT8_C( 107) },
-      {  INT8_C(  28),      INT8_MIN, -INT8_C(  38),  INT8_C(  65),  INT8_C(  25),  INT8_C(   5),  INT8_C(  24), -INT8_C( 118),
-        -INT8_C(  97), -INT8_C(  28), -INT8_C(  47), -INT8_C( 126),  INT8_C(  18), -INT8_C(   1), -INT8_C(   7),  INT8_C( 108) },
+      { -INT32_C(   574077407), -INT32_C(   954821724) } },
+    { {  INT32_C(   963396554), -INT32_C(   654278038) },
+      { -INT8_C(  50),  INT8_C( 116),  INT8_C(  39), -INT8_C(  91), -INT8_C( 113), -INT8_C(  69),  INT8_C(  38), -INT8_C(  13) },
+      { -INT8_C( 126), -INT8_C(  34), -INT8_C(  41),  INT8_C(  94), -INT8_C(   6),  INT8_C( 106), -INT8_C(  12), -INT8_C(  10),
+         INT8_C(  60), -INT8_C(  32),  INT8_C(  72),  INT8_C(  89),  INT8_C(  11), -INT8_C(  62), -INT8_C(  24), -INT8_C(  43) },
        INT32_C(           2),
-      {  INT32_C(  1865123168), -INT32_C(   685074139),  INT32_C(  1187737277),  INT32_C(  1999515362) } },
-    { {  INT32_C(   868034456), -INT32_C(  2015953517), -INT32_C(   908904769), -INT32_C(   382457907) },
-      { -INT8_C(  89),  INT8_C(  15),  INT8_C(  42), -INT8_C(  63),  INT8_C(  20),  INT8_C(  66),  INT8_C(  75), -INT8_C(  77),
-         INT8_C(  38),  INT8_C(  28),  INT8_C(  53),  INT8_C(  56),  INT8_C(  28),  INT8_C(  46), -INT8_C(  92), -INT8_C(  76) },
-      {  INT8_C(  85),  INT8_C(  98), -INT8_C(  25), -INT8_C(  24),  INT8_C(  95), -INT8_C(  67),  INT8_C( 111),  INT8_C(  30),
-        -INT8_C(  12),  INT8_C(  66), -INT8_C(  25), -INT8_C(  63),  INT8_C( 106),  INT8_C(  28), -INT8_C(  86),  INT8_C(  17) },
+      {  INT32_C(   963384551), -INT32_C(   654281031) } },
+    { {  INT32_C(  1879987205), -INT32_C(  1538715946) },
+      { -INT8_C( 126),  INT8_C( 113),  INT8_C(  73),  INT8_C(  18),  INT8_C(  44),  INT8_C( 111),  INT8_C(   5), -INT8_C(  81) },
+      {  INT8_C(  77), -INT8_C(  36),  INT8_C(  13),  INT8_C(  72),  INT8_C(  70),  INT8_C(   1),  INT8_C(  62), -INT8_C( 126),
+        -INT8_C(  31), -INT8_C( 122), -INT8_C(  36), -INT8_C(  20),  INT8_C(  72), -INT8_C(  60), -INT8_C(  63),  INT8_C(  78) },
        INT32_C(           3),
-      {  INT32_C(   868034456), -INT32_C(  2015953517), -INT32_C(   908904769), -INT32_C(   382447031) } },
-
+      {  INT32_C(  1879968158), -INT32_C(  1538726071) } }
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_int32x4_t r_ = simde_vld1q_s32(test_vec[i].r_);
-    simde_int8x16_t a = simde_vld1q_s8(test_vec[i].a);
+    simde_int32x2_t r_ = simde_vld1_s32(test_vec[i].r_);
+    simde_int8x8_t a = simde_vld1_s8(test_vec[i].a);
     simde_int8x16_t b = simde_vld1q_s8(test_vec[i].b);
-    simde_int32x4_t r = simde_vdot_laneq_s32(r_, a, b, test_vec[i].lane);
-    simde_test_arm_neon_assert_equal_i32x4(r, simde_vld1q_s32(test_vec[i].r));
+    simde_int32x2_t r = simde_vdot_laneq_s32(r_, a, b, test_vec[i].lane);
+    simde_test_arm_neon_assert_equal_i32x2(r, simde_vld1_s32(test_vec[i].r));
   }
 
   return 0;
@@ -248,16 +237,16 @@ test_simde_vdot_laneq_s32 (SIMDE_MUNIT_TEST_ARGS) {
   fputc('\n', stdout);
   const int lanes[] = { 0, 1, 2, 3, 0, 1, 2, 3 };
   for (int i = 0 ; i < 8 ; i++) {
-    simde_int32x4_t r_ = simde_test_arm_neon_random_i32x4();
-    simde_int8x16_t a = simde_test_arm_neon_random_i8x16();
+    simde_int32x2_t r_ = simde_test_arm_neon_random_i32x2();
+    simde_int8x8_t a = simde_test_arm_neon_random_i8x8();
     simde_int8x16_t b = simde_test_arm_neon_random_i8x16();
-    simde_int32x4_t r = simde_vdot_laneq_s32(r_, a, b, lanes[i]);
+    simde_int32x2_t r = simde_vdot_laneq_s32(r_, a, b, lanes[i]);
 
-    simde_test_arm_neon_write_i32x4(2, r_, SIMDE_TEST_VEC_POS_FIRST);
-    simde_test_arm_neon_write_i8x16(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_arm_neon_write_i32x2(2, r_, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_arm_neon_write_i8x8(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
     simde_test_arm_neon_write_i8x16(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
     simde_test_codegen_write_i32(2, lanes[i], SIMDE_TEST_VEC_POS_MIDDLE);
-    simde_test_arm_neon_write_i32x4(2, r, SIMDE_TEST_VEC_POS_LAST);
+    simde_test_arm_neon_write_i32x2(2, r, SIMDE_TEST_VEC_POS_LAST);
   }
   return 1;
 #endif
@@ -273,72 +262,63 @@ test_simde_vdot_laneq_u32 (SIMDE_MUNIT_TEST_ARGS) {
     const int lane;
     uint32_t r[4];
   } test_vec[] = {
-    { { UINT32_C(1243008842), UINT32_C(2042260212), UINT32_C(4021263272), UINT32_C( 707897681) },
-      { UINT8_C(214), UINT8_C(  0), UINT8_C(102), UINT8_C(248), UINT8_C(105), UINT8_C(136), UINT8_C(248), UINT8_C(231),
-        UINT8_C( 35), UINT8_C(235), UINT8_C( 87), UINT8_C( 56), UINT8_C(130), UINT8_C(122), UINT8_C(173), UINT8_C(204) },
-      { UINT8_C( 73), UINT8_C(196), UINT8_C( 22), UINT8_C( 61), UINT8_C( 46), UINT8_C(209), UINT8_C(183), UINT8_C(215),
-        UINT8_C(108), UINT8_C(102), UINT8_C(198), UINT8_C(189), UINT8_C( 16), UINT8_C(247), UINT8_C(231), UINT8_C(230) },
+    { { UINT32_C(4212112153), UINT32_C(2140133093) },
+      { UINT8_C(219), UINT8_C( 10), UINT8_C(230), UINT8_C( 71), UINT8_C( 87), UINT8_C( 27), UINT8_C(218), UINT8_C(104) },
+      { UINT8_C(119), UINT8_C(112), UINT8_C(148), UINT8_C( 58), UINT8_C(217), UINT8_C(247), UINT8_C(231), UINT8_C( 79),
+        UINT8_C(162), UINT8_C(164), UINT8_C( 33), UINT8_C(182), UINT8_C(172), UINT8_C(196), UINT8_C( 77), UINT8_C(197) },
        INT32_C(           0),
-      { UINT32_C(1243041836), UINT32_C(2042260212), UINT32_C(4021263272), UINT32_C( 707897681) } },
-    { { UINT32_C(1625247223), UINT32_C(4165457877), UINT32_C(1144037058), UINT32_C(1628495384) },
-      { UINT8_C(162), UINT8_C( 39), UINT8_C(159), UINT8_C(208), UINT8_C(248), UINT8_C( 86), UINT8_C(167), UINT8_C(100),
-        UINT8_C(188), UINT8_C(109), UINT8_C( 33), UINT8_C(204), UINT8_C(100), UINT8_C(  9), UINT8_C(179), UINT8_C( 91) },
-      { UINT8_C( 86), UINT8_C(146), UINT8_C(188), UINT8_C( 44), UINT8_C(105), UINT8_C(  3), UINT8_C( 36), UINT8_C( 43),
-        UINT8_C(162), UINT8_C( 85), UINT8_C(111), UINT8_C(186), UINT8_C( 51), UINT8_C(127), UINT8_C( 28), UINT8_C(213) },
+      { UINT32_C(4212177492), UINT32_C(2140184766) } },
+    { { UINT32_C(1707105408), UINT32_C( 249843507) },
+      { UINT8_C( 89), UINT8_C(202), UINT8_C( 85), UINT8_C(177), UINT8_C(229), UINT8_C( 48), UINT8_C( 25), UINT8_C( 92) },
+      { UINT8_C(160), UINT8_C(174), UINT8_C(150), UINT8_C(121), UINT8_C(165), UINT8_C(125), UINT8_C(201), UINT8_C( 71),
+        UINT8_C( 33), UINT8_C(234), UINT8_C(253), UINT8_C(205), UINT8_C(175), UINT8_C( 75), UINT8_C(146), UINT8_C( 47) },
        INT32_C(           1),
-      { UINT32_C(1625247223), UINT32_C(4165494487), UINT32_C(1144037058), UINT32_C(1628495384) } },
-    { { UINT32_C(2661661606), UINT32_C(3439480081), UINT32_C( 530195642), UINT32_C(2205830445) },
-      { UINT8_C(223), UINT8_C( 54), UINT8_C(175), UINT8_C( 72), UINT8_C( 58), UINT8_C(212), UINT8_C(115), UINT8_C(220),
-        UINT8_C( 41), UINT8_C(226), UINT8_C(150), UINT8_C( 92), UINT8_C( 97), UINT8_C(178), UINT8_C( 49), UINT8_C(  8) },
-      { UINT8_C(109), UINT8_C(214), UINT8_C(166), UINT8_C(126), UINT8_C( 35), UINT8_C(169), UINT8_C( 76), UINT8_C(222),
-        UINT8_C(205), UINT8_C(230), UINT8_C(253), UINT8_C(250), UINT8_C( 51), UINT8_C(119), UINT8_C(125), UINT8_C( 18) },
+      { UINT32_C(1707174995), UINT32_C( 249898849) } },
+    { { UINT32_C(3667153575), UINT32_C(4226381985) },
+      { UINT8_C( 66), UINT8_C( 62), UINT8_C(172), UINT8_C( 39), UINT8_C(110), UINT8_C(197), UINT8_C(132), UINT8_C( 14) },
+      { UINT8_C(115), UINT8_C( 26), UINT8_C(136), UINT8_C( 25), UINT8_C(152), UINT8_C( 81), UINT8_C( 96), UINT8_C(185),
+        UINT8_C( 59), UINT8_C( 94), UINT8_C(135), UINT8_C(234), UINT8_C(169), UINT8_C( 25), UINT8_C( 25), UINT8_C( 80) },
        INT32_C(           2),
-      { UINT32_C(2661661606), UINT32_C(3439480081), UINT32_C( 530316977), UINT32_C(2205830445) } },
-    { { UINT32_C(3898224046), UINT32_C( 717540609), UINT32_C( 277240495), UINT32_C(2048440077) },
-      { UINT8_C(141), UINT8_C(191), UINT8_C(249), UINT8_C(177), UINT8_C(104), UINT8_C( 69), UINT8_C(143), UINT8_C( 53),
-        UINT8_C( 43), UINT8_C(140), UINT8_C( 47), UINT8_C( 94), UINT8_C(  3), UINT8_C(172), UINT8_C(112), UINT8_C(177) },
-      { UINT8_C(217), UINT8_C(202), UINT8_C(153), UINT8_C(218), UINT8_C(151), UINT8_C( 93), UINT8_C(  4), UINT8_C( 70),
-        UINT8_C(184), UINT8_C(138), UINT8_C( 86), UINT8_C(197), UINT8_C( 65), UINT8_C(111), UINT8_C( 63), UINT8_C(207) },
+      { UINT32_C(3667195643), UINT32_C(4226428089) } },
+    { { UINT32_C( 220966252), UINT32_C(1728582693) },
+      { UINT8_C( 82), UINT8_C(180), UINT8_C(143), UINT8_C(193), UINT8_C(122), UINT8_C( 19), UINT8_C(207), UINT8_C(237) },
+      { UINT8_C( 45), UINT8_C( 87), UINT8_C(  6), UINT8_C(197), UINT8_C(168), UINT8_C(103), UINT8_C(127), UINT8_C(228),
+        UINT8_C(197), UINT8_C(  6), UINT8_C(206), UINT8_C(110), UINT8_C( 31), UINT8_C(232), UINT8_C(190), UINT8_C(139) },
        INT32_C(           3),
-      { UINT32_C(3898224046), UINT32_C( 717540609), UINT32_C( 277240495), UINT32_C(2048503059) } },
-    { { UINT32_C(2524985390), UINT32_C(2831880061), UINT32_C(2651257499), UINT32_C(2152756902) },
-      { UINT8_C( 64), UINT8_C(233), UINT8_C( 90), UINT8_C(215), UINT8_C( 71), UINT8_C( 95), UINT8_C( 29),    UINT8_MAX,
-        UINT8_C(233), UINT8_C(116), UINT8_C(196), UINT8_C( 43), UINT8_C(227), UINT8_C(  3), UINT8_C(250), UINT8_C( 17) },
-      { UINT8_C( 60), UINT8_C(122), UINT8_C(167), UINT8_C(185), UINT8_C(137), UINT8_C(114), UINT8_C( 98), UINT8_C( 36),
-        UINT8_C(108), UINT8_C(104), UINT8_C(194), UINT8_C( 18), UINT8_C(223), UINT8_C( 18), UINT8_C(146), UINT8_C( 31) },
+      { UINT32_C( 221064551), UINT32_C(1728663156) } },
+    { { UINT32_C(3147426197), UINT32_C(1344446973) },
+      { UINT8_C( 86), UINT8_C(177), UINT8_C( 17), UINT8_C(208), UINT8_C(196), UINT8_C(224), UINT8_C(189), UINT8_C(242) },
+      { UINT8_C( 56), UINT8_C(196), UINT8_C(183), UINT8_C(224), UINT8_C( 43), UINT8_C( 54), UINT8_C(196), UINT8_C(240),
+        UINT8_C( 60), UINT8_C(147), UINT8_C( 94), UINT8_C( 92), UINT8_C(123), UINT8_C( 28), UINT8_C(231), UINT8_C( 16) },
        INT32_C(           0),
-      { UINT32_C(2525072461), UINT32_C(2831880061), UINT32_C(2651257499), UINT32_C(2152756902) } },
-    { { UINT32_C(1140321788), UINT32_C( 893523020), UINT32_C(1801455240), UINT32_C(1165777417) },
-      { UINT8_C(212), UINT8_C( 35),    UINT8_MAX, UINT8_C( 93), UINT8_C(149), UINT8_C( 97), UINT8_C(129), UINT8_C(  1),
-        UINT8_C(201), UINT8_C( 68), UINT8_C( 20), UINT8_C(168), UINT8_C( 86), UINT8_C(166), UINT8_C(200), UINT8_C( 82) },
-      { UINT8_C(147), UINT8_C(191), UINT8_C(149), UINT8_C(223), UINT8_C(211), UINT8_C(215), UINT8_C( 21), UINT8_C( 92),
-        UINT8_C(221), UINT8_C(117), UINT8_C(199), UINT8_C(231), UINT8_C(208), UINT8_C( 68), UINT8_C( 44), UINT8_C(164) },
+      { UINT32_C(3147515408), UINT32_C(1344590648) } },
+    { { UINT32_C(  63668230), UINT32_C(2018766370) },
+      { UINT8_C(159), UINT8_C(100), UINT8_C( 72), UINT8_C(100), UINT8_C( 69), UINT8_C(  5), UINT8_C( 86), UINT8_C(125) },
+      { UINT8_C(201), UINT8_C( 13), UINT8_C( 93), UINT8_C(244), UINT8_C( 68), UINT8_C( 34), UINT8_C(228), UINT8_C(128),
+        UINT8_C(181), UINT8_C( 66), UINT8_C(220), UINT8_C( 48), UINT8_C( 95), UINT8_C(196), UINT8_C( 64), UINT8_C(101) },
        INT32_C(           1),
-      { UINT32_C(1140321788), UINT32_C( 893578115), UINT32_C(1801455240), UINT32_C(1165777417) } },
-    { { UINT32_C(4244777831), UINT32_C(1459520396), UINT32_C( 519967431), UINT32_C(1282459321) },
-      { UINT8_C(133), UINT8_C(  6), UINT8_C( 44), UINT8_C( 89), UINT8_C(221), UINT8_C( 65), UINT8_C(181), UINT8_C(187),
-        UINT8_C(182), UINT8_C(124), UINT8_C(162), UINT8_C(134), UINT8_C(192), UINT8_C(206), UINT8_C( 43), UINT8_C( 40) },
-      { UINT8_C(250), UINT8_C( 45), UINT8_C( 37), UINT8_C(134), UINT8_C(176), UINT8_C( 35), UINT8_C(220), UINT8_C(120),
-        UINT8_C( 54), UINT8_C(219), UINT8_C(150), UINT8_C(239), UINT8_C(161), UINT8_C(  6), UINT8_C( 59), UINT8_C( 39) },
+      { UINT32_C(  63711658), UINT32_C(2018806840) } },
+    { { UINT32_C(1718094916), UINT32_C(2581511418) },
+      { UINT8_C( 32), UINT8_C( 38), UINT8_C(253), UINT8_C(101), UINT8_C( 44), UINT8_C( 83), UINT8_C(226), UINT8_C(245) },
+      { UINT8_C( 97), UINT8_C( 64), UINT8_C(234), UINT8_C(165), UINT8_C( 98), UINT8_C(206), UINT8_C( 37), UINT8_C( 23),
+        UINT8_C( 17), UINT8_C(  2), UINT8_C( 71), UINT8_C(112), UINT8_C(198), UINT8_C(135), UINT8_C(213), UINT8_C( 10) },
        INT32_C(           2),
-      { UINT32_C(4244777831), UINT32_C(1459520396), UINT32_C( 520060741), UINT32_C(1282459321) } },
-    { { UINT32_C(3934283532), UINT32_C(1604662696), UINT32_C(1927628721), UINT32_C( 261754901) },
-      { UINT8_C( 61), UINT8_C(191), UINT8_C(150), UINT8_C(238), UINT8_C(226), UINT8_C(114), UINT8_C(102), UINT8_C( 24),
-        UINT8_C( 77), UINT8_C(252), UINT8_C(  7), UINT8_C(239), UINT8_C(  2), UINT8_C( 67), UINT8_C( 22), UINT8_C( 15) },
-      { UINT8_C(170), UINT8_C(150), UINT8_C(249), UINT8_C( 83), UINT8_C(203), UINT8_C(158), UINT8_C(178), UINT8_C(124),
-        UINT8_C(229), UINT8_C(151), UINT8_C(238), UINT8_C(250), UINT8_C(168), UINT8_C(136), UINT8_C( 10), UINT8_C(229) },
+      { UINT32_C(1718124811), UINT32_C(2581555818) } },
+    { { UINT32_C(2373008787), UINT32_C( 438783993) },
+      { UINT8_C(118), UINT8_C( 36), UINT8_C(127), UINT8_C(162), UINT8_C(120), UINT8_C( 98), UINT8_C(151), UINT8_C(217) },
+      { UINT8_C(162), UINT8_C(129), UINT8_C(126), UINT8_C(  4), UINT8_C( 80), UINT8_C(163), UINT8_C( 27), UINT8_C( 97),
+        UINT8_C(165), UINT8_C( 98), UINT8_C(209), UINT8_C(107), UINT8_C(233), UINT8_C(166), UINT8_C(118), UINT8_C(125) },
        INT32_C(           3),
-      { UINT32_C(3934283532), UINT32_C(1604662696), UINT32_C(1927628721), UINT32_C( 261768004) } },
-
+      { UINT32_C(2373077493), UINT32_C( 438873164) } }
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_uint32x4_t r_ = simde_vld1q_u32(test_vec[i].r_);
-    simde_uint8x16_t a = simde_vld1q_u8(test_vec[i].a);
+    simde_uint32x2_t r_ = simde_vld1_u32(test_vec[i].r_);
+    simde_uint8x8_t a = simde_vld1_u8(test_vec[i].a);
     simde_uint8x16_t b = simde_vld1q_u8(test_vec[i].b);
-    simde_uint32x4_t r = simde_vdot_laneq_u32(r_, a, b, test_vec[i].lane);
+    simde_uint32x2_t r = simde_vdot_laneq_u32(r_, a, b, test_vec[i].lane);
 
-    simde_test_arm_neon_assert_equal_u32x4(r, simde_vld1q_u32(test_vec[i].r));
+    simde_test_arm_neon_assert_equal_u32x2(r, simde_vld1_u32(test_vec[i].r));
   }
 
   return 0;
@@ -346,16 +326,16 @@ test_simde_vdot_laneq_u32 (SIMDE_MUNIT_TEST_ARGS) {
   fputc('\n', stdout);
   const int lanes[] = { 0, 1, 2, 3, 0, 1, 2, 3 };
   for (int i = 0 ; i < 8 ; i++) {
-    simde_uint32x4_t r_ = simde_test_arm_neon_random_u32x4();
-    simde_uint8x16_t a = simde_test_arm_neon_random_u8x16();
+    simde_uint32x2_t r_ = simde_test_arm_neon_random_u32x2();
+    simde_uint8x8_t a = simde_test_arm_neon_random_u8x8();
     simde_uint8x16_t b = simde_test_arm_neon_random_u8x16();
-    simde_uint32x4_t r = simde_vdot_laneq_u32(r_, a, b, lanes[i]);
+    simde_uint32x2_t r = simde_vdot_laneq_u32(r_, a, b, lanes[i]);
 
-    simde_test_arm_neon_write_u32x4(2, r_, SIMDE_TEST_VEC_POS_FIRST);
-    simde_test_arm_neon_write_u8x16(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_arm_neon_write_u32x2(2, r_, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_arm_neon_write_u8x8(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
     simde_test_arm_neon_write_u8x16(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
     simde_test_codegen_write_i32(2, lanes[i], SIMDE_TEST_VEC_POS_MIDDLE);
-    simde_test_arm_neon_write_u32x4(2, r, SIMDE_TEST_VEC_POS_LAST);
+    simde_test_arm_neon_write_u32x2(2, r, SIMDE_TEST_VEC_POS_LAST);
   }
   return 1;
 #endif


### PR DESCRIPTION
- Fixed errors in macros such as `__ARM_FEATURE_DOTPROD` and `SIMDE_ARM_NEON_A64V8_NATIVE`
- Fixed implementation logic of the functions
- Fixed parameters and return types of `simde_vdot_laneq_s32` and `simde_vdot_laneq_u32`
- Updated test cases in `dot_lane.c`

Haven't taken a look at the `SIMDE_ARM_NEON_A32V7_NATIVE` fallback. Will fix it in a separate PR