### PR TITLE
docker/Dockerfile: Use netselect-apt to speed up image build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,11 @@ FROM debian:${release}-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+RUN apt-get update -y && \
+    apt-get install -y netselect-apt
+RUN netselect-apt -n testing
+RUN mv sources.list /etc/apt/sources.list
+
 COPY docker/bin /tmp/simde-bin
 RUN \
   for script in simde-reset-build.sh; do \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,9 +7,9 @@ FROM debian:${release}-slim
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \
-    apt-get install -y netselect-apt
-RUN netselect-apt -n testing
-RUN mv sources.list /etc/apt/sources.list
+    apt-get install -y netselect-apt && \
+    netselect-apt -n testing && \
+    mv sources.list /etc/apt/sources.list
 
 COPY docker/bin /tmp/simde-bin
 RUN \


### PR DESCRIPTION
This adds netselect-apt to the docker build which selects the best debian mirror automatically
according to the region. This significantly improves the package manager's download speeds.