### PR TITLE
gfni: add many x86, ARM, z/Arch, PPC and WASM implementations

### DIFF
--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -707,7 +707,7 @@ simde_mm_move_sd (simde__m128d a, simde__m128d b) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128d
 simde_x_mm_broadcastlow_pd(simde__m128d a) {
-  /* This function broadcasts the first element in the inpu vector to
+  /* This function broadcasts the first element in the input vector to
    * all lanes.  It is used to avoid generating spurious exceptions in
    * *_sd functions since there may be garbage in the upper lanes. */
 
@@ -720,10 +720,8 @@ simde_x_mm_broadcastlow_pd(simde__m128d a) {
 
     #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
       r_.neon_f64 = vdupq_laneq_f64(a_.neon_f64, 0);
-    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_i64 = vdupq_laneq_s64(a_.neon_i64, 0);
     #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-      r_.altivec_s64 = vec_splat(a_.altivec_s64, 0);
+      r_.altivec_f64 = vec_splat(a_.altivec_f64, 0);
     #elif defined(SIMDE_SHUFFLE_VECTOR_)
       r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, a_.f64, 0, 0);
     #else


### PR DESCRIPTION
Add implementations of simde_x_mm_gf2p8matrix_multiply_epi64_epi8 for the following architectures :-
SIMDE_X86_SSE2_NATIVE
SIMDE_ARM_NEON_A64V8_NATIVE
SIMDE_ARM_NEON_A32V7_NATIVE
SIMDE_ZARCH_ZVECTOR_14_NATIVE
SIMDE_ZARCH_ZVECTOR_13_NATIVE
SIMDE_POWER_ALTIVEC_P8_NATIVE
SIMDE_POWER_ALTIVEC_P6_NATIVE
SIMDE_WASM_SIMD128_NATIVE
For these architectures this function is used indirectly by all the `*gf2p8affine*` intrinsics.

Note that qemu doesn't support the ZARCH_ZVECTOR_14 vec_bperm_u128 intrinsic but it was tested on real hardware.
Also gcc gives an ICE with C++ code on z/Arch.