### PR TITLE
neon: Finish implementation of CLEZ, CLT, CLTZ function families

### DIFF
--- a/simde/arm/neon/clez.h
+++ b/simde/arm/neon/clez.h
@@ -37,6 +37,48 @@ SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
 SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
+uint64_t
+simde_vclezd_s64(int64_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return HEDLEY_STATIC_CAST(uint64_t, vclezd_s64(a));
+  #else
+    return (a <= 0) ? UINT64_MAX : 0;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vclezd_s64
+  #define vclezd_s64(a) simde_vclezd_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint64_t
+simde_vclezd_f64(simde_float64_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return HEDLEY_STATIC_CAST(uint64_t, vclezd_f64(a));
+  #else
+    return (a <= SIMDE_FLOAT64_C(0.0)) ? UINT64_MAX : 0;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vclezd_f64
+  #define vclezd_f64(a) simde_vclezd_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint32_t
+simde_vclezs_f32(simde_float32_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return HEDLEY_STATIC_CAST(uint32_t, vclezs_f32(a));
+  #else
+    return (a <= SIMDE_FLOAT32_C(0.0)) ? UINT32_MAX : 0;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vclezs_f32
+  #define vclezs_f32(a) simde_vclezs_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
 simde_uint32x4_t
 simde_vclezq_f32(simde_float32x4_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)

--- a/simde/arm/neon/clt.h
+++ b/simde/arm/neon/clt.h
@@ -36,6 +36,62 @@ SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
 SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
+uint64_t
+simde_vcltd_f64(simde_float64_t a, simde_float64_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return HEDLEY_STATIC_CAST(uint64_t, vcltd_f64(a, b));
+  #else
+    return (a < b) ? UINT64_MAX : 0;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcltd_f64
+  #define vcltd_f64(a, b) simde_vcltd_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint64_t
+simde_vcltd_s64(int64_t a, int64_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return HEDLEY_STATIC_CAST(uint64_t, vcltd_s64(a, b));
+  #else
+    return (a < b) ? UINT64_MAX : 0;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcltd_s64
+  #define vcltd_s64(a, b) simde_vcltd_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint64_t
+simde_vcltd_u64(uint64_t a, uint64_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return HEDLEY_STATIC_CAST(uint64_t, vcltd_u64(a, b));
+  #else
+    return (a < b) ? UINT64_MAX : 0;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcltd_u64
+  #define vcltd_u64(a, b) simde_vcltd_u64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint32_t
+simde_vclts_f32(simde_float32_t a, simde_float32_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return HEDLEY_STATIC_CAST(uint32_t, vclts_f32(a, b));
+  #else
+    return (a < b) ? UINT32_MAX : 0;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vclts_f32
+  #define vclts_f32(a, b) simde_vclts_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
 simde_uint32x4_t
 simde_vcltq_f32(simde_float32x4_t a, simde_float32x4_t b) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
@@ -57,7 +113,7 @@ simde_vcltq_f32(simde_float32x4_t a, simde_float32x4_t b) {
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT32_MAX : 0;
+        r_.values[i] = simde_vclts_f32(a_.values[i], b_.values[i]);
       }
     #endif
 
@@ -91,7 +147,7 @@ simde_vcltq_f64(simde_float64x2_t a, simde_float64x2_t b) {
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT64_MAX : 0;
+        r_.values[i] = simde_vcltd_f64(a_.values[i], b_.values[i]);
       }
     #endif
 
@@ -227,7 +283,7 @@ simde_vcltq_s64(simde_int64x2_t a, simde_int64x2_t b) {
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT64_MAX : 0;
+        r_.values[i] = simde_vcltd_s64(a_.values[i], b_.values[i]);
       }
     #endif
 
@@ -365,7 +421,7 @@ simde_vcltq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT64_MAX : 0;
+        r_.values[i] = simde_vcltd_u64(a_.values[i], b_.values[i]);
       }
     #endif
 
@@ -393,7 +449,7 @@ simde_vclt_f32(simde_float32x2_t a, simde_float32x2_t b) {
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT32_MAX : 0;
+        r_.values[i] = simde_vclts_f32(a_.values[i], b_.values[i]);
       }
     #endif
 
@@ -421,7 +477,7 @@ simde_vclt_f64(simde_float64x1_t a, simde_float64x1_t b) {
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT64_MAX : 0;
+        r_.values[i] = simde_vcltd_f64(a_.values[i], b_.values[i]);
       }
     #endif
 
@@ -539,7 +595,7 @@ simde_vclt_s64(simde_int64x1_t a, simde_int64x1_t b) {
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT64_MAX : 0;
+        r_.values[i] = simde_vcltd_s64(a_.values[i], b_.values[i]);
       }
     #endif
 
@@ -660,7 +716,7 @@ simde_vclt_u64(simde_uint64x1_t a, simde_uint64x1_t b) {
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT64_MAX : 0;
+        r_.values[i] = simde_vcltd_u64(a_.values[i], b_.values[i]);
       }
     #endif
 

--- a/simde/arm/neon/cltz.h
+++ b/simde/arm/neon/cltz.h
@@ -32,16 +32,62 @@
 #include "types.h"
 #include "shr_n.h"
 #include "reinterpret.h"
+#include "clt.h"
+#include "dup_n.h"
 
 HEDLEY_DIAGNOSTIC_PUSH
 SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
 SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
+uint64_t
+simde_vcltzd_s64(int64_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return HEDLEY_STATIC_CAST(uint64_t, vcltzd_s64(a));
+  #else
+    return (a < 0) ? UINT64_MAX : 0;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcltzd_s64
+  #define vcltzd_s64(a) simde_vcltzd_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint64_t
+simde_vcltzd_f64(simde_float64_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return HEDLEY_STATIC_CAST(uint64_t, vcltzd_f64(a));
+  #else
+    return (a < SIMDE_FLOAT64_C(0.0)) ? UINT64_MAX : 0;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcltzd_f64
+  #define vcltzd_f64(a) simde_vcltzd_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint32_t
+simde_vcltzs_f32(simde_float32_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return HEDLEY_STATIC_CAST(uint32_t, vcltzs_f32(a));
+  #else
+    return (a < SIMDE_FLOAT32_C(0.0)) ? UINT32_MAX : 0;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcltzs_f32
+  #define vcltzs_f32(a) simde_vcltzs_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
 simde_uint32x2_t
 simde_vcltz_f32(simde_float32x2_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vcltz_f32(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vclt_f32(a, simde_vdup_n_f32(SIMDE_FLOAT32_C(0.0)));
   #else
     simde_float32x2_private a_ = simde_float32x2_to_private(a);
     simde_uint32x2_private r_;
@@ -68,6 +114,8 @@ simde_uint64x1_t
 simde_vcltz_f64(simde_float64x1_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vcltz_f64(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vclt_f64(a, simde_vdup_n_f64(SIMDE_FLOAT64_C(0.0)));
   #else
     simde_float64x1_private a_ = simde_float64x1_to_private(a);
     simde_uint64x1_private r_;
@@ -94,6 +142,8 @@ simde_uint8x8_t
 simde_vcltz_s8(simde_int8x8_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vcltz_s8(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vclt_s8(a, simde_vdup_n_s8(0));
   #else
     return simde_vreinterpret_u8_s8(simde_vshr_n_s8(a, 7));
   #endif
@@ -108,6 +158,8 @@ simde_uint16x4_t
 simde_vcltz_s16(simde_int16x4_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vcltz_s16(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vclt_s16(a, simde_vdup_n_s16(0));
   #else
     return simde_vreinterpret_u16_s16(simde_vshr_n_s16(a, 15));
   #endif
@@ -122,6 +174,8 @@ simde_uint32x2_t
 simde_vcltz_s32(simde_int32x2_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vcltz_s32(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vclt_s32(a, simde_vdup_n_s32(0));
   #else
     return simde_vreinterpret_u32_s32(simde_vshr_n_s32(a, 31));
   #endif
@@ -136,6 +190,8 @@ simde_uint64x1_t
 simde_vcltz_s64(simde_int64x1_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vcltz_s64(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vclt_s64(a, simde_vdup_n_s64(0));
   #else
     return simde_vreinterpret_u64_s64(simde_vshr_n_s64(a, 63));
   #endif
@@ -150,6 +206,8 @@ simde_uint32x4_t
 simde_vcltzq_f32(simde_float32x4_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vcltzq_f32(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcltq_f32(a, simde_vdupq_n_f32(SIMDE_FLOAT32_C(0.0)));
   #else
     simde_float32x4_private a_ = simde_float32x4_to_private(a);
     simde_uint32x4_private r_;
@@ -176,6 +234,8 @@ simde_uint64x2_t
 simde_vcltzq_f64(simde_float64x2_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vcltzq_f64(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcltq_f64(a, simde_vdupq_n_f64(SIMDE_FLOAT64_C(0.0)));
   #else
     simde_float64x2_private a_ = simde_float64x2_to_private(a);
     simde_uint64x2_private r_;
@@ -202,6 +262,8 @@ simde_uint8x16_t
 simde_vcltzq_s8(simde_int8x16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vcltzq_s8(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcltq_s8(a, simde_vdupq_n_s8(0));
   #else
     return simde_vreinterpretq_u8_s8(simde_vshrq_n_s8(a, 7));
   #endif
@@ -216,6 +278,8 @@ simde_uint16x8_t
 simde_vcltzq_s16(simde_int16x8_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vcltzq_s16(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcltq_s16(a, simde_vdupq_n_s16(0));
   #else
     return simde_vreinterpretq_u16_s16(simde_vshrq_n_s16(a, 15));
   #endif
@@ -230,6 +294,8 @@ simde_uint32x4_t
 simde_vcltzq_s32(simde_int32x4_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vcltzq_s32(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcltq_s32(a, simde_vdupq_n_s32(0));
   #else
     return simde_vreinterpretq_u32_s32(simde_vshrq_n_s32(a, 31));
   #endif
@@ -244,6 +310,8 @@ simde_uint64x2_t
 simde_vcltzq_s64(simde_int64x2_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vcltzq_s64(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcltq_s64(a, simde_vdupq_n_s64(0));
   #else
     return simde_vreinterpretq_u64_s64(simde_vshrq_n_s64(a, 63));
   #endif

--- a/test/arm/neon/clez.c
+++ b/test/arm/neon/clez.c
@@ -673,6 +673,138 @@ test_simde_vclezq_s64 (SIMDE_MUNIT_TEST_ARGS) {
 #endif
 }
 
+static int
+test_simde_vclezd_s64 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    int64_t a;
+    uint64_t r;
+  } test_vec[] = {
+    { -INT64_C( 6372801726486154762),
+                         UINT64_MAX },
+   {  INT64_C( 2498958616137907508),
+     UINT64_C(                   0) },
+   {  INT64_C( 1572062256963230121),
+     UINT64_C(                   0) },
+   {  INT64_C(  120974916005461340),
+     UINT64_C(                   0) },
+   { -INT64_C( 1154129063315081028),
+                         UINT64_MAX },
+   {  INT64_C(  555258176266455539),
+     UINT64_C(                   0) },
+   {  INT64_C( 4442239051251043142),
+     UINT64_C(                   0) },
+   {  INT64_C( 7568995907833488381),
+     UINT64_C(                   0) }
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    uint64_t r = simde_vclezd_s64(test_vec[i].a);
+    simde_assert_equal_u64(r, test_vec[i].r);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    int64_t a = simde_test_codegen_random_i64();
+    uint64_t r = simde_vclezd_s64(a);
+
+    simde_test_codegen_write_i64(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_codegen_write_u64(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_vclezd_f64 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    simde_float64_t a;
+    uint64_t r;
+  } test_vec[] = {
+    { SIMDE_FLOAT64_C(  -339.74),
+                         UINT64_MAX },
+   { SIMDE_FLOAT64_C(   -68.07),
+                         UINT64_MAX },
+   { SIMDE_FLOAT64_C(  -628.28),
+                         UINT64_MAX },
+   { SIMDE_FLOAT64_C(   764.54),
+     UINT64_C(                   0) },
+   { SIMDE_FLOAT64_C(   552.63),
+     UINT64_C(                   0) },
+   { SIMDE_FLOAT64_C(  -265.81),
+                         UINT64_MAX },
+   { SIMDE_FLOAT64_C(  -985.62),
+                         UINT64_MAX },
+   { SIMDE_FLOAT64_C(    59.35),
+     UINT64_C(                   0) }
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    uint64_t r = simde_vclezd_f64(test_vec[i].a);
+    simde_assert_equal_u64(r, test_vec[i].r);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde_float64_t a = simde_test_codegen_random_f64(-1000, 1000);
+    uint64_t r = simde_vclezd_f64(a);
+
+    simde_test_codegen_write_f64(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_codegen_write_u64(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_vclezs_f32 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    simde_float32_t a;
+    uint32_t r;
+  } test_vec[] = {
+    { SIMDE_FLOAT32_C(   683.74),
+     UINT32_C(         0) },
+   { SIMDE_FLOAT32_C(  -775.03),
+               UINT32_MAX },
+   { SIMDE_FLOAT32_C(   360.39),
+     UINT32_C(         0) },
+   { SIMDE_FLOAT32_C(   691.68),
+     UINT32_C(         0) },
+   { SIMDE_FLOAT32_C(   549.89),
+     UINT32_C(         0) },
+   { SIMDE_FLOAT32_C(  -850.76),
+               UINT32_MAX },
+   { SIMDE_FLOAT32_C(   828.85),
+     UINT32_C(         0) },
+   { SIMDE_FLOAT32_C(   571.99),
+     UINT32_C(         0) }
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    uint32_t r = simde_vclezs_f32(test_vec[i].a);
+    simde_assert_equal_u32(r, test_vec[i].r);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde_float32_t a = simde_test_codegen_random_f32(-1000, 1000);
+    uint32_t r = simde_vclezs_f32(a);
+
+    simde_test_codegen_write_f32(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_codegen_write_u32(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
 SIMDE_TEST_FUNC_LIST_BEGIN
 SIMDE_TEST_FUNC_LIST_ENTRY(vclez_f32)
 SIMDE_TEST_FUNC_LIST_ENTRY(vclez_f64)
@@ -687,6 +819,10 @@ SIMDE_TEST_FUNC_LIST_ENTRY(vclezq_s8)
 SIMDE_TEST_FUNC_LIST_ENTRY(vclezq_s16)
 SIMDE_TEST_FUNC_LIST_ENTRY(vclezq_s32)
 SIMDE_TEST_FUNC_LIST_ENTRY(vclezq_s64)
+
+SIMDE_TEST_FUNC_LIST_ENTRY(vclezd_s64)
+SIMDE_TEST_FUNC_LIST_ENTRY(vclezd_f64)
+SIMDE_TEST_FUNC_LIST_ENTRY(vclezs_f32)
 SIMDE_TEST_FUNC_LIST_END
 
 #include "test-neon-footer.h"

--- a/test/arm/neon/clt.c
+++ b/test/arm/neon/clt.c
@@ -1397,6 +1397,226 @@ test_simde_vcltq_u64 (SIMDE_MUNIT_TEST_ARGS) {
 #endif
 }
 
+static int
+test_simde_vcltd_f64 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    simde_float64_t a;
+    simde_float64_t b;
+    uint64_t r;
+  } test_vec[] = {
+    { SIMDE_FLOAT64_C(   533.95),
+      SIMDE_FLOAT64_C(   746.90),
+                          UINT64_MAX },
+    { SIMDE_FLOAT64_C(   573.36),
+      SIMDE_FLOAT64_C(   889.97),
+                          UINT64_MAX },
+    { SIMDE_FLOAT64_C(  -468.38),
+      SIMDE_FLOAT64_C(  -287.97),
+                          UINT64_MAX },
+    { SIMDE_FLOAT64_C(  -620.98),
+      SIMDE_FLOAT64_C(   535.88),
+                          UINT64_MAX },
+    { SIMDE_FLOAT64_C(   425.47),
+      SIMDE_FLOAT64_C(    98.32),
+      UINT64_C(                   0) },
+    { SIMDE_FLOAT64_C(  -160.48),
+      SIMDE_FLOAT64_C(   423.53),
+                          UINT64_MAX },
+    { SIMDE_FLOAT64_C(  -851.46),
+      SIMDE_FLOAT64_C(  -635.13),
+                          UINT64_MAX },
+    { SIMDE_FLOAT64_C(   951.90),
+      SIMDE_FLOAT64_C(  -927.56),
+      UINT64_C(                   0) }
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    uint64_t r = simde_vcltd_f64(test_vec[i].a, test_vec[i].b);
+    simde_assert_equal_u64(r, test_vec[i].r);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde_float64_t a = simde_test_codegen_random_f64(-1000, 1000);
+    simde_float64_t b = simde_test_codegen_random_f64(-1000, 1000);
+    uint64_t r = simde_vcltd_f64(a, b);
+
+    simde_test_codegen_write_f64(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_codegen_write_f64(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_u64(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_vcltd_s64 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    int64_t a;
+    int64_t b;
+    uint64_t r;
+  } test_vec[] = {
+    {  INT64_C(  255893999981097058),
+      INT64_C( 4825350567398967245),
+                         UINT64_MAX },
+   {  INT64_C( 6007846673558272820),
+     -INT64_C( 2265888410887594764),
+     UINT64_C(                   0) },
+   {  INT64_C( 9160927138501202914),
+     -INT64_C(  524970878510387539),
+     UINT64_C(                   0) },
+   {  INT64_C( 5040462918486993384),
+      INT64_C( 2705724683769958702),
+     UINT64_C(                   0) },
+   { -INT64_C(  473045855704439490),
+      INT64_C( 4238208662586090773),
+                         UINT64_MAX },
+   {  INT64_C( 4892260587991122765),
+     -INT64_C( 1547412342135848418),
+     UINT64_C(                   0) },
+   {  INT64_C( 5181191478929181602),
+     -INT64_C( 4162186453568170577),
+     UINT64_C(                   0) },
+   {  INT64_C(   75517635955332788),
+      INT64_C( 2009706568804924492),
+                         UINT64_MAX }
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    uint64_t r = simde_vcltd_s64(test_vec[i].a, test_vec[i].b);
+    simde_assert_equal_u64(r, test_vec[i].r);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    int64_t a = simde_test_codegen_random_i64();
+    int64_t b = simde_test_codegen_random_i64();
+    uint64_t r = simde_vcltd_s64(a, b);
+
+    simde_test_codegen_write_i64(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_codegen_write_i64(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_u64(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_vcltd_u64 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    uint64_t a;
+    uint64_t b;
+    uint64_t r;
+  } test_vec[] = {
+    { UINT64_C(13199469999607627188),
+      UINT64_C(17475643578917670213),
+                          UINT64_MAX },
+    { UINT64_C( 9291426536416340492),
+      UINT64_C(17318693780852396996),
+                          UINT64_MAX },
+    { UINT64_C(10941498941691552025),
+      UINT64_C(10556677798004887888),
+      UINT64_C(                   0) },
+    { UINT64_C(14373927621614517189),
+      UINT64_C( 7562489693708022726),
+      UINT64_C(                   0) },
+    { UINT64_C( 2208278725635197629),
+      UINT64_C(11100016101477383154),
+                          UINT64_MAX },
+    { UINT64_C(14353550357350878568),
+      UINT64_C( 5744549760829371905),
+      UINT64_C(                   0) },
+    { UINT64_C(10841012728057709191),
+      UINT64_C(13073415685580726270),
+                          UINT64_MAX },
+    { UINT64_C( 1256314152064909992),
+      UINT64_C( 9109404319922338185),
+                          UINT64_MAX }
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    uint64_t r = simde_vcltd_u64(test_vec[i].a, test_vec[i].b);
+    simde_assert_equal_u64(r, test_vec[i].r);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    uint64_t a = simde_test_codegen_random_u64();
+    uint64_t b = simde_test_codegen_random_u64();
+    uint64_t r = simde_vcltd_u64(a, b);
+
+    simde_test_codegen_write_u64(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_codegen_write_u64(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_u64(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_vclts_f32 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    simde_float32_t a;
+    simde_float32_t b;
+    uint32_t r;
+  } test_vec[] = {
+    { SIMDE_FLOAT32_C(  -190.08),
+      SIMDE_FLOAT32_C(   833.00),
+                UINT32_MAX },
+    { SIMDE_FLOAT32_C(   896.69),
+      SIMDE_FLOAT32_C(   900.72),
+                UINT32_MAX },
+    { SIMDE_FLOAT32_C(  -980.09),
+      SIMDE_FLOAT32_C(  -878.50),
+                UINT32_MAX },
+    { SIMDE_FLOAT32_C(  -545.23),
+      SIMDE_FLOAT32_C(  -846.74),
+      UINT32_C(         0) },
+    { SIMDE_FLOAT32_C(  -227.24),
+      SIMDE_FLOAT32_C(  -583.33),
+      UINT32_C(         0) },
+    { SIMDE_FLOAT32_C(  -329.70),
+      SIMDE_FLOAT32_C(   600.18),
+                UINT32_MAX },
+    { SIMDE_FLOAT32_C(  -438.24),
+      SIMDE_FLOAT32_C(   847.23),
+                UINT32_MAX },
+    { SIMDE_FLOAT32_C(   716.84),
+      SIMDE_FLOAT32_C(  -704.38),
+      UINT32_C(         0) }
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    uint32_t r = simde_vclts_f32(test_vec[i].a, test_vec[i].b);
+    simde_assert_equal_u32(r, test_vec[i].r);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde_float32_t a = simde_test_codegen_random_f32(-1000, 1000);
+    simde_float32_t b = simde_test_codegen_random_f32(-1000, 1000);
+    uint32_t r = simde_vclts_f32(a, b);
+
+    simde_test_codegen_write_f32(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_codegen_write_f32(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_u32(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
 SIMDE_TEST_FUNC_LIST_BEGIN
 SIMDE_TEST_FUNC_LIST_ENTRY(vclt_f32)
 SIMDE_TEST_FUNC_LIST_ENTRY(vclt_f64)
@@ -1419,6 +1639,11 @@ SIMDE_TEST_FUNC_LIST_ENTRY(vcltq_u8)
 SIMDE_TEST_FUNC_LIST_ENTRY(vcltq_u16)
 SIMDE_TEST_FUNC_LIST_ENTRY(vcltq_u32)
 SIMDE_TEST_FUNC_LIST_ENTRY(vcltq_u64)
+
+SIMDE_TEST_FUNC_LIST_ENTRY(vcltd_f64)
+SIMDE_TEST_FUNC_LIST_ENTRY(vcltd_s64)
+SIMDE_TEST_FUNC_LIST_ENTRY(vcltd_u64)
+SIMDE_TEST_FUNC_LIST_ENTRY(vclts_f32)
 SIMDE_TEST_FUNC_LIST_END
 
 #include "test-neon-footer.h"

--- a/test/arm/neon/cltz.c
+++ b/test/arm/neon/cltz.c
@@ -425,6 +425,138 @@ test_simde_vcltzq_s64 (SIMDE_MUNIT_TEST_ARGS) {
   return 0;
 }
 
+static int
+test_simde_vcltzd_s64 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    int64_t a;
+    uint64_t r;
+  } test_vec[] = {
+    {  INT64_C( 4895556179217159423),
+      UINT64_C(                   0) },
+    { -INT64_C( 5958045163452274988),
+                          UINT64_MAX },
+    { -INT64_C( 7404907283308324771),
+                          UINT64_MAX },
+    { -INT64_C( 5357149720396651297),
+                          UINT64_MAX },
+    {  INT64_C( 3626495416649243816),
+      UINT64_C(                   0) },
+    {  INT64_C( 2771735539879904332),
+      UINT64_C(                   0) },
+    { -INT64_C( 8777399505245099129),
+                          UINT64_MAX },
+    { -INT64_C( 7459753252293551091),
+                          UINT64_MAX }
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    uint64_t r = simde_vcltzd_s64(test_vec[i].a);
+    simde_assert_equal_u64(r, test_vec[i].r);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    int64_t a = simde_test_codegen_random_i64();
+    uint64_t r = simde_vcltzd_s64(a);
+
+    simde_test_codegen_write_i64(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_codegen_write_u64(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_vcltzd_f64 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    simde_float64_t a;
+    uint64_t r;
+  } test_vec[] = {
+    { SIMDE_FLOAT64_C(   918.77),
+      UINT64_C(                   0) },
+    { SIMDE_FLOAT64_C(  -706.44),
+                          UINT64_MAX },
+    { SIMDE_FLOAT64_C(  -108.73),
+                          UINT64_MAX },
+    { SIMDE_FLOAT64_C(  -943.89),
+                          UINT64_MAX },
+    { SIMDE_FLOAT64_C(   654.01),
+      UINT64_C(                   0) },
+    { SIMDE_FLOAT64_C(   689.80),
+      UINT64_C(                   0) },
+    { SIMDE_FLOAT64_C(   101.37),
+      UINT64_C(                   0) },
+    { SIMDE_FLOAT64_C(   763.46),
+      UINT64_C(                   0) }
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    uint64_t r = simde_vcltzd_f64(test_vec[i].a);
+    simde_assert_equal_u64(r, test_vec[i].r);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde_float64_t a = simde_test_codegen_random_f64(-1000, 1000);
+    uint64_t r = simde_vcltzd_f64(a);
+
+    simde_test_codegen_write_f64(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_codegen_write_u64(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_vcltzs_f32 (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    simde_float32_t a;
+    uint32_t r;
+  } test_vec[] = {
+    { SIMDE_FLOAT32_C(   418.80),
+      UINT32_C(         0) },
+    { SIMDE_FLOAT32_C(   -38.64),
+                UINT32_MAX },
+    { SIMDE_FLOAT32_C(   835.62),
+      UINT32_C(         0) },
+    { SIMDE_FLOAT32_C(  -210.67),
+                UINT32_MAX },
+    { SIMDE_FLOAT32_C(   753.71),
+      UINT32_C(         0) },
+    { SIMDE_FLOAT32_C(   601.27),
+      UINT32_C(         0) },
+    { SIMDE_FLOAT32_C(  -439.56),
+                UINT32_MAX },
+    { SIMDE_FLOAT32_C(   192.08),
+      UINT32_C(         0) }
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    uint32_t r = simde_vcltzs_f32(test_vec[i].a);
+    simde_assert_equal_u32(r, test_vec[i].r);
+  }
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  for (int i = 0 ; i < 8 ; i++) {
+    simde_float32_t a = simde_test_codegen_random_f32(-1000, 1000);
+    uint32_t r = simde_vcltzs_f32(a);
+
+    simde_test_codegen_write_f32(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_codegen_write_u32(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
 SIMDE_TEST_FUNC_LIST_BEGIN
 SIMDE_TEST_FUNC_LIST_ENTRY(vcltz_f32)
 SIMDE_TEST_FUNC_LIST_ENTRY(vcltz_f64)
@@ -439,6 +571,10 @@ SIMDE_TEST_FUNC_LIST_ENTRY(vcltzq_s8)
 SIMDE_TEST_FUNC_LIST_ENTRY(vcltzq_s16)
 SIMDE_TEST_FUNC_LIST_ENTRY(vcltzq_s32)
 SIMDE_TEST_FUNC_LIST_ENTRY(vcltzq_s64)
+
+SIMDE_TEST_FUNC_LIST_ENTRY(vcltzd_f64)
+SIMDE_TEST_FUNC_LIST_ENTRY(vcltzd_s64)
+SIMDE_TEST_FUNC_LIST_ENTRY(vcltzs_f32)
 SIMDE_TEST_FUNC_LIST_END
 
 #include "test-neon-footer.h"


### PR DESCRIPTION
Adds the scalar functions for CLEZ, CLT, and CLTZ.

Also added fallbacks for `SIMDE_NATURAL_VECTOR_SIZE > 0` in CLTZ functions which make use of `vclt` and `vdup_n` to implement the function. 

Has passed all CI tests over at my fork