### PR TITLE
neon/cle: Add implementations for remaining functions

### DIFF
--- a/simde/arm/neon/cle.h
+++ b/simde/arm/neon/cle.h
@@ -35,6 +35,62 @@ SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
 SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
+uint64_t
+simde_vcled_f64(simde_float64_t a, simde_float64_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return HEDLEY_STATIC_CAST(uint64_t, vcled_f64(a, b));
+  #else
+    return (a <= b) ? UINT64_MAX : 0;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcled_f64
+  #define vcled_f64(a, b) simde_vcled_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint64_t
+simde_vcled_s64(int64_t a, int64_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return HEDLEY_STATIC_CAST(uint64_t, vcled_s64(a, b));
+  #else
+    return (a <= b) ? UINT64_MAX : 0;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcled_s64
+  #define vcled_s64(a, b) simde_vcled_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint64_t
+simde_vcled_u64(uint64_t a, uint64_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return HEDLEY_STATIC_CAST(uint64_t, vcled_u64(a, b));
+  #else
+    return (a <= b) ? UINT64_MAX : 0;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcled_u64
+  #define vcled_u64(a, b) simde_vcled_u64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint32_t
+simde_vcles_f32(simde_float32_t a, simde_float32_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return HEDLEY_STATIC_CAST(uint32_t, vcles_f32(a, b));
+  #else
+    return (a <= b) ? UINT32_MAX : 0;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcles_f32
+  #define vcles_f32(a, b) simde_vcles_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
 simde_uint32x4_t
 simde_vcleq_f32(simde_float32x4_t a, simde_float32x4_t b) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
@@ -56,7 +112,7 @@ simde_vcleq_f32(simde_float32x4_t a, simde_float32x4_t b) {
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT32_MAX : 0;
+        r_.values[i] = simde_vcles_f32(a_.values[i], b_.values[i]);
       }
     #endif
 
@@ -90,7 +146,7 @@ simde_vcleq_f64(simde_float64x2_t a, simde_float64x2_t b) {
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT64_MAX : 0;
+        r_.values[i] = simde_vcled_f64(a_.values[i], b_.values[i]);
       }
     #endif
 
@@ -226,7 +282,7 @@ simde_vcleq_s64(simde_int64x2_t a, simde_int64x2_t b) {
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT64_MAX : 0;
+        r_.values[i] = simde_vcled_s64(a_.values[i], b_.values[i]);
       }
     #endif
 
@@ -364,7 +420,7 @@ simde_vcleq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT64_MAX : 0;
+        r_.values[i] = simde_vcled_u64(a_.values[i], b_.values[i]);
       }
     #endif
 
@@ -392,7 +448,7 @@ simde_vcle_f32(simde_float32x2_t a, simde_float32x2_t b) {
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT32_MAX : 0;
+        r_.values[i] = simde_vcles_f32(a_.values[i], b_.values[i]);
       }
     #endif
 
@@ -420,7 +476,7 @@ simde_vcle_f64(simde_float64x1_t a, simde_float64x1_t b) {
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT64_MAX : 0;
+        r_.values[i] = simde_vcled_f64(a_.values[i], b_.values[i]);
       }
     #endif
 
@@ -538,7 +594,7 @@ simde_vcle_s64(simde_int64x1_t a, simde_int64x1_t b) {
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT64_MAX : 0;
+        r_.values[i] = simde_vcled_s64(a_.values[i], b_.values[i]);
       }
     #endif
 
@@ -659,7 +715,7 @@ simde_vcle_u64(simde_uint64x1_t a, simde_uint64x1_t b) {
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT64_MAX : 0;
+        r_.values[i] = simde_vcled_u64(a_.values[i], b_.values[i]);
       }
     #endif
 

--- a/simde/arm/neon/cle.h
+++ b/simde/arm/neon/cle.h
@@ -37,13 +37,13 @@ SIMDE_BEGIN_DECLS_
 SIMDE_FUNCTION_ATTRIBUTES
 uint64_t
 simde_vcled_f64(simde_float64_t a, simde_float64_t b) {
-  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return HEDLEY_STATIC_CAST(uint64_t, vcled_f64(a, b));
   #else
     return (a <= b) ? UINT64_MAX : 0;
   #endif
 }
-#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
   #undef vcled_f64
   #define vcled_f64(a, b) simde_vcled_f64((a), (b))
 #endif
@@ -51,13 +51,13 @@ simde_vcled_f64(simde_float64_t a, simde_float64_t b) {
 SIMDE_FUNCTION_ATTRIBUTES
 uint64_t
 simde_vcled_s64(int64_t a, int64_t b) {
-  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return HEDLEY_STATIC_CAST(uint64_t, vcled_s64(a, b));
   #else
     return (a <= b) ? UINT64_MAX : 0;
   #endif
 }
-#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
   #undef vcled_s64
   #define vcled_s64(a, b) simde_vcled_s64((a), (b))
 #endif
@@ -65,13 +65,13 @@ simde_vcled_s64(int64_t a, int64_t b) {
 SIMDE_FUNCTION_ATTRIBUTES
 uint64_t
 simde_vcled_u64(uint64_t a, uint64_t b) {
-  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return HEDLEY_STATIC_CAST(uint64_t, vcled_u64(a, b));
   #else
     return (a <= b) ? UINT64_MAX : 0;
   #endif
 }
-#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
   #undef vcled_u64
   #define vcled_u64(a, b) simde_vcled_u64((a), (b))
 #endif
@@ -79,13 +79,13 @@ simde_vcled_u64(uint64_t a, uint64_t b) {
 SIMDE_FUNCTION_ATTRIBUTES
 uint32_t
 simde_vcles_f32(simde_float32_t a, simde_float32_t b) {
-  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return HEDLEY_STATIC_CAST(uint32_t, vcles_f32(a, b));
   #else
     return (a <= b) ? UINT32_MAX : 0;
   #endif
 }
-#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
   #undef vcles_f32
   #define vcles_f32(a, b) simde_vcles_f32((a), (b))
 #endif

--- a/simde/arm/neon/fma_n.h
+++ b/simde/arm/neon/fma_n.h
@@ -38,7 +38,7 @@ SIMDE_BEGIN_DECLS_
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float32x2_t
 simde_vfma_n_f32(simde_float32x2_t a, simde_float32x2_t b, simde_float32_t c) {
-  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && (defined(__ARM_FEATURE_FMA) && __ARM_FEATURE_FMA) && (!defined(__clang__) || SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0))
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && (defined(__ARM_FEATURE_FMA) && __ARM_FEATURE_FMA) && (!defined(__clang__) || SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0)) && !defined(SIMDE_BUG_GCC_95399)
     return vfma_n_f32(a, b, c);
   #else
     return simde_vfma_f32(a, b, simde_vdup_n_f32(c));
@@ -66,7 +66,7 @@ simde_vfma_n_f64(simde_float64x1_t a, simde_float64x1_t b, simde_float64_t c) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float32x4_t
 simde_vfmaq_n_f32(simde_float32x4_t a, simde_float32x4_t b, simde_float32_t c) {
-  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && (defined(__ARM_FEATURE_FMA) && __ARM_FEATURE_FMA) && (!defined(__clang__) || SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0))
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && (defined(__ARM_FEATURE_FMA) && __ARM_FEATURE_FMA) && (!defined(__clang__) || SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0)) && !defined(SIMDE_BUG_GCC_95399)
     return vfmaq_n_f32(a, b, c);
   #else
     return simde_vfmaq_f32(a, b, simde_vdupq_n_f32(c));

--- a/test/arm/neon/cle.c
+++ b/test/arm/neon/cle.c
@@ -1397,6 +1397,226 @@ test_simde_vcleq_u64 (SIMDE_MUNIT_TEST_ARGS) {
 #endif
 }
 
+static int
+test_simde_vcled_f64 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    simde_float64_t a;
+    simde_float64_t b;
+    uint64_t r;
+  } test_vec[] = {
+    { SIMDE_FLOAT64_C(  -305.11),
+      SIMDE_FLOAT64_C(  -236.09),
+                          UINT64_MAX },
+    { SIMDE_FLOAT64_C(   921.92),
+      SIMDE_FLOAT64_C(   733.85),
+      UINT64_C(                   0) },
+    { SIMDE_FLOAT64_C(  -486.91),
+      SIMDE_FLOAT64_C(   623.76),
+                          UINT64_MAX },
+    { SIMDE_FLOAT64_C(  -463.48),
+      SIMDE_FLOAT64_C(  -725.12),
+      UINT64_C(                   0) },
+    { SIMDE_FLOAT64_C(  -340.50),
+      SIMDE_FLOAT64_C(   856.54),
+                          UINT64_MAX },
+    { SIMDE_FLOAT64_C(  -716.95),
+      SIMDE_FLOAT64_C(    55.73),
+                          UINT64_MAX },
+    { SIMDE_FLOAT64_C(  -230.29),
+      SIMDE_FLOAT64_C(  -777.07),
+      UINT64_C(                   0) },
+    { SIMDE_FLOAT64_C(  -322.84),
+      SIMDE_FLOAT64_C(   432.77),
+                          UINT64_MAX }
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    uint64_t r = simde_vcled_f64(test_vec[i].a, test_vec[i].b);
+    simde_assert_equal_u64(r, test_vec[i].r);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde_float64_t a = simde_test_codegen_random_f64(-1000, 1000);
+    simde_float64_t b = simde_test_codegen_random_f64(-1000, 1000);
+    uint64_t r = simde_vcled_f64(a, b);
+
+    simde_test_codegen_write_f64(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_codegen_write_f64(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_u64(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_vcled_s64 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    int64_t a;
+    int64_t b;
+    uint64_t r;
+  } test_vec[] = {
+    {  INT64_C( 1693521115750436170),
+      -INT64_C( 3888653578582840719),
+      UINT64_C(                   0) },
+    {  INT64_C( 5257715414734765947),
+       INT64_C( 2276217586990052365),
+      UINT64_C(                   0) },
+    { -INT64_C( 8223843280110320820),
+       INT64_C( 1849835537639662773),
+                          UINT64_MAX },
+    {  INT64_C( 4397546442680567662),
+       INT64_C( 2027099013263462701),
+      UINT64_C(                   0) },
+    {  INT64_C( 7773147769218575158),
+       INT64_C( 2549028272055568040),
+      UINT64_C(                   0) },
+    {  INT64_C(  679175870948221695),
+       INT64_C( 8351693777404660219),
+                          UINT64_MAX },
+    {  INT64_C( 4105493476102491352),
+       INT64_C( 4342557720306402666),
+                          UINT64_MAX },
+    {  INT64_C(  748959899008574847),
+       INT64_C( 8435732057402208096),
+                          UINT64_MAX }
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    uint64_t r = simde_vcled_s64(test_vec[i].a, test_vec[i].b);
+    simde_assert_equal_u64(r, test_vec[i].r);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    int64_t a = simde_test_codegen_random_i64();
+    int64_t b = simde_test_codegen_random_i64();
+    uint64_t r = simde_vcled_s64(a, b);
+
+    simde_test_codegen_write_i64(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_codegen_write_i64(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_u64(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_vcled_u64 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    uint64_t a;
+    uint64_t b;
+    uint64_t r;
+  } test_vec[] = {
+    { UINT64_C(16524267212941547145),
+      UINT64_C( 3223249864016383810),
+      UINT64_C(                   0) },
+    { UINT64_C( 6811672435386426989),
+      UINT64_C(11775800435636133210),
+                          UINT64_MAX },
+    { UINT64_C(12628952539174039523),
+      UINT64_C(18353552287922538716),
+                          UINT64_MAX },
+    { UINT64_C( 9325831290852424464),
+      UINT64_C( 6277143169552901983),
+      UINT64_C(                   0) },
+    { UINT64_C(13938633037399316563),
+      UINT64_C(11011299473229520193),
+      UINT64_C(                   0) },
+    { UINT64_C(12457258167826795066),
+      UINT64_C(10467564267655027065),
+      UINT64_C(                   0) },
+    { UINT64_C( 3729755587036182811),
+      UINT64_C( 4935333909924940893),
+                          UINT64_MAX },
+    { UINT64_C(12544924326037889822),
+      UINT64_C(11218150562683698912),
+      UINT64_C(                   0) }
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    uint64_t r = simde_vcled_u64(test_vec[i].a, test_vec[i].b);
+    simde_assert_equal_u64(r, test_vec[i].r);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    uint64_t a = simde_test_codegen_random_u64();
+    uint64_t b = simde_test_codegen_random_u64();
+    uint64_t r = simde_vcled_u64(a, b);
+
+    simde_test_codegen_write_u64(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_codegen_write_u64(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_u64(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_vcles_f32 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    simde_float32_t a;
+    simde_float32_t b;
+    uint32_t r;
+  } test_vec[] = {
+    { SIMDE_FLOAT32_C(  -462.77),
+      SIMDE_FLOAT32_C(  -563.18),
+      UINT32_C(         0) },
+    { SIMDE_FLOAT32_C(  -590.17),
+      SIMDE_FLOAT32_C(   687.19),
+                UINT32_MAX },
+    { SIMDE_FLOAT32_C(   198.94),
+      SIMDE_FLOAT32_C(  -270.32),
+      UINT32_C(         0) },
+    { SIMDE_FLOAT32_C(   -57.87),
+      SIMDE_FLOAT32_C(  -211.45),
+      UINT32_C(         0) },
+    { SIMDE_FLOAT32_C(  -623.27),
+      SIMDE_FLOAT32_C(   512.37),
+                UINT32_MAX },
+    { SIMDE_FLOAT32_C(  -869.47),
+      SIMDE_FLOAT32_C(    30.49),
+                UINT32_MAX },
+    { SIMDE_FLOAT32_C(   837.56),
+      SIMDE_FLOAT32_C(   837.84),
+                UINT32_MAX },
+    { SIMDE_FLOAT32_C(    98.31),
+      SIMDE_FLOAT32_C(  -717.52),
+      UINT32_C(         0) }
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    uint32_t r = simde_vcles_f32(test_vec[i].a, test_vec[i].b);
+    simde_assert_equal_u32(r, test_vec[i].r);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde_float32_t a = simde_test_codegen_random_f32(-1000, 1000);
+    simde_float32_t b = simde_test_codegen_random_f32(-1000, 1000);
+    uint32_t r = simde_vcles_f32(a, b);
+
+    simde_test_codegen_write_f32(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_codegen_write_f32(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_u32(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
 SIMDE_TEST_FUNC_LIST_BEGIN
 SIMDE_TEST_FUNC_LIST_ENTRY(vcle_f32)
 SIMDE_TEST_FUNC_LIST_ENTRY(vcle_f64)
@@ -1419,6 +1639,11 @@ SIMDE_TEST_FUNC_LIST_ENTRY(vcleq_u8)
 SIMDE_TEST_FUNC_LIST_ENTRY(vcleq_u16)
 SIMDE_TEST_FUNC_LIST_ENTRY(vcleq_u32)
 SIMDE_TEST_FUNC_LIST_ENTRY(vcleq_u64)
+
+SIMDE_TEST_FUNC_LIST_ENTRY(vcled_f64)
+SIMDE_TEST_FUNC_LIST_ENTRY(vcled_s64)
+SIMDE_TEST_FUNC_LIST_ENTRY(vcled_u64)
+SIMDE_TEST_FUNC_LIST_ENTRY(vcles_f32)
 SIMDE_TEST_FUNC_LIST_END
 
 #include "test-neon-footer.h"


### PR DESCRIPTION
Implements
- vcled_f63
- vcled_s64
- vcled_u64
- vcles_f32

The new scalar functions are used in the vector implementations.