### PR TITLE
avx512: fix macros using avx256

### DIFF
--- a/simde/x86/avx512/blend.h
+++ b/simde/x86/avx512/blend.h
@@ -44,7 +44,7 @@ simde_mm_mask_blend_epi8(simde__mmask16 k, simde__m128i a, simde__m128i b) {
     return simde_mm_mask_mov_epi8(a, k, b);
   #endif
 }
-#if defined(SIMDE_X86_AVX256BW_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
   #undef _mm_mask_blend_epi8
   #define _mm_mask_blend_epi8(k, a, b) simde_mm_mask_blend_epi8(k, a, b)
 #endif
@@ -58,7 +58,7 @@ simde_mm_mask_blend_epi16(simde__mmask8 k, simde__m128i a, simde__m128i b) {
     return simde_mm_mask_mov_epi16(a, k, b);
   #endif
 }
-#if defined(SIMDE_X86_AVX256BW_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
   #undef _mm_mask_blend_epi16
   #define _mm_mask_blend_epi16(k, a, b) simde_mm_mask_blend_epi16(k, a, b)
 #endif
@@ -128,7 +128,7 @@ simde_mm256_mask_blend_epi8(simde__mmask32 k, simde__m256i a, simde__m256i b) {
     return simde_mm256_mask_mov_epi8(a, k, b);
   #endif
 }
-#if defined(SIMDE_X86_AVX256BW_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
   #undef _mm256_mask_blend_epi8
   #define _mm256_mask_blend_epi8(k, a, b) simde_mm256_mask_blend_epi8(k, a, b)
 #endif
@@ -142,7 +142,7 @@ simde_mm256_mask_blend_epi16(simde__mmask16 k, simde__m256i a, simde__m256i b) {
     return simde_mm256_mask_mov_epi16(a, k, b);
   #endif
 }
-#if defined(SIMDE_X86_AVX256BW_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
   #undef _mm256_mask_blend_epi16
   #define _mm256_mask_blend_epi16(k, a, b) simde_mm256_mask_blend_epi16(k, a, b)
 #endif

--- a/simde/x86/avx512/mov_mask.h
+++ b/simde/x86/avx512/mov_mask.h
@@ -56,7 +56,7 @@ simde_mm_movepi8_mask (simde__m128i a) {
     return r;
   #endif
 }
-#if defined(SIMDE_X86_AVX256BW_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
   #undef _mm_movepi8_mask
   #define _mm_movepi8_mask(a) simde_mm_movepi8_mask(a)
 #endif
@@ -87,7 +87,7 @@ simde_mm_movepi16_mask (simde__m128i a) {
     return r;
   #endif
 }
-#if defined(SIMDE_X86_AVX256BW_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
   #undef _mm_movepi16_mask
   #define _mm_movepi16_mask(a) simde_mm_movepi16_mask(a)
 #endif
@@ -97,7 +97,7 @@ simde__mmask8
 simde_mm_movepi32_mask (simde__m128i a) {
   #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512DQ_NATIVE)
     return _mm_movepi32_mask(a);
-  #elif defined(SIMDE_X86_SSE2_NATIVE)
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
     return HEDLEY_STATIC_CAST(simde__mmask8, simde_mm_movemask_ps(simde_mm_castsi128_ps(a)));
   #else
     simde__m128i_private a_ = simde__m128i_to_private(a);
@@ -111,7 +111,7 @@ simde_mm_movepi32_mask (simde__m128i a) {
     return r;
   #endif
 }
-#if defined(SIMDE_X86_AVX256DQ_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
   #undef _mm_movepi32_mask
   #define _mm_movepi32_mask(a) simde_mm_movepi32_mask(a)
 #endif
@@ -135,7 +135,7 @@ simde_mm_movepi64_mask (simde__m128i a) {
     return r;
   #endif
 }
-#if defined(SIMDE_X86_AVX256DQ_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
   #undef _mm_movepi64_mask
   #define _mm_movepi64_mask(a) simde_mm_movepi64_mask(a)
 #endif
@@ -163,7 +163,7 @@ simde_mm256_movepi8_mask (simde__m256i a) {
     return HEDLEY_STATIC_CAST(simde__mmask32, r);
   #endif
 }
-#if defined(SIMDE_X86_AVX256BW_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
   #undef _mm256_movepi8_mask
   #define _mm256_movepi8_mask(a) simde_mm256_movepi8_mask(a)
 #endif
@@ -191,7 +191,7 @@ simde_mm256_movepi16_mask (simde__m256i a) {
     return r;
   #endif
 }
-#if defined(SIMDE_X86_AVX256BW_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
   #undef _mm256_movepi16_mask
   #define _mm256_movepi16_mask(a) simde_mm256_movepi16_mask(a)
 #endif
@@ -219,7 +219,7 @@ simde_mm256_movepi32_mask (simde__m256i a) {
     return r;
   #endif
 }
-#if defined(SIMDE_X86_AVX256DQ_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
   #undef _mm256_movepi32_mask
   #define _mm256_movepi32_mask(a) simde_mm256_movepi32_mask(a)
 #endif
@@ -247,7 +247,7 @@ simde_mm256_movepi64_mask (simde__m256i a) {
     return r;
   #endif
 }
-#if defined(SIMDE_X86_AVX256DQ_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
   #undef _mm256_movepi64_mask
   #define _mm256_movepi64_mask(a) simde_mm256_movepi64_mask(a)
 #endif

--- a/simde/x86/avx512/srlv.h
+++ b/simde/x86/avx512/srlv.h
@@ -39,7 +39,7 @@ SIMDE_BEGIN_DECLS_
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_mm_srlv_epi16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_AVX256VL_NATIVE) && defined(SIMDE_X86_AVX256BW_NATIVE)
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
     return _mm_srlv_epi16(a, b);
   #else
     simde__m128i_private
@@ -151,7 +151,7 @@ simde_mm_maskz_srlv_epi64(simde__mmask8 k, simde__m128i a, simde__m128i b) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m256i
 simde_mm256_srlv_epi16 (simde__m256i a, simde__m256i b) {
-  #if defined(SIMDE_X86_AVX256VL_NATIVE) && defined(SIMDE_X86_AVX256BW_NATIVE)
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
     return _mm256_srlv_epi16(a, b);
   #else
     simde__m256i_private


### PR DESCRIPTION
This fixes macros defined with AVX256 instead of AVX512. Also replaces call to `simde_mm_movemask_ps` from `simde_mm_movepi32_mask` to conditional `SIMDE_NATURAL_VECTOR_SIZE_GE(128)` from native SSE.