### PR TITLE
neon/st3q_u8: Wasm optimization

### DIFF
--- a/simde/arm/neon/st3.h
+++ b/simde/arm/neon/st3.h
@@ -347,6 +347,40 @@ void
 simde_vst3q_u8(uint8_t *ptr, simde_uint8x16x3_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst3q_u8(ptr, val);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    simde_uint8x16_private a_[3] = {simde_uint8x16_to_private(val.val[0]),
+                                    simde_uint8x16_to_private(val.val[1]),
+                                    simde_uint8x16_to_private(val.val[2])};
+    v128_t a = a_[0].v128;
+    v128_t b = a_[1].v128;
+    v128_t c = a_[2].v128;
+
+    // r0 = [a0, b0, a6, a1, b1, a7, a2, b2, a8, a3, b3, a9, a4, b4, a10, a5]
+    v128_t r0 = wasm_i8x16_shuffle(a, b, 0, 16, 6, 1, 17, 7, 2, 18, 8, 3, 19, 9,
+                                   4, 20, 10, 5);
+    // m0 = [a0, b0, c0, a1, b1, c1, a2, b2, c2, a3, b3, c3, a4, b4, c4, a5]
+    v128_t m0 = wasm_i8x16_shuffle(r0, c, 0, 1, 16, 3, 4, 17, 6, 7, 18, 9, 10,
+                                   19, 12, 13, 20, 15);
+    wasm_v128_store(ptr, m0);
+
+    // r1 = [b5, c5, b11, b6, c6, b12, b7, c7, b13, b8, c8, b14, b9, c9, b15,
+    // b10]
+    v128_t r1 = wasm_i8x16_shuffle(b, c, 5, 21, 11, 6, 22, 12, 7, 23, 13, 8, 24,
+                                   14, 9, 25, 15, 10);
+    // m1 = [b5, c5, a6, b6, c6, a7, b7, c7, a8, b8, c8, a9, b9, c9, a10, b10]
+    v128_t m1 = wasm_i8x16_shuffle(r1, r0, 0, 1, 18, 3, 4, 21, 6, 7, 24, 9, 10,
+                                   27, 12, 13, 30, 15);
+    wasm_v128_store(ptr + 16, m1);
+
+    // r2 = [c10, a11, X, c11, a12, X, c12, a13, X, c13, a14, X, c14, a15, X,
+    // c15]
+    v128_t r2 = wasm_i8x16_shuffle(c, a, 10, 27, 0, 11, 28, 0, 12, 29, 0, 13,
+                                   30, 0, 14, 31, 0, 15);
+    // m2 = [c10, a11, b11, c11, a12, b12, c12, a13, b13, c13, a14, b14, c14,
+    // a15, b15, c15]
+    v128_t m2 = wasm_i8x16_shuffle(r2, r1, 0, 1, 18, 3, 4, 21, 6, 7, 24, 9, 10,
+                                   27, 12, 13, 30, 15);
+    wasm_v128_store(ptr + 32, m2);
   #else
     uint8_t buf[48];
     simde_uint8x16_private a_[3] = { simde_uint8x16_to_private(val.val[0]), simde_uint8x16_to_private(val.val[1]), simde_uint8x16_to_private(val.val[2]) };


### PR DESCRIPTION
Autovectorizer is unable to do anything here, so implement it using a
bunch of shuffles.