### PR TITLE
various: correct PPC and z/Arch versions plus typo

### DIFF
--- a/simde/arm/neon/rev32.h
+++ b/simde/arm/neon/rev32.h
@@ -131,7 +131,7 @@ simde_vrev32q_s8(simde_int8x16_t a) {
                                    vec_revb(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int), a)));
   #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char),
-                                   vec_reve(HEDLEY_REINTERPRET_CAST(SIMDE1_POWER_ALTIVEC_VECTOR(signed int), vec_reve(a))));
+                                   vec_reve(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int), vec_reve(a))));
   #else
     simde_int8x16_private
       r_,

--- a/simde/arm/neon/rnd.h
+++ b/simde/arm/neon/rnd.h
@@ -115,7 +115,7 @@ simde_float64x2_t
 simde_vrndq_f64(simde_float64x2_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vrndq_f64(a);
-  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return vec_trunc(a);
   #else
     simde_float64x2_private

--- a/simde/arm/neon/rndm.h
+++ b/simde/arm/neon/rndm.h
@@ -115,7 +115,7 @@ simde_float64x2_t
 simde_vrndmq_f64(simde_float64x2_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vrndmq_f64(a);
-  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return vec_floor(a);
   #else
     simde_float64x2_private

--- a/simde/arm/neon/rndp.h
+++ b/simde/arm/neon/rndp.h
@@ -115,7 +115,7 @@ simde_float64x2_t
 simde_vrndpq_f64(simde_float64x2_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vrndpq_f64(a);
-  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return vec_ceil(a);
   #else
     simde_float64x2_private

--- a/simde/arm/sve/add.h
+++ b/simde/arm/sve/add.h
@@ -1101,7 +1101,7 @@ simde_svadd_f64_x(simde_svbool_t pg, simde_svfloat64_t op1, simde_svfloat64_t op
       for (int i = 0 ; i < HEDLEY_STATIC_CAST(int, sizeof(r.m128d) / sizeof(r.m128d[0])) ; i++) {
         r.m128d[i] = _mm_add_pd(op1.m128d[i], op2.m128d[i]);
       }
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
       r.altivec = vec_add(op1.altivec, op2.altivec);
     #elif defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       r.altivec = op1.altivec + op2.altivec;

--- a/simde/arm/sve/and.h
+++ b/simde/arm/sve/and.h
@@ -424,7 +424,7 @@ simde_svand_s64_x(simde_svbool_t pg, simde_svint64_t op1, simde_svint64_t op2) {
       for (int i = 0 ; i < HEDLEY_STATIC_CAST(int, sizeof(r.m128i) / sizeof(r.m128i[0])) ; i++) {
         r.m128i[i] = _mm_and_si128(op1.m128i[i], op2.m128i[i]);
       }
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
       r.altivec = vec_and(op1.altivec, op2.altivec);
     #elif defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       r.altivec = op1.altivec & op2.altivec;

--- a/simde/arm/sve/cmplt.h
+++ b/simde/arm/sve/cmplt.h
@@ -360,7 +360,7 @@ simde_svcmplt_f32(simde_svbool_t pg, simde_svfloat32_t op1, simde_svfloat32_t op
       }
     #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
       r.altivec_b32 = vec_and(pg.altivec_b32, vec_cmplt(op1.altivec, op2.altivec));
-    #elif defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #elif defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
       r.altivec_b32 = pg.altivec_b32 & vec_cmplt(op1.altivec, op2.altivec);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r.v128 = wasm_v128_and(pg.v128, wasm_f32x4_lt(op1.v128, op2.v128));

--- a/simde/arm/sve/dup.h
+++ b/simde/arm/sve/dup.h
@@ -54,7 +54,7 @@ simde_svdup_n_s8(int8_t op) {
       for (int i = 0 ; i < HEDLEY_STATIC_CAST(int, sizeof(r.m128i) / sizeof(r.m128i[0])) ; i++) {
         r.m128i[i] = _mm_set1_epi8(op);
       }
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       r.altivec = vec_splats(op);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r.v128 = wasm_i8x16_splat(op);
@@ -151,7 +151,7 @@ simde_svdup_n_s16(int16_t op) {
       for (int i = 0 ; i < HEDLEY_STATIC_CAST(int, sizeof(r.m128i) / sizeof(r.m128i[0])) ; i++) {
         r.m128i[i] = _mm_set1_epi16(op);
       }
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       r.altivec = vec_splats(op);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r.v128 = wasm_i16x8_splat(op);
@@ -248,7 +248,7 @@ simde_svdup_n_s32(int32_t op) {
       for (int i = 0 ; i < HEDLEY_STATIC_CAST(int, sizeof(r.m128i) / sizeof(r.m128i[0])) ; i++) {
         r.m128i[i] = _mm_set1_epi32(op);
       }
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       r.altivec = vec_splats(op);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r.v128 = wasm_i32x4_splat(op);
@@ -345,7 +345,7 @@ simde_svdup_n_s64(int64_t op) {
       for (int i = 0 ; i < HEDLEY_STATIC_CAST(int, sizeof(r.m128i) / sizeof(r.m128i[0])) ; i++) {
         r.m128i[i] = _mm_set1_epi64x(op);
       }
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       r.altivec = vec_splats(HEDLEY_STATIC_CAST(signed long long int, op));
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r.v128 = wasm_i64x2_splat(op);
@@ -442,7 +442,7 @@ simde_svdup_n_u8(uint8_t op) {
       for (int i = 0 ; i < HEDLEY_STATIC_CAST(int, sizeof(r.m128i) / sizeof(r.m128i[0])) ; i++) {
         r.m128i[i] = _mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, op));
       }
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       r.altivec = vec_splats(op);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r.v128 = wasm_i8x16_splat(HEDLEY_STATIC_CAST(int8_t, op));
@@ -539,7 +539,7 @@ simde_svdup_n_u16(uint16_t op) {
       for (int i = 0 ; i < HEDLEY_STATIC_CAST(int, sizeof(r.m128i) / sizeof(r.m128i[0])) ; i++) {
         r.m128i[i] = _mm_set1_epi16(HEDLEY_STATIC_CAST(int16_t, op));
       }
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       r.altivec = vec_splats(op);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r.v128 = wasm_i16x8_splat(HEDLEY_STATIC_CAST(int16_t, op));
@@ -636,7 +636,7 @@ simde_svdup_n_u32(uint32_t op) {
       for (int i = 0 ; i < HEDLEY_STATIC_CAST(int, sizeof(r.m128i) / sizeof(r.m128i[0])) ; i++) {
         r.m128i[i] = _mm_set1_epi32(HEDLEY_STATIC_CAST(int32_t, op));
       }
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       r.altivec = vec_splats(op);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r.v128 = wasm_i32x4_splat(HEDLEY_STATIC_CAST(int32_t, op));
@@ -733,7 +733,7 @@ simde_svdup_n_u64(uint64_t op) {
       for (int i = 0 ; i < HEDLEY_STATIC_CAST(int, sizeof(r.m128i) / sizeof(r.m128i[0])) ; i++) {
         r.m128i[i] = _mm_set1_epi64x(HEDLEY_STATIC_CAST(int64_t, op));
       }
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       r.altivec = vec_splats(HEDLEY_STATIC_CAST(unsigned long long int, op));
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r.v128 = wasm_i64x2_splat(HEDLEY_STATIC_CAST(int64_t, op));
@@ -830,7 +830,7 @@ simde_svdup_n_f32(simde_float32 op) {
       for (int i = 0 ; i < HEDLEY_STATIC_CAST(int, sizeof(r.m128) / sizeof(r.m128[0])) ; i++) {
         r.m128[i] = _mm_set1_ps(op);
       }
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
       r.altivec = vec_splats(op);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r.v128 = wasm_f32x4_splat(op);

--- a/simde/arm/sve/sel.h
+++ b/simde/arm/sve/sel.h
@@ -319,7 +319,7 @@ simde_x_svsel_s64_z(simde_svbool_t pg, simde_svint64_t op1) {
       for (int i = 0 ; i < HEDLEY_STATIC_CAST(int, sizeof(r.m128i) / sizeof(r.m128i[0])) ; i++) {
         r.m128i[i] = _mm_and_si128(pg.m128i[i], op1.m128i[i]);
       }
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
       r.altivec = vec_and(pg.altivec_b64, op1.altivec);
     #elif defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       r.altivec = HEDLEY_REINTERPRET_CAST(__typeof__(op1.altivec), pg.values_i64) & op1.altivec;
@@ -364,7 +364,7 @@ simde_svsel_s64(simde_svbool_t pg, simde_svint64_t op1, simde_svint64_t op2) {
       for (int i = 0 ; i < HEDLEY_STATIC_CAST(int, sizeof(r.m128i) / sizeof(r.m128i[0])) ; i++) {
         r.m128i[i] = _mm_or_si128(_mm_and_si128(pg.m128i[i], op1.m128i[i]), _mm_andnot_si128(pg.m128i[i], op2.m128i[i]));
       }
-    #elif (defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)) && !defined(SIMDE_BUG_CLANG_46770)
+    #elif (defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)) && !defined(SIMDE_BUG_CLANG_46770)
       r.altivec = vec_sel(op2.altivec, op1.altivec, pg.altivec_b64);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r.v128 = wasm_v128_bitselect(op1.v128, op2.v128, pg.v128);

--- a/simde/arm/sve/sub.h
+++ b/simde/arm/sve/sub.h
@@ -1101,7 +1101,7 @@ simde_svsub_f64_x(simde_svbool_t pg, simde_svfloat64_t op1, simde_svfloat64_t op
       for (int i = 0 ; i < HEDLEY_STATIC_CAST(int, sizeof(r.m128d) / sizeof(r.m128d[0])) ; i++) {
         r.m128d[i] = _mm_sub_pd(op1.m128d[i], op2.m128d[i]);
       }
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
       r.altivec = vec_sub(op1.altivec, op2.altivec);
     #elif defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       r.altivec = op1.altivec - op2.altivec;

--- a/simde/arm/sve/types.h
+++ b/simde/arm/sve/types.h
@@ -183,7 +183,7 @@ SIMDE_BEGIN_DECLS_
       int64x2_t neon;
     #endif
 
-    #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       SIMDE_POWER_ALTIVEC_VECTOR(signed long long int) altivec;
     #endif
 
@@ -287,7 +287,7 @@ SIMDE_BEGIN_DECLS_
       uint64x2_t neon;
     #endif
 
-    #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long int) altivec;
     #endif
 
@@ -847,7 +847,7 @@ SIMDE_BEGIN_DECLS_
         SIMDE_POWER_ALTIVEC_VECTOR(SIMDE_POWER_ALTIVEC_BOOL short) altivec_b16;
         SIMDE_POWER_ALTIVEC_VECTOR(SIMDE_POWER_ALTIVEC_BOOL   int) altivec_b32;
       #endif
-      #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
         SIMDE_POWER_ALTIVEC_VECTOR(SIMDE_POWER_ALTIVEC_BOOL  long long) altivec_b64;
       #endif
 

--- a/simde/wasm/simd128.h
+++ b/simde/wasm/simd128.h
@@ -775,7 +775,7 @@ simde_wasm_f32x4_splat (simde_float32 a) {
       r_.sse_m128 = _mm_set1_ps(a);
     #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_f32 = vdupq_n_f32(a);
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
       r_.altivec_f32 = vec_splats(a);
     #else
       SIMDE_VECTORIZE

--- a/simde/x86/avx512/abs.h
+++ b/simde/x86/avx512/abs.h
@@ -538,7 +538,7 @@ simde_mm512_abs_pd(simde__m512d v2) {
       for (size_t i = 0 ; i < (sizeof(r_.m128d_private) / sizeof(r_.m128d_private[0])) ; i++) {
         r_.m128d_private[i].neon_f64 = vabsq_f64(v2_.m128d_private[i].neon_f64);
       }
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
       for (size_t i = 0 ; i < (sizeof(r_.m128d_private) / sizeof(r_.m128d_private[0])) ; i++) {
         r_.m128d_private[i].altivec_f64 = vec_abs(v2_.m128d_private[i].altivec_f64);
       }

--- a/simde/x86/avx512/lzcnt.h
+++ b/simde/x86/avx512/lzcnt.h
@@ -162,7 +162,7 @@ simde_mm_lzcnt_epi32(simde__m128i a) {
       r_,
       a_ = simde__m128i_to_private(a);
 
-    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       r_.altivec_u32 = vec_cntlz(a_.altivec_u32);
     #else
       SIMDE_VECTORIZE

--- a/simde/x86/avx512/round.h
+++ b/simde/x86/avx512/round.h
@@ -62,7 +62,7 @@ SIMDE_BEGIN_DECLS_
         break;
 
       case SIMDE_MM_FROUND_TO_NEAREST_INT:
-        #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
+        #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
           for (size_t i = 0 ; i < (sizeof(r_.m128_private) / sizeof(r_.m128_private[0])) ; i++) {
             r_.m128_private[i].altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_rint(a_.m128_private[i].altivec_f32));
           }

--- a/simde/x86/sse.h
+++ b/simde/x86/sse.h
@@ -576,7 +576,7 @@ simde_x_mm_round_ps (simde__m128 a, int rounding, int lax_rounding)
       break;
 
     case SIMDE_MM_FROUND_TO_NEAREST_INT:
-      #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
+      #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
         r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_rint(a_.altivec_f32));
       #elif defined(SIMDE_ARM_NEON_A32V8_NATIVE)
         r_.neon_f32 = vrndnq_f32(a_.neon_f32);
@@ -1857,7 +1857,7 @@ simde_x_mm_copysign_ps(simde__m128 dest, simde__m128 src) {
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     const v128_t sign_pos = wasm_f32x4_splat(-0.0f);
     r_.wasm_v128 = wasm_v128_bitselect(src_.wasm_v128, dest_.wasm_v128, sign_pos);
-  #elif defined(SIMDE_POWER_ALTIVEC_P9_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     #if !defined(HEDLEY_IBM_VERSION)
       r_.altivec_f32 = vec_cpsgn(dest_.altivec_f32, src_.altivec_f32);
     #else
@@ -3401,10 +3401,7 @@ simde_x_mm_negate_ps(simde__m128 a) {
       r_,
       a_ = simde__m128_to_private(a);
 
-    #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && \
-        (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8,1,0))
-      r_.altivec_f32 = vec_neg(a_.altivec_f32);
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_f32 = vnegq_f32(a_.neon_f32);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 = wasm_f32x4_neg(a_.wasm_v128);

--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -407,7 +407,7 @@ simde_mm_set1_pd (simde_float64 a) {
       r_.wasm_v128 = wasm_f64x2_splat(a);
     #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
       r_.neon_f64 = vdupq_n_f64(a);
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       r_.altivec_f64 = vec_splats(HEDLEY_STATIC_CAST(double, a));
     #else
       SIMDE_VECTORIZE
@@ -466,7 +466,7 @@ simde_x_mm_not_pd(simde__m128d a) {
 
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_i32 = vmvnq_s32(a_.neon_i32);
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
       r_.altivec_f64 = vec_nor(a_.altivec_f64, a_.altivec_f64);
     #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
       r_.altivec_i32 = vec_nor(a_.altivec_i32, a_.altivec_i32);
@@ -1507,7 +1507,7 @@ simde_x_mm_copysign_pd(simde__m128d dest, simde__m128d src) {
       uint64x2_t sign_pos = vdupq_n_u64(u64_nz);
     #endif
     r_.neon_u64 = vbslq_u64(sign_pos, src_.neon_u64, dest_.neon_u64);
-  #elif defined(SIMDE_POWER_ALTIVEC_P9_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     #if !defined(HEDLEY_IBM_VERSION)
       r_.altivec_f64 = vec_cpsgn(dest_.altivec_f64, src_.altivec_f64);
     #else
@@ -3925,7 +3925,7 @@ simde_mm_min_pd (simde__m128d a, simde__m128d b) {
       a_ = simde__m128d_to_private(a),
       b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       r_.altivec_f64 = vec_min(a_.altivec_f64, b_.altivec_f64);
     #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
       r_.neon_f64 = vminq_f64(a_.neon_f64, b_.neon_f64);
@@ -4924,7 +4924,7 @@ simde_mm_set1_epi8 (int8_t a) {
       r_.neon_i8 = vdupq_n_s8(a);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 = wasm_i8x16_splat(a);
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       r_.altivec_i8 = vec_splats(HEDLEY_STATIC_CAST(signed char, a));
     #else
       SIMDE_VECTORIZE
@@ -4952,7 +4952,7 @@ simde_mm_set1_epi16 (int16_t a) {
       r_.neon_i16 = vdupq_n_s16(a);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 = wasm_i16x8_splat(a);
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       r_.altivec_i16 = vec_splats(HEDLEY_STATIC_CAST(signed short, a));
     #else
       SIMDE_VECTORIZE
@@ -4980,7 +4980,7 @@ simde_mm_set1_epi32 (int32_t a) {
       r_.neon_i32 = vdupq_n_s32(a);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 = wasm_i32x4_splat(a);
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       r_.altivec_i32 = vec_splats(HEDLEY_STATIC_CAST(signed int, a));
     #else
       SIMDE_VECTORIZE
@@ -5008,7 +5008,7 @@ simde_mm_set1_epi64x (int64_t a) {
       r_.neon_i64 = vdupq_n_s64(a);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 = wasm_i64x2_splat(a);
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
       r_.altivec_i64 = vec_splats(HEDLEY_STATIC_CAST(signed long long, a));
     #else
       SIMDE_VECTORIZE
@@ -5041,7 +5041,7 @@ simde_mm_set1_epi64 (simde__m64 a) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_x_mm_set1_epu8 (uint8_t value) {
-  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return simde__m128i_from_altivec_u8(vec_splats(HEDLEY_STATIC_CAST(unsigned char, value)));
   #else
     return simde_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, value));
@@ -5051,7 +5051,7 @@ simde_x_mm_set1_epu8 (uint8_t value) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_x_mm_set1_epu16 (uint16_t value) {
-  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return simde__m128i_from_altivec_u16(vec_splats(HEDLEY_STATIC_CAST(unsigned short, value)));
   #else
     return simde_mm_set1_epi16(HEDLEY_STATIC_CAST(int16_t, value));
@@ -5061,7 +5061,7 @@ simde_x_mm_set1_epu16 (uint16_t value) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_x_mm_set1_epu32 (uint32_t value) {
-  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return simde__m128i_from_altivec_u32(vec_splats(HEDLEY_STATIC_CAST(unsigned int, value)));
   #else
     return simde_mm_set1_epi32(HEDLEY_STATIC_CAST(int32_t, value));
@@ -5071,7 +5071,7 @@ simde_x_mm_set1_epu32 (uint32_t value) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_x_mm_set1_epu64 (uint64_t value) {
-  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return simde__m128i_from_altivec_u64(vec_splats(HEDLEY_STATIC_CAST(unsigned long long, value)));
   #else
     return simde_mm_set1_epi64x(HEDLEY_STATIC_CAST(int64_t, value));
@@ -5823,7 +5823,7 @@ simde_mm_slli_epi16 (simde__m128i a, const int imm8)
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
   #define simde_mm_slli_epi16(a, imm8) \
     ((imm8 < 16) ? wasm_i16x8_shl(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i16x8_const(0,0,0,0,0,0,0,0))
-#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_mm_slli_epi16(a, imm8) \
     ((imm8 & ~15) ? simde_mm_setzero_si128() : simde__m128i_from_altivec_i16(vec_sl(simde__m128i_to_altivec_i16(a), vec_splat_u16(HEDLEY_STATIC_CAST(unsigned short, imm8)))))
 #endif
@@ -5872,7 +5872,7 @@ simde_mm_slli_epi32 (simde__m128i a, const int imm8)
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
   #define simde_mm_slli_epi32(a, imm8) \
     ((imm8 < 32) ? wasm_i32x4_shl(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i32x4_const(0,0,0,0))
-#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_mm_slli_epi32(a, imm8) \
      (__extension__ ({ \
        simde__m128i ret; \
@@ -5979,7 +5979,7 @@ simde_mm_srli_epi16 (simde__m128i a, const int imm8)
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
   #define simde_mm_srli_epi16(a, imm8) \
     ((imm8 < 16) ? wasm_u16x8_shr(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i16x8_const(0,0,0,0,0,0,0,0))
-#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_mm_srli_epi16(a, imm8) \
     ((imm8 & ~15) ? simde_mm_setzero_si128() : simde__m128i_from_altivec_i16(vec_sr(simde__m128i_to_altivec_i16(a), vec_splat_u16(HEDLEY_STATIC_CAST(unsigned short, imm8)))))
 #endif
@@ -6028,7 +6028,7 @@ simde_mm_srli_epi32 (simde__m128i a, const int imm8)
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
   #define simde_mm_srli_epi32(a, imm8) \
     ((imm8 < 32) ? wasm_u32x4_shr(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i32x4_const(0,0,0,0))
-#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_mm_srli_epi32(a, imm8) \
     (__extension__ ({ \
         simde__m128i ret; \


### PR DESCRIPTION
Vectors with float require ZARCH14.
POWER6 is sufficient for most basic operations but 64-bit ones require POWER7 (or POWER8 if they imply integer arithmetic).
vec_cntlz requires POWER8.
Correct typo SIMDE1_POWER_ALTIVEC_VECTOR -> SIMDE_POWER_ALTIVEC_VECTOR.