### PR TITLE
Add Windows ARM64 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,3 +377,27 @@ jobs:
       run: ninja -C build -v
     - name: Test
       run: ninja -C build -v test
+
+  msvc-arm64:
+    name: Windows msvc-arm64
+    runs-on: [windows-latest] 
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install Meson, Ninja and coverage
+        run: |
+          python3 -m pip install --upgrade ninja meson
+          choco install opencppcoverage codecov
+      - name: Use ARM64 Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64_arm64
+      - name: Configure and Build
+        run: |
+          meson --backend=ninja build --cross-file test/arm64cl.txt
+          ninja -C build -v test
+
+
+  

--- a/test/arm64cl.txt
+++ b/test/arm64cl.txt
@@ -1,0 +1,17 @@
+[binaries]
+c = 'cl'
+cpp = 'cl'
+ar = 'lib'
+windres = 'rc'
+
+[built-in options]
+c_args = ['-DWINAPI_FAMILY=WINAPI_FAMILY_APP']
+c_link_args = ['-APPCONTAINER', 'WindowsApp.lib']
+cpp_args = ['-DWINAPI_FAMILY=WINAPI_FAMILY_APP']
+cpp_link_args = ['-APPCONTAINER', 'WindowsApp.lib']
+
+[host_machine]
+system = 'windows'
+cpu_family = 'aarch64'
+cpu = 'armv8'
+endian = 'little'


### PR DESCRIPTION
As @nemequ asked in #860, I implemented Windows ARM64 CI on GitHub Action.

The CI itself is working fine, and it's doing its work of revealing problems between the toolchain and the project.