### PR TITLE
avx512/fixupimm: initial implementation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -237,6 +237,7 @@ simde_avx512_families = [
   'dpwssds',
   'expand',
   'extract',
+  'fixupimm',
   'flushsubnormal',
   'fmadd',
   'fmsub',

--- a/meson.build
+++ b/meson.build
@@ -238,6 +238,7 @@ simde_avx512_families = [
   'expand',
   'extract',
   'fixupimm',
+  'fixupimm_round',
   'flushsubnormal',
   'fmadd',
   'fmsub',

--- a/simde/simde-math.h
+++ b/simde/simde-math.h
@@ -410,10 +410,27 @@ simde_math_fpclassifyf(float v) {
   #else
     return
       simde_math_isnormalf(v) ? SIMDE_MATH_FP_NORMAL    :
-      (v == 0.0f)           ? SIMDE_MATH_FP_ZERO      :
+      (v == 0.0f)             ? SIMDE_MATH_FP_ZERO      :
       simde_math_isnanf(v)    ? SIMDE_MATH_FP_NAN       :
       simde_math_isinff(v)    ? SIMDE_MATH_FP_INFINITE  :
                                 SIMDE_MATH_FP_SUBNORMAL;
+  #endif
+}
+
+static HEDLEY_INLINE
+int
+simde_math_fpclassify(double v) {
+  #if SIMDE_MATH_BUILTIN_LIBM(fpclassify)
+    return __builtin_fpclassify(SIMDE_MATH_FP_NAN, SIMDE_MATH_FP_INFINITE, SIMDE_MATH_FP_NORMAL, SIMDE_MATH_FP_SUBNORMAL, SIMDE_MATH_FP_ZERO, v);
+  #elif defined(fpclassify)
+    return fpclassify(v);
+  #else
+    return
+      simde_math_isnormal(v) ? SIMDE_MATH_FP_NORMAL    :
+      (v == 0.0)             ? SIMDE_MATH_FP_ZERO      :
+      simde_math_isnan(v)    ? SIMDE_MATH_FP_NAN       :
+      simde_math_isinf(v)    ? SIMDE_MATH_FP_INFINITE  :
+                               SIMDE_MATH_FP_SUBNORMAL;
   #endif
 }
 

--- a/simde/simde-math.h
+++ b/simde/simde-math.h
@@ -222,57 +222,61 @@ SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
 #endif
 
 #if !defined(SIMDE_MATH_FLT_MIN)
-  #if defined(FLT_MIN)
-    #define SIMDE_MATH_FLT_MIN FLT_MIN
-  #elif defined(__FLT_MIN__)
+  #if defined(__FLT_MIN__)
     #define SIMDE_MATH_FLT_MIN __FLT_MIN__
-  #elif defined(__cplusplus)
-    #include <cfloat>
-    #define SIMDE_MATH_FLT_MIN FLT_MIN
   #else
-    #include <float.h>
+    #if !defined(FLT_MIN)
+      #if defined(__cplusplus)
+        #include <cfloat>
+      #else
+        #include <float.h>
+      #endif
+    #endif
     #define SIMDE_MATH_FLT_MIN FLT_MIN
   #endif
 #endif
 
 #if !defined(SIMDE_MATH_FLT_MAX)
-  #if defined(FLT_MAX)
-    #define SIMDE_MATH_FLT_MAX FLT_MAX
-  #elif defined(__FLT_MAX__)
+  #if defined(__FLT_MAX__)
     #define SIMDE_MATH_FLT_MAX __FLT_MAX__
-  #elif defined(__cplusplus)
-    #include <cfloat>
-    #define SIMDE_MATH_FLT_MAX FLT_MAX
   #else
-    #include <float.h>
+    #if !defined(FLT_MAX)
+      #if defined(__cplusplus)
+        #include <cfloat>
+      #else
+        #include <float.h>
+      #endif
+    #endif
     #define SIMDE_MATH_FLT_MAX FLT_MAX
   #endif
 #endif
 
 #if !defined(SIMDE_MATH_DBL_MIN)
-  #if defined(DBL_MIN)
-    #define SIMDE_MATH_DBL_MIN DBL_MIN
-  #elif defined(__DBL_MIN__)
+  #if defined(__DBL_MIN__)
     #define SIMDE_MATH_DBL_MIN __DBL_MIN__
-  #elif defined(__cplusplus)
-    #include <cfloat>
-    #define SIMDE_MATH_DBL_MIN DBL_MIN
   #else
-    #include <float.h>
+    #if !defined(DBL_MIN)
+      #if defined(__cplusplus)
+        #include <cfloat>
+      #else
+        #include <float.h>
+      #endif
+    #endif
     #define SIMDE_MATH_DBL_MIN DBL_MIN
   #endif
 #endif
 
 #if !defined(SIMDE_MATH_DBL_MAX)
-  #if defined(DBL_MAX)
-    #define SIMDE_MATH_DBL_MAX DBL_MAX
-  #elif defined(__DBL_MAX__)
+  #if defined(__DBL_MAX__)
     #define SIMDE_MATH_DBL_MAX __DBL_MAX__
-  #elif defined(__cplusplus)
-    #include <cfloat>
-    #define SIMDE_MATH_DBL_MAX DBL_MAX
   #else
-    #include <float.h>
+    #if !defined(DBL_MAX)
+      #if defined(__cplusplus)
+        #include <cfloat>
+      #else
+        #include <float.h>
+      #endif
+    #endif
     #define SIMDE_MATH_DBL_MAX DBL_MAX
   #endif
 #endif

--- a/simde/simde-math.h
+++ b/simde/simde-math.h
@@ -374,6 +374,49 @@ SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
   #endif
 #endif
 
+#if defined(FP_NAN)
+  #define SIMDE_MATH_FP_NAN FP_NAN
+#else
+  #define SIMDE_MATH_FP_NAN 0
+#endif
+#if defined(FP_INFINITE)
+  #define SIMDE_MATH_FP_INFINITE FP_INFINITE
+#else
+  #define SIMDE_MATH_FP_INFINITE 1
+#endif
+#if defined(FP_ZERO)
+  #define SIMDE_MATH_FP_ZERO FP_ZERO
+#else
+  #define SIMDE_MATH_FP_ZERO 2
+#endif
+#if defined(FP_SUBNORMAL)
+  #define SIMDE_MATH_FP_SUBNORMAL FP_SUBNORMAL
+#else
+  #define SIMDE_MATH_FP_SUBNORMAL 3
+#endif
+#if defined(FP_NORMAL)
+  #define SIMDE_MATH_FP_NORMAL FP_NORMAL
+#else
+  #define SIMDE_MATH_FP_NORMAL 4
+#endif
+
+static HEDLEY_INLINE
+int
+simde_math_fpclassifyf(float v) {
+  #if SIMDE_MATH_BUILTIN_LIBM(fpclassify)
+    return __builtin_fpclassify(SIMDE_MATH_FP_NAN, SIMDE_MATH_FP_INFINITE, SIMDE_MATH_FP_NORMAL, SIMDE_MATH_FP_SUBNORMAL, SIMDE_MATH_FP_ZERO, v);
+  #elif defined(fpclassify)
+    return fpclassify(v);
+  #else
+    return
+      simde_math_isnormalf(v) ? SIMDE_MATH_FP_NORMAL    :
+      (v == 0.0f)           ? SIMDE_MATH_FP_ZERO      :
+      simde_math_isnanf(v)    ? SIMDE_MATH_FP_NAN       :
+      simde_math_isinff(v)    ? SIMDE_MATH_FP_INFINITE  :
+                                SIMDE_MATH_FP_SUBNORMAL;
+  #endif
+}
+
 /*** Manipulation functions ***/
 
 #if !defined(simde_math_nextafter)

--- a/simde/simde-math.h
+++ b/simde/simde-math.h
@@ -235,6 +235,20 @@ SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
   #endif
 #endif
 
+#if !defined(SIMDE_MATH_FLT_MAX)
+  #if defined(FLT_MAX)
+    #define SIMDE_MATH_FLT_MAX FLT_MAX
+  #elif defined(__FLT_MAX__)
+    #define SIMDE_MATH_FLT_MAX __FLT_MAX__
+  #elif defined(__cplusplus)
+    #include <cfloat>
+    #define SIMDE_MATH_FLT_MAX FLT_MAX
+  #else
+    #include <float.h>
+    #define SIMDE_MATH_FLT_MAX FLT_MAX
+  #endif
+#endif
+
 #if !defined(SIMDE_MATH_DBL_MIN)
   #if defined(DBL_MIN)
     #define SIMDE_MATH_DBL_MIN DBL_MIN
@@ -246,6 +260,20 @@ SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
   #else
     #include <float.h>
     #define SIMDE_MATH_DBL_MIN DBL_MIN
+  #endif
+#endif
+
+#if !defined(SIMDE_MATH_DBL_MAX)
+  #if defined(DBL_MAX)
+    #define SIMDE_MATH_DBL_MAX DBL_MAX
+  #elif defined(__DBL_MAX__)
+    #define SIMDE_MATH_DBL_MAX __DBL_MAX__
+  #elif defined(__cplusplus)
+    #include <cfloat>
+    #define SIMDE_MATH_DBL_MAX DBL_MAX
+  #else
+    #include <float.h>
+    #define SIMDE_MATH_DBL_MAX DBL_MAX
   #endif
 #endif
 

--- a/simde/x86/avx512.h
+++ b/simde/x86/avx512.h
@@ -64,6 +64,7 @@
 #include "avx512/expand.h"
 #include "avx512/extract.h"
 #include "avx512/fixupimm.h"
+#include "avx512/fixupimm_round.h"
 #include "avx512/flushsubnormal.h"
 #include "avx512/fmadd.h"
 #include "avx512/fmsub.h"

--- a/simde/x86/avx512.h
+++ b/simde/x86/avx512.h
@@ -63,6 +63,7 @@
 #include "avx512/dpwssds.h"
 #include "avx512/expand.h"
 #include "avx512/extract.h"
+#include "avx512/fixupimm.h"
 #include "avx512/flushsubnormal.h"
 #include "avx512/fmadd.h"
 #include "avx512/fmsub.h"

--- a/simde/x86/avx512/fixupimm.h
+++ b/simde/x86/avx512/fixupimm.h
@@ -466,6 +466,467 @@ simde_mm_fixupimm_ss (simde__m128 a, simde__m128 b, simde__m128i c, int imm8)
   #define _mm_maskz_fixupimm_ss(k, a, b, c, imm8) simde_mm_maskz_fixupimm_ss(k, a, b, c, imm8)
 #endif
 
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_fixupimm_pd (simde__m128d a, simde__m128d b, simde__m128i c, int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255) {
+  HEDLEY_STATIC_CAST(void, imm8);
+  simde__m128d_private
+    r_,
+    a_ = simde__m128d_to_private(a),
+    b_ = simde__m128d_to_private(b),
+    s_ = simde__m128d_to_private(simde_x_mm_flushsubnormal_pd(b));
+  simde__m128i_private c_ = simde__m128i_to_private(c);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+    int32_t select = 1;
+    switch (simde_math_fpclassify(s_.f64[i])) {
+      case SIMDE_MATH_FP_NORMAL:
+        select = (s_.f64[i] < SIMDE_FLOAT64_C(0.0)) ? 6 : (s_.f64[i] == SIMDE_FLOAT64_C(1.0)) ? 3 : 7;
+        break;
+      case SIMDE_MATH_FP_ZERO:
+        select = 2;
+        break;
+      case SIMDE_MATH_FP_NAN:
+        select = 0;
+        break;
+      case SIMDE_MATH_FP_INFINITE:
+        select = ((s_.f64[i] > SIMDE_FLOAT64_C(0.0)) ? 5 : 4);
+        break;
+    }
+
+    switch (((c_.i64[i] >> (select << 2)) & 15)) {
+      case 0:
+        r_.f64[i] =  a_.f64[i];
+        break;
+      case 1:
+        r_.f64[i] =  b_.f64[i];
+        break;
+      case 2:
+        r_.f64[i] =  SIMDE_MATH_NAN;
+        break;
+      case 3:
+        r_.f64[i] = -SIMDE_MATH_NAN;
+        break;
+      case 4:
+        r_.f64[i] = -SIMDE_MATH_INFINITY;
+        break;
+      case 5:
+        r_.f64[i] =  SIMDE_MATH_INFINITY;
+        break;
+      case 6:
+      #if defined(simde_math_copysignf)
+        r_.f64[i] =  simde_math_copysign(SIMDE_MATH_INFINITY, s_.f64[i]);
+      #else
+        r_.f64[i] =  simde_uint64_as_float64((simde_float64_as_uint64(s_.f64[i]) & 0x8000000000000000) | simde_float64_as_uint64(SIMDE_MATH_INFINITY));
+      #endif
+        break;
+      case 7:
+        r_.f64[i] =  SIMDE_FLOAT64_C(-0.0);
+        break;
+      case 8:
+        r_.f64[i] =  SIMDE_FLOAT64_C(0.0);
+        break;
+      case 9:
+        r_.f64[i] =  SIMDE_FLOAT64_C(-1.0);
+        break;
+      case 10:
+        r_.f64[i] =  SIMDE_FLOAT64_C(1.0);
+        break;
+      case 11:
+        r_.f64[i] =  SIMDE_FLOAT64_C(0.5);
+        break;
+      case 12:
+        r_.f64[i] =  SIMDE_FLOAT64_C(90.0);
+        break;
+      case 13:
+        r_.f64[i] =  SIMDE_MATH_PI / 2;
+        break;
+      case 14:
+        r_.f64[i] =  SIMDE_MATH_DBL_MAX;
+        break;
+      case 15:
+        r_.f64[i] = -SIMDE_MATH_DBL_MAX;
+        break;
+    }
+  }
+
+  return simde__m128d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm_fixupimm_pd(a, b, c, imm8) _mm_fixupimm_pd(a, b, c, imm8)
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fixupimm_pd
+  #define _mm_fixupimm_pd(a, b, c, imm8) simde_mm_fixupimm_pd(a, b, c, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm_mask_fixupimm_pd(a, k, b, c, imm8) _mm_mask_fixupimm_pd(a, k, b, c, imm8)
+#else
+  #define simde_mm_mask_fixupimm_pd(a, k, b, c, imm8) simde_mm_mask_mov_pd(a, k, simde_mm_fixupimm_pd(a, b, c, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_fixupimm_pd
+  #define _mm_mask_fixupimm_pd(a, k, b, c, imm8) simde_mm_mask_fixupimm_pd(a, k, b, c, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm_maskz_fixupimm_pd(k, a, b, c, imm8) _mm_maskz_fixupimm_pd(k, a, b, c, imm8)
+#else
+  #define simde_mm_maskz_fixupimm_pd(k, a, b, c, imm8) simde_mm_maskz_mov_pd(k, simde_mm_fixupimm_pd(a, b, c, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_fixupimm_pd
+  #define _mm_maskz_fixupimm_pd(k, a, b, c, imm8) simde_mm_maskz_fixupimm_pd(k, a, b, c, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_fixupimm_pd (simde__m256d a, simde__m256d b, simde__m256i c, int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255) {
+  HEDLEY_STATIC_CAST(void, imm8);
+  simde__m256d_private
+    r_,
+    a_ = simde__m256d_to_private(a),
+    b_ = simde__m256d_to_private(b),
+    s_ = simde__m256d_to_private(simde_x_mm256_flushsubnormal_pd(b));
+  simde__m256i_private c_ = simde__m256i_to_private(c);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+    int32_t select = 1;
+    switch (simde_math_fpclassify(s_.f64[i])) {
+      case SIMDE_MATH_FP_NORMAL:
+        select = (s_.f64[i] < SIMDE_FLOAT64_C(0.0)) ? 6 : (s_.f64[i] == SIMDE_FLOAT64_C(1.0)) ? 3 : 7;
+        break;
+      case SIMDE_MATH_FP_ZERO:
+        select = 2;
+        break;
+      case SIMDE_MATH_FP_NAN:
+        select = 0;
+        break;
+      case SIMDE_MATH_FP_INFINITE:
+        select = ((s_.f64[i] > SIMDE_FLOAT64_C(0.0)) ? 5 : 4);
+        break;
+    }
+
+    switch (((c_.i64[i] >> (select << 2)) & 15)) {
+      case 0:
+        r_.f64[i] =  a_.f64[i];
+        break;
+      case 1:
+        r_.f64[i] =  b_.f64[i];
+        break;
+      case 2:
+        r_.f64[i] =  SIMDE_MATH_NAN;
+        break;
+      case 3:
+        r_.f64[i] = -SIMDE_MATH_NAN;
+        break;
+      case 4:
+        r_.f64[i] = -SIMDE_MATH_INFINITY;
+        break;
+      case 5:
+        r_.f64[i] =  SIMDE_MATH_INFINITY;
+        break;
+      case 6:
+      #if defined(simde_math_copysignf)
+        r_.f64[i] =  simde_math_copysign(SIMDE_MATH_INFINITY, s_.f64[i]);
+      #else
+        r_.f64[i] =  simde_uint64_as_float64((simde_float64_as_uint64(s_.f64[i]) & 0x8000000000000000) | simde_float64_as_uint64(SIMDE_MATH_INFINITY));
+      #endif
+        break;
+      case 7:
+        r_.f64[i] =  SIMDE_FLOAT64_C(-0.0);
+        break;
+      case 8:
+        r_.f64[i] =  SIMDE_FLOAT64_C(0.0);
+        break;
+      case 9:
+        r_.f64[i] =  SIMDE_FLOAT64_C(-1.0);
+        break;
+      case 10:
+        r_.f64[i] =  SIMDE_FLOAT64_C(1.0);
+        break;
+      case 11:
+        r_.f64[i] =  SIMDE_FLOAT64_C(0.5);
+        break;
+      case 12:
+        r_.f64[i] =  SIMDE_FLOAT64_C(90.0);
+        break;
+      case 13:
+        r_.f64[i] =  SIMDE_MATH_PI / 2;
+        break;
+      case 14:
+        r_.f64[i] =  SIMDE_MATH_DBL_MAX;
+        break;
+      case 15:
+        r_.f64[i] = -SIMDE_MATH_DBL_MAX;
+        break;
+    }
+  }
+
+  return simde__m256d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm256_fixupimm_pd(a, b, c, imm8) _mm256_fixupimm_pd(a, b, c, imm8)
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_fixupimm_pd
+  #define _mm256_fixupimm_pd(a, b, c, imm8) simde_mm256_fixupimm_pd(a, b, c, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm256_mask_fixupimm_pd(a, k, b, c, imm8) _mm256_mask_fixupimm_pd(a, k, b, c, imm8)
+#else
+  #define simde_mm256_mask_fixupimm_pd(a, k, b, c, imm8) simde_mm256_mask_mov_pd(a, k, simde_mm256_fixupimm_pd(a, b, c, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_fixupimm_pd
+  #define _mm256_mask_fixupimm_pd(a, k, b, c, imm8) simde_mm256_mask_fixupimm_pd(a, k, b, c, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm256_maskz_fixupimm_pd(k, a, b, c, imm8) _mm256_maskz_fixupimm_pd(k, a, b, c, imm8)
+#else
+  #define simde_mm256_maskz_fixupimm_pd(k, a, b, c, imm8) simde_mm256_maskz_mov_pd(k, simde_mm256_fixupimm_pd(a, b, c, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_fixupimm_pd
+  #define _mm256_maskz_fixupimm_pd(k, a, b, c, imm8) simde_mm256_maskz_fixupimm_pd(k, a, b, c, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_fixupimm_pd (simde__m512d a, simde__m512d b, simde__m512i c, int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255) {
+  HEDLEY_STATIC_CAST(void, imm8);
+  simde__m512d_private
+    r_,
+    a_ = simde__m512d_to_private(a),
+    b_ = simde__m512d_to_private(b),
+    s_ = simde__m512d_to_private(simde_x_mm512_flushsubnormal_pd(b));
+  simde__m512i_private c_ = simde__m512i_to_private(c);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+    int32_t select = 1;
+    switch (simde_math_fpclassify(s_.f64[i])) {
+      case SIMDE_MATH_FP_NORMAL:
+        select = (s_.f64[i] < SIMDE_FLOAT64_C(0.0)) ? 6 : (s_.f64[i] == SIMDE_FLOAT64_C(1.0)) ? 3 : 7;
+        break;
+      case SIMDE_MATH_FP_ZERO:
+        select = 2;
+        break;
+      case SIMDE_MATH_FP_NAN:
+        select = 0;
+        break;
+      case SIMDE_MATH_FP_INFINITE:
+        select = ((s_.f64[i] > SIMDE_FLOAT64_C(0.0)) ? 5 : 4);
+        break;
+    }
+
+    switch (((c_.i64[i] >> (select << 2)) & 15)) {
+      case 0:
+        r_.f64[i] =  a_.f64[i];
+        break;
+      case 1:
+        r_.f64[i] =  b_.f64[i];
+        break;
+      case 2:
+        r_.f64[i] =  SIMDE_MATH_NAN;
+        break;
+      case 3:
+        r_.f64[i] = -SIMDE_MATH_NAN;
+        break;
+      case 4:
+        r_.f64[i] = -SIMDE_MATH_INFINITY;
+        break;
+      case 5:
+        r_.f64[i] =  SIMDE_MATH_INFINITY;
+        break;
+      case 6:
+      #if defined(simde_math_copysignf)
+        r_.f64[i] =  simde_math_copysign(SIMDE_MATH_INFINITY, s_.f64[i]);
+      #else
+        r_.f64[i] =  simde_uint64_as_float64((simde_float64_as_uint64(s_.f64[i]) & 0x8000000000000000) | simde_float64_as_uint64(SIMDE_MATH_INFINITY));
+      #endif
+        break;
+      case 7:
+        r_.f64[i] =  SIMDE_FLOAT64_C(-0.0);
+        break;
+      case 8:
+        r_.f64[i] =  SIMDE_FLOAT64_C(0.0);
+        break;
+      case 9:
+        r_.f64[i] =  SIMDE_FLOAT64_C(-1.0);
+        break;
+      case 10:
+        r_.f64[i] =  SIMDE_FLOAT64_C(1.0);
+        break;
+      case 11:
+        r_.f64[i] =  SIMDE_FLOAT64_C(0.5);
+        break;
+      case 12:
+        r_.f64[i] =  SIMDE_FLOAT64_C(90.0);
+        break;
+      case 13:
+        r_.f64[i] =  SIMDE_MATH_PI / 2;
+        break;
+      case 14:
+        r_.f64[i] =  SIMDE_MATH_DBL_MAX;
+        break;
+      case 15:
+        r_.f64[i] = -SIMDE_MATH_DBL_MAX;
+        break;
+    }
+  }
+
+  return simde__m512d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_fixupimm_pd(a, b, c, imm8) _mm512_fixupimm_pd(a, b, c, imm8)
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_fixupimm_pd
+  #define _mm512_fixupimm_pd(a, b, c, imm8) simde_mm512_fixupimm_pd(a, b, c, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_mask_fixupimm_pd(a, k, b, c, imm8) _mm512_mask_fixupimm_pd(a, k, b, c, imm8)
+#else
+  #define simde_mm512_mask_fixupimm_pd(a, k, b, c, imm8) simde_mm512_mask_mov_pd(a, k, simde_mm512_fixupimm_pd(a, b, c, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_fixupimm_pd
+  #define _mm512_mask_fixupimm_pd(a, k, b, c, imm8) simde_mm512_mask_fixupimm_pd(a, k, b, c, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_maskz_fixupimm_pd(k, a, b, c, imm8) _mm512_maskz_fixupimm_pd(k, a, b, c, imm8)
+#else
+  #define simde_mm512_maskz_fixupimm_pd(k, a, b, c, imm8) simde_mm512_maskz_mov_pd(k, simde_mm512_fixupimm_pd(a, b, c, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_fixupimm_pd
+  #define _mm512_maskz_fixupimm_pd(k, a, b, c, imm8) simde_mm512_maskz_fixupimm_pd(k, a, b, c, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_fixupimm_sd (simde__m128d a, simde__m128d b, simde__m128i c, int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255) {
+  HEDLEY_STATIC_CAST(void, imm8);
+  simde__m128d_private
+    a_ = simde__m128d_to_private(a),
+    b_ = simde__m128d_to_private(b),
+    s_ = simde__m128d_to_private(simde_x_mm_flushsubnormal_pd(b));
+  simde__m128i_private c_ = simde__m128i_to_private(c);
+
+  int32_t select = 1;
+  switch (simde_math_fpclassify(s_.f64[0])) {
+    case SIMDE_MATH_FP_NORMAL:
+      select = (s_.f64[0] < SIMDE_FLOAT64_C(0.0)) ? 6 : (s_.f64[0] == SIMDE_FLOAT64_C(1.0)) ? 3 : 7;
+      break;
+    case SIMDE_MATH_FP_ZERO:
+      select = 2;
+      break;
+    case SIMDE_MATH_FP_NAN:
+      select = 0;
+      break;
+    case SIMDE_MATH_FP_INFINITE:
+      select = ((s_.f64[0] > SIMDE_FLOAT64_C(0.0)) ? 5 : 4);
+      break;
+  }
+
+  switch (((c_.i64[0] >> (select << 2)) & 15)) {
+    case 0:
+      b_.f64[0] =  a_.f64[0];
+      break;
+    case 1:
+      b_.f64[0] =  b_.f64[0];
+      break;
+    case 2:
+      b_.f64[0] =  SIMDE_MATH_NAN;
+      break;
+    case 3:
+      b_.f64[0] = -SIMDE_MATH_NAN;
+      break;
+    case 4:
+      b_.f64[0] = -SIMDE_MATH_INFINITY;
+      break;
+    case 5:
+      b_.f64[0] =  SIMDE_MATH_INFINITY;
+      break;
+    case 6:
+    #if defined(simde_math_copysignf)
+      b_.f64[0] =  simde_math_copysign(SIMDE_MATH_INFINITY, s_.f64[0]);
+    #else
+      b_.f64[0] =  simde_uint64_as_float64((simde_float64_as_uint64(s_.f64[0]) & 0x8000000000000000) | simde_float64_as_uint64(SIMDE_MATH_INFINITY));
+    #endif
+      break;
+    case 7:
+      b_.f64[0] =  SIMDE_FLOAT64_C(-0.0);
+      break;
+    case 8:
+      b_.f64[0] =  SIMDE_FLOAT64_C(0.0);
+      break;
+    case 9:
+      b_.f64[0] =  SIMDE_FLOAT64_C(-1.0);
+      break;
+    case 10:
+      b_.f64[0] =  SIMDE_FLOAT64_C(1.0);
+      break;
+    case 11:
+      b_.f64[0] =  SIMDE_FLOAT64_C(0.5);
+      break;
+    case 12:
+      b_.f64[0] =  SIMDE_FLOAT64_C(90.0);
+      break;
+    case 13:
+      b_.f64[0] =  SIMDE_MATH_PI / 2;
+      break;
+    case 14:
+      b_.f64[0] =  SIMDE_MATH_DBL_MAX;
+      break;
+    case 15:
+      b_.f64[0] = -SIMDE_MATH_DBL_MAX;
+      break;
+  }
+
+  return simde__m128d_from_private(b_);
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm_fixupimm_sd(a, b, c, imm8) _mm_fixupimm_sd(a, b, c, imm8)
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fixupimm_sd
+  #define _mm_fixupimm_sd(a, b, c, imm8) simde_mm_fixupimm_sd(a, b, c, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm_mask_fixupimm_sd(a, k, b, c, imm8) _mm_mask_fixupimm_sd(a, k, b, c, imm8)
+#else
+  #define simde_mm_mask_fixupimm_sd(a, k, b, c, imm8) simde_mm_mask_mov_pd(a, ((k) | 2), simde_mm_fixupimm_sd(a, b, c, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_fixupimm_sd
+  #define _mm_mask_fixupimm_sd(a, k, b, c, imm8) simde_mm_mask_fixupimm_sd(a, k, b, c, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm_maskz_fixupimm_sd(k, a, b, c, imm8) _mm_maskz_fixupimm_sd(k, a, b, c, imm8)
+#else
+  #define simde_mm_maskz_fixupimm_sd(k, a, b, c, imm8) simde_mm_maskz_mov_pd(((k) | 2), simde_mm_fixupimm_sd(a, b, c, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_fixupimm_sd
+  #define _mm_maskz_fixupimm_sd(k, a, b, c, imm8) simde_mm_maskz_fixupimm_sd(k, a, b, c, imm8)
+#endif
+
+
 SIMDE_END_DECLS_
 HEDLEY_DIAGNOSTIC_POP
 

--- a/simde/x86/avx512/fixupimm.h
+++ b/simde/x86/avx512/fixupimm.h
@@ -1,0 +1,113 @@
+#if !defined(SIMDE_X86_AVX512_FIXUPIMM_H)
+#define SIMDE_X86_AVX512_FIXUPIMM_H
+
+#include "types.h"
+#include "flushsubnormal.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+#if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm_fixupimm_ps(a, b, c, imm8) _mm_fixupimm_ps(a, b, c, imm8);
+#else
+  SIMDE_FUNCTION_ATTRIBUTES
+  simde__m128
+  simde_mm_fixupimm_ps (simde__m128 a, simde__m128 b, simde__m128i c, int imm8)
+      SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255) {
+    HEDLEY_STATIC_CAST(void, imm8);
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b),
+      s_ = simde__m128_to_private(simde_x_mm_flushsubnormal_ps(b));
+    simde__m128i_private c_ = simde__m128i_to_private(c);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      int32_t select;
+      if (simde_math_isnanf(s_.f32[i]))
+        select = 0;
+      else if (s_.f32[i] ==  SIMDE_FLOAT32_C(0.0))
+        select = 2;
+      else if (s_.f32[i] ==  SIMDE_FLOAT32_C(1.0))
+        select = 3;
+      else if (s_.f32[i] == -SIMDE_MATH_INFINITYF)
+        select = 4;
+      else if (s_.f32[i] ==  SIMDE_MATH_INFINITYF)
+        select = 5;
+      else if (s_.f32[i]  <  0)
+        select = 6;
+      else if (s_.f32[i]  >  0)
+        select = 7;
+      else
+        select = 1;
+
+      switch (((c_.i32[i] >> (select << 2)) & 15)) {
+        case 0:
+          r_.f32[i] =  a_.f32[i];
+          break;
+        case 1:
+          r_.f32[i] =  b_.f32[i];
+          break;
+        case 2:
+          r_.f32[i] =  SIMDE_MATH_NANF;
+          break;
+        case 3:
+          r_.f32[i] = -SIMDE_MATH_NANF;
+          break;
+        case 4:
+          r_.f32[i] = -SIMDE_MATH_INFINITYF;
+          break;
+        case 5:
+          r_.f32[i] =  SIMDE_MATH_INFINITYF;
+          break;
+        case 6:
+        #if defined(simde_math_copysignf)
+          r_.f32[i] =  simde_math_copysignf(SIMDE_MATH_INFINITYF, s_.f32[i]);
+        #else
+          r_.f32[i] =  simde_uint32_as_float32((simde_float32_as_uint32(s_.f32[i]) & 0x80000000) | simde_float32_as_uint32(SIMDE_MATH_INFINITYF));
+        #endif
+          break;
+        case 7:
+          r_.f32[i] =  SIMDE_FLOAT32_C(-0.0);
+          break;
+        case 8:
+          r_.f32[i] =  SIMDE_FLOAT32_C(0.0);
+          break;
+        case 9:
+          r_.f32[i] =  SIMDE_FLOAT32_C(-1.0);
+          break;
+        case 10:
+          r_.f32[i] =  SIMDE_FLOAT32_C(1.0);
+          break;
+        case 11:
+          r_.f32[i] =  SIMDE_FLOAT32_C(0.5);
+          break;
+        case 12:
+          r_.f32[i] =  SIMDE_FLOAT32_C(90.0);
+          break;
+        case 13:
+          r_.f32[i] =  SIMDE_MATH_PIF / 2;
+          break;
+        case 14:
+          r_.f32[i] =  SIMDE_MATH_FLT_MAX;
+          break;
+        case 15:
+          r_.f32[i] = -SIMDE_MATH_FLT_MAX;
+          break;
+      }
+    }
+
+    return simde__m128_from_private(r_);
+  }
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fixupimm_ps
+  #define _mm_fixupimm_ps(a, b, c, imm8) simde_mm_fixupimm_ps(a, b, c, imm8)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_FIXUPIMM_H) */

--- a/simde/x86/avx512/fixupimm.h
+++ b/simde/x86/avx512/fixupimm.h
@@ -125,6 +125,347 @@ simde_mm_fixupimm_ps (simde__m128 a, simde__m128 b, simde__m128i c, int imm8)
   #define _mm_maskz_fixupimm_ps(k, a, b, c, imm8) simde_mm_maskz_fixupimm_ps(k, a, b, c, imm8)
 #endif
 
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_fixupimm_ps (simde__m256 a, simde__m256 b, simde__m256i c, int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255) {
+  HEDLEY_STATIC_CAST(void, imm8);
+  simde__m256_private
+    r_,
+    a_ = simde__m256_to_private(a),
+    b_ = simde__m256_to_private(b),
+    s_ = simde__m256_to_private(simde_x_mm256_flushsubnormal_ps(b));
+  simde__m256i_private c_ = simde__m256i_to_private(c);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+    int32_t select = 1;
+    switch (simde_math_fpclassifyf(s_.f32[i])) {
+      case SIMDE_MATH_FP_NORMAL:
+        select = (s_.f32[i] < SIMDE_FLOAT32_C(0.0)) ? 6 : (s_.f32[i] == SIMDE_FLOAT32_C(1.0)) ? 3 : 7;
+        break;
+      case SIMDE_MATH_FP_ZERO:
+        select = 2;
+        break;
+      case SIMDE_MATH_FP_NAN:
+        select = 0;
+        break;
+      case SIMDE_MATH_FP_INFINITE:
+        select = ((s_.f32[i] > SIMDE_FLOAT32_C(0.0)) ? 5 : 4);
+        break;
+    }
+
+    switch (((c_.i32[i] >> (select << 2)) & 15)) {
+      case 0:
+        r_.f32[i] =  a_.f32[i];
+        break;
+      case 1:
+        r_.f32[i] =  b_.f32[i];
+        break;
+      case 2:
+        r_.f32[i] =  SIMDE_MATH_NANF;
+        break;
+      case 3:
+        r_.f32[i] = -SIMDE_MATH_NANF;
+        break;
+      case 4:
+        r_.f32[i] = -SIMDE_MATH_INFINITYF;
+        break;
+      case 5:
+        r_.f32[i] =  SIMDE_MATH_INFINITYF;
+        break;
+      case 6:
+      #if defined(simde_math_copysignf)
+        r_.f32[i] =  simde_math_copysignf(SIMDE_MATH_INFINITYF, s_.f32[i]);
+      #else
+        r_.f32[i] =  simde_uint32_as_float32((simde_float32_as_uint32(s_.f32[i]) & 0x80000000) | simde_float32_as_uint32(SIMDE_MATH_INFINITYF));
+      #endif
+        break;
+      case 7:
+        r_.f32[i] =  SIMDE_FLOAT32_C(-0.0);
+        break;
+      case 8:
+        r_.f32[i] =  SIMDE_FLOAT32_C(0.0);
+        break;
+      case 9:
+        r_.f32[i] =  SIMDE_FLOAT32_C(-1.0);
+        break;
+      case 10:
+        r_.f32[i] =  SIMDE_FLOAT32_C(1.0);
+        break;
+      case 11:
+        r_.f32[i] =  SIMDE_FLOAT32_C(0.5);
+        break;
+      case 12:
+        r_.f32[i] =  SIMDE_FLOAT32_C(90.0);
+        break;
+      case 13:
+        r_.f32[i] =  SIMDE_MATH_PIF / 2;
+        break;
+      case 14:
+        r_.f32[i] =  SIMDE_MATH_FLT_MAX;
+        break;
+      case 15:
+        r_.f32[i] = -SIMDE_MATH_FLT_MAX;
+        break;
+    }
+  }
+
+  return simde__m256_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm256_fixupimm_ps(a, b, c, imm8) _mm256_fixupimm_ps(a, b, c, imm8)
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_fixupimm_ps
+  #define _mm256_fixupimm_ps(a, b, c, imm8) simde_mm256_fixupimm_ps(a, b, c, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm256_mask_fixupimm_ps(a, k, b, c, imm8) _mm256_mask_fixupimm_ps(a, k, b, c, imm8)
+#else
+  #define simde_mm256_mask_fixupimm_ps(a, k, b, c, imm8) simde_mm256_mask_mov_ps(a, k, simde_mm256_fixupimm_ps(a, b, c, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_fixupimm_ps
+  #define _mm256_mask_fixupimm_ps(a, k, b, c, imm8) simde_mm256_mask_fixupimm_ps(a, k, b, c, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm256_maskz_fixupimm_ps(k, a, b, c, imm8) _mm256_maskz_fixupimm_ps(k, a, b, c, imm8)
+#else
+  #define simde_mm256_maskz_fixupimm_ps(k, a, b, c, imm8) simde_mm256_maskz_mov_ps(k, simde_mm256_fixupimm_ps(a, b, c, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_fixupimm_ps
+  #define _mm256_maskz_fixupimm_ps(k, a, b, c, imm8) simde_mm256_maskz_fixupimm_ps(k, a, b, c, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_fixupimm_ps (simde__m512 a, simde__m512 b, simde__m512i c, int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255) {
+  HEDLEY_STATIC_CAST(void, imm8);
+  simde__m512_private
+    r_,
+    a_ = simde__m512_to_private(a),
+    b_ = simde__m512_to_private(b),
+    s_ = simde__m512_to_private(simde_x_mm512_flushsubnormal_ps(b));
+  simde__m512i_private c_ = simde__m512i_to_private(c);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+    int32_t select = 1;
+    switch (simde_math_fpclassifyf(s_.f32[i])) {
+      case SIMDE_MATH_FP_NORMAL:
+        select = (s_.f32[i] < SIMDE_FLOAT32_C(0.0)) ? 6 : (s_.f32[i] == SIMDE_FLOAT32_C(1.0)) ? 3 : 7;
+        break;
+      case SIMDE_MATH_FP_ZERO:
+        select = 2;
+        break;
+      case SIMDE_MATH_FP_NAN:
+        select = 0;
+        break;
+      case SIMDE_MATH_FP_INFINITE:
+        select = ((s_.f32[i] > SIMDE_FLOAT32_C(0.0)) ? 5 : 4);
+        break;
+    }
+
+    switch (((c_.i32[i] >> (select << 2)) & 15)) {
+      case 0:
+        r_.f32[i] =  a_.f32[i];
+        break;
+      case 1:
+        r_.f32[i] =  b_.f32[i];
+        break;
+      case 2:
+        r_.f32[i] =  SIMDE_MATH_NANF;
+        break;
+      case 3:
+        r_.f32[i] = -SIMDE_MATH_NANF;
+        break;
+      case 4:
+        r_.f32[i] = -SIMDE_MATH_INFINITYF;
+        break;
+      case 5:
+        r_.f32[i] =  SIMDE_MATH_INFINITYF;
+        break;
+      case 6:
+      #if defined(simde_math_copysignf)
+        r_.f32[i] =  simde_math_copysignf(SIMDE_MATH_INFINITYF, s_.f32[i]);
+      #else
+        r_.f32[i] =  simde_uint32_as_float32((simde_float32_as_uint32(s_.f32[i]) & 0x80000000) | simde_float32_as_uint32(SIMDE_MATH_INFINITYF));
+      #endif
+        break;
+      case 7:
+        r_.f32[i] =  SIMDE_FLOAT32_C(-0.0);
+        break;
+      case 8:
+        r_.f32[i] =  SIMDE_FLOAT32_C(0.0);
+        break;
+      case 9:
+        r_.f32[i] =  SIMDE_FLOAT32_C(-1.0);
+        break;
+      case 10:
+        r_.f32[i] =  SIMDE_FLOAT32_C(1.0);
+        break;
+      case 11:
+        r_.f32[i] =  SIMDE_FLOAT32_C(0.5);
+        break;
+      case 12:
+        r_.f32[i] =  SIMDE_FLOAT32_C(90.0);
+        break;
+      case 13:
+        r_.f32[i] =  SIMDE_MATH_PIF / 2;
+        break;
+      case 14:
+        r_.f32[i] =  SIMDE_MATH_FLT_MAX;
+        break;
+      case 15:
+        r_.f32[i] = -SIMDE_MATH_FLT_MAX;
+        break;
+    }
+  }
+
+  return simde__m512_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_fixupimm_ps(a, b, c, imm8) _mm512_fixupimm_ps(a, b, c, imm8)
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_fixupimm_ps
+  #define _mm512_fixupimm_ps(a, b, c, imm8) simde_mm512_fixupimm_ps(a, b, c, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_mask_fixupimm_ps(a, k, b, c, imm8) _mm512_mask_fixupimm_ps(a, k, b, c, imm8)
+#else
+  #define simde_mm512_mask_fixupimm_ps(a, k, b, c, imm8) simde_mm512_mask_mov_ps(a, k, simde_mm512_fixupimm_ps(a, b, c, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_fixupimm_ps
+  #define _mm512_mask_fixupimm_ps(a, k, b, c, imm8) simde_mm512_mask_fixupimm_ps(a, k, b, c, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_maskz_fixupimm_ps(k, a, b, c, imm8) _mm512_maskz_fixupimm_ps(k, a, b, c, imm8)
+#else
+  #define simde_mm512_maskz_fixupimm_ps(k, a, b, c, imm8) simde_mm512_maskz_mov_ps(k, simde_mm512_fixupimm_ps(a, b, c, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_fixupimm_ps
+  #define _mm512_maskz_fixupimm_ps(k, a, b, c, imm8) simde_mm512_maskz_fixupimm_ps(k, a, b, c, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_fixupimm_ss (simde__m128 a, simde__m128 b, simde__m128i c, int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255) {
+  HEDLEY_STATIC_CAST(void, imm8);
+  simde__m128_private
+    a_ = simde__m128_to_private(a),
+    b_ = simde__m128_to_private(b),
+    s_ = simde__m128_to_private(simde_x_mm_flushsubnormal_ps(b));
+  simde__m128i_private c_ = simde__m128i_to_private(c);
+
+  int32_t select = 1;
+  switch (simde_math_fpclassifyf(s_.f32[0])) {
+    case SIMDE_MATH_FP_NORMAL:
+      select = (s_.f32[0] < SIMDE_FLOAT32_C(0.0)) ? 6 : (s_.f32[0] == SIMDE_FLOAT32_C(1.0)) ? 3 : 7;
+      break;
+    case SIMDE_MATH_FP_ZERO:
+      select = 2;
+      break;
+    case SIMDE_MATH_FP_NAN:
+      select = 0;
+      break;
+    case SIMDE_MATH_FP_INFINITE:
+      select = ((s_.f32[0] > SIMDE_FLOAT32_C(0.0)) ? 5 : 4);
+      break;
+  }
+
+  switch (((c_.i32[0] >> (select << 2)) & 15)) {
+    case 0:
+      b_.f32[0] =  a_.f32[0];
+      break;
+    case 2:
+      b_.f32[0] =  SIMDE_MATH_NANF;
+      break;
+    case 3:
+      b_.f32[0] = -SIMDE_MATH_NANF;
+      break;
+    case 4:
+      b_.f32[0] = -SIMDE_MATH_INFINITYF;
+      break;
+    case 5:
+      b_.f32[0] =  SIMDE_MATH_INFINITYF;
+      break;
+    case 6:
+    #if defined(simde_math_copysignf)
+      b_.f32[0] =  simde_math_copysignf(SIMDE_MATH_INFINITYF, s_.f32[0]);
+    #else
+      b_.f32[0] =  simde_uint32_as_float32((simde_float32_as_uint32(s_.f32[0]) & 0x80000000) | simde_float32_as_uint32(SIMDE_MATH_INFINITYF));
+    #endif
+      break;
+    case 7:
+      b_.f32[0] =  SIMDE_FLOAT32_C(-0.0);
+      break;
+    case 8:
+      b_.f32[0] =  SIMDE_FLOAT32_C(0.0);
+      break;
+    case 9:
+      b_.f32[0] =  SIMDE_FLOAT32_C(-1.0);
+      break;
+    case 10:
+      b_.f32[0] =  SIMDE_FLOAT32_C(1.0);
+      break;
+    case 11:
+      b_.f32[0] =  SIMDE_FLOAT32_C(0.5);
+      break;
+    case 12:
+      b_.f32[0] =  SIMDE_FLOAT32_C(90.0);
+      break;
+    case 13:
+      b_.f32[0] =  SIMDE_MATH_PIF / 2;
+      break;
+    case 14:
+      b_.f32[0] =  SIMDE_MATH_FLT_MAX;
+      break;
+    case 15:
+      b_.f32[0] = -SIMDE_MATH_FLT_MAX;
+      break;
+  }
+
+  return simde__m128_from_private(b_);
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm_fixupimm_ss(a, b, c, imm8) _mm_fixupimm_ss(a, b, c, imm8)
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fixupimm_ss
+  #define _mm_fixupimm_ss(a, b, c, imm8) simde_mm_fixupimm_ss(a, b, c, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm_mask_fixupimm_ss(a, k, b, c, imm8) _mm_mask_fixupimm_ss(a, k, b, c, imm8)
+#else
+  #define simde_mm_mask_fixupimm_ss(a, k, b, c, imm8) simde_mm_mask_mov_ps(a, ((k) | 14), simde_mm_fixupimm_ss(a, b, c, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_fixupimm_ss
+  #define _mm_mask_fixupimm_ss(a, k, b, c, imm8) simde_mm_mask_fixupimm_ss(a, k, b, c, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm_maskz_fixupimm_ss(k, a, b, c, imm8) _mm_maskz_fixupimm_ss(k, a, b, c, imm8)
+#else
+  #define simde_mm_maskz_fixupimm_ss(k, a, b, c, imm8) simde_mm_maskz_mov_ps(((k) | 14), simde_mm_fixupimm_ss(a, b, c, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_fixupimm_ss
+  #define _mm_maskz_fixupimm_ss(k, a, b, c, imm8) simde_mm_maskz_fixupimm_ss(k, a, b, c, imm8)
+#endif
+
 SIMDE_END_DECLS_
 HEDLEY_DIAGNOSTIC_POP
 

--- a/simde/x86/avx512/fixupimm.h
+++ b/simde/x86/avx512/fixupimm.h
@@ -9,7 +9,7 @@ SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
 SIMDE_BEGIN_DECLS_
 
 #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
-  #define simde_mm_fixupimm_ps(a, b, c, imm8) _mm_fixupimm_ps(a, b, c, imm8);
+  #define simde_mm_fixupimm_ps(a, b, c, imm8) _mm_fixupimm_ps(a, b, c, imm8)
 #else
   SIMDE_FUNCTION_ATTRIBUTES
   simde__m128

--- a/simde/x86/avx512/fixupimm.h
+++ b/simde/x86/avx512/fixupimm.h
@@ -8,99 +8,98 @@ HEDLEY_DIAGNOSTIC_PUSH
 SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
 SIMDE_BEGIN_DECLS_
 
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_fixupimm_ps (simde__m128 a, simde__m128 b, simde__m128i c, int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255) {
+  HEDLEY_STATIC_CAST(void, imm8);
+  simde__m128_private
+    r_,
+    a_ = simde__m128_to_private(a),
+    b_ = simde__m128_to_private(b),
+    s_ = simde__m128_to_private(simde_x_mm_flushsubnormal_ps(b));
+  simde__m128i_private c_ = simde__m128i_to_private(c);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+    int32_t select;
+    if (simde_math_isnanf(s_.f32[i]))
+      select = 0;
+    else if (s_.f32[i] ==  SIMDE_FLOAT32_C(0.0))
+      select = 2;
+    else if (s_.f32[i] ==  SIMDE_FLOAT32_C(1.0))
+      select = 3;
+    else if (s_.f32[i] == -SIMDE_MATH_INFINITYF)
+      select = 4;
+    else if (s_.f32[i] ==  SIMDE_MATH_INFINITYF)
+      select = 5;
+    else if (s_.f32[i]  <  0)
+      select = 6;
+    else if (s_.f32[i]  >  0)
+      select = 7;
+    else
+      select = 1;
+
+    switch (((c_.i32[i] >> (select << 2)) & 15)) {
+      case 0:
+        r_.f32[i] =  a_.f32[i];
+        break;
+      case 1:
+        r_.f32[i] =  b_.f32[i];
+        break;
+      case 2:
+        r_.f32[i] =  SIMDE_MATH_NANF;
+        break;
+      case 3:
+        r_.f32[i] = -SIMDE_MATH_NANF;
+        break;
+      case 4:
+        r_.f32[i] = -SIMDE_MATH_INFINITYF;
+        break;
+      case 5:
+        r_.f32[i] =  SIMDE_MATH_INFINITYF;
+        break;
+      case 6:
+      #if defined(simde_math_copysignf)
+        r_.f32[i] =  simde_math_copysignf(SIMDE_MATH_INFINITYF, s_.f32[i]);
+      #else
+        r_.f32[i] =  simde_uint32_as_float32((simde_float32_as_uint32(s_.f32[i]) & 0x80000000) | simde_float32_as_uint32(SIMDE_MATH_INFINITYF));
+      #endif
+        break;
+      case 7:
+        r_.f32[i] =  SIMDE_FLOAT32_C(-0.0);
+        break;
+      case 8:
+        r_.f32[i] =  SIMDE_FLOAT32_C(0.0);
+        break;
+      case 9:
+        r_.f32[i] =  SIMDE_FLOAT32_C(-1.0);
+        break;
+      case 10:
+        r_.f32[i] =  SIMDE_FLOAT32_C(1.0);
+        break;
+      case 11:
+        r_.f32[i] =  SIMDE_FLOAT32_C(0.5);
+        break;
+      case 12:
+        r_.f32[i] =  SIMDE_FLOAT32_C(90.0);
+        break;
+      case 13:
+        r_.f32[i] =  SIMDE_MATH_PIF / 2;
+        break;
+      case 14:
+        r_.f32[i] =  SIMDE_MATH_FLT_MAX;
+        break;
+      case 15:
+        r_.f32[i] = -SIMDE_MATH_FLT_MAX;
+        break;
+    }
+  }
+
+  return simde__m128_from_private(r_);
+}
 #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
   #define simde_mm_fixupimm_ps(a, b, c, imm8) _mm_fixupimm_ps(a, b, c, imm8)
-#else
-  SIMDE_FUNCTION_ATTRIBUTES
-  simde__m128
-  simde_mm_fixupimm_ps (simde__m128 a, simde__m128 b, simde__m128i c, int imm8)
-      SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255) {
-    HEDLEY_STATIC_CAST(void, imm8);
-    simde__m128_private
-      r_,
-      a_ = simde__m128_to_private(a),
-      b_ = simde__m128_to_private(b),
-      s_ = simde__m128_to_private(simde_x_mm_flushsubnormal_ps(b));
-    simde__m128i_private c_ = simde__m128i_to_private(c);
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
-      int32_t select;
-      if (simde_math_isnanf(s_.f32[i]))
-        select = 0;
-      else if (s_.f32[i] ==  SIMDE_FLOAT32_C(0.0))
-        select = 2;
-      else if (s_.f32[i] ==  SIMDE_FLOAT32_C(1.0))
-        select = 3;
-      else if (s_.f32[i] == -SIMDE_MATH_INFINITYF)
-        select = 4;
-      else if (s_.f32[i] ==  SIMDE_MATH_INFINITYF)
-        select = 5;
-      else if (s_.f32[i]  <  0)
-        select = 6;
-      else if (s_.f32[i]  >  0)
-        select = 7;
-      else
-        select = 1;
-
-      switch (((c_.i32[i] >> (select << 2)) & 15)) {
-        case 0:
-          r_.f32[i] =  a_.f32[i];
-          break;
-        case 1:
-          r_.f32[i] =  b_.f32[i];
-          break;
-        case 2:
-          r_.f32[i] =  SIMDE_MATH_NANF;
-          break;
-        case 3:
-          r_.f32[i] = -SIMDE_MATH_NANF;
-          break;
-        case 4:
-          r_.f32[i] = -SIMDE_MATH_INFINITYF;
-          break;
-        case 5:
-          r_.f32[i] =  SIMDE_MATH_INFINITYF;
-          break;
-        case 6:
-        #if defined(simde_math_copysignf)
-          r_.f32[i] =  simde_math_copysignf(SIMDE_MATH_INFINITYF, s_.f32[i]);
-        #else
-          r_.f32[i] =  simde_uint32_as_float32((simde_float32_as_uint32(s_.f32[i]) & 0x80000000) | simde_float32_as_uint32(SIMDE_MATH_INFINITYF));
-        #endif
-          break;
-        case 7:
-          r_.f32[i] =  SIMDE_FLOAT32_C(-0.0);
-          break;
-        case 8:
-          r_.f32[i] =  SIMDE_FLOAT32_C(0.0);
-          break;
-        case 9:
-          r_.f32[i] =  SIMDE_FLOAT32_C(-1.0);
-          break;
-        case 10:
-          r_.f32[i] =  SIMDE_FLOAT32_C(1.0);
-          break;
-        case 11:
-          r_.f32[i] =  SIMDE_FLOAT32_C(0.5);
-          break;
-        case 12:
-          r_.f32[i] =  SIMDE_FLOAT32_C(90.0);
-          break;
-        case 13:
-          r_.f32[i] =  SIMDE_MATH_PIF / 2;
-          break;
-        case 14:
-          r_.f32[i] =  SIMDE_MATH_FLT_MAX;
-          break;
-        case 15:
-          r_.f32[i] = -SIMDE_MATH_FLT_MAX;
-          break;
-      }
-    }
-
-    return simde__m128_from_private(r_);
-  }
 #endif
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
   #undef _mm_fixupimm_ps

--- a/simde/x86/avx512/fixupimm.h
+++ b/simde/x86/avx512/fixupimm.h
@@ -926,7 +926,6 @@ simde_mm_fixupimm_sd (simde__m128d a, simde__m128d b, simde__m128i c, int imm8)
   #define _mm_maskz_fixupimm_sd(k, a, b, c, imm8) simde_mm_maskz_fixupimm_sd(k, a, b, c, imm8)
 #endif
 
-
 SIMDE_END_DECLS_
 HEDLEY_DIAGNOSTIC_POP
 

--- a/simde/x86/avx512/fixupimm.h
+++ b/simde/x86/avx512/fixupimm.h
@@ -516,7 +516,7 @@ simde_mm_fixupimm_pd (simde__m128d a, simde__m128d b, simde__m128i c, int imm8)
         r_.f64[i] =  SIMDE_MATH_INFINITY;
         break;
       case 6:
-      #if defined(simde_math_copysignf)
+      #if defined(simde_math_copysign)
         r_.f64[i] =  simde_math_copysign(SIMDE_MATH_INFINITY, s_.f64[i]);
       #else
         r_.f64[i] =  simde_uint64_as_float64((simde_float64_as_uint64(s_.f64[i]) & 0x8000000000000000) | simde_float64_as_uint64(SIMDE_MATH_INFINITY));
@@ -632,7 +632,7 @@ simde_mm256_fixupimm_pd (simde__m256d a, simde__m256d b, simde__m256i c, int imm
         r_.f64[i] =  SIMDE_MATH_INFINITY;
         break;
       case 6:
-      #if defined(simde_math_copysignf)
+      #if defined(simde_math_copysign)
         r_.f64[i] =  simde_math_copysign(SIMDE_MATH_INFINITY, s_.f64[i]);
       #else
         r_.f64[i] =  simde_uint64_as_float64((simde_float64_as_uint64(s_.f64[i]) & 0x8000000000000000) | simde_float64_as_uint64(SIMDE_MATH_INFINITY));
@@ -748,7 +748,7 @@ simde_mm512_fixupimm_pd (simde__m512d a, simde__m512d b, simde__m512i c, int imm
         r_.f64[i] =  SIMDE_MATH_INFINITY;
         break;
       case 6:
-      #if defined(simde_math_copysignf)
+      #if defined(simde_math_copysign)
         r_.f64[i] =  simde_math_copysign(SIMDE_MATH_INFINITY, s_.f64[i]);
       #else
         r_.f64[i] =  simde_uint64_as_float64((simde_float64_as_uint64(s_.f64[i]) & 0x8000000000000000) | simde_float64_as_uint64(SIMDE_MATH_INFINITY));
@@ -861,7 +861,7 @@ simde_mm_fixupimm_sd (simde__m128d a, simde__m128d b, simde__m128i c, int imm8)
       b_.f64[0] =  SIMDE_MATH_INFINITY;
       break;
     case 6:
-    #if defined(simde_math_copysignf)
+    #if defined(simde_math_copysign)
       b_.f64[0] =  simde_math_copysign(SIMDE_MATH_INFINITY, s_.f64[0]);
     #else
       b_.f64[0] =  simde_uint64_as_float64((simde_float64_as_uint64(s_.f64[0]) & 0x8000000000000000) | simde_float64_as_uint64(SIMDE_MATH_INFINITY));

--- a/simde/x86/avx512/fixupimm.h
+++ b/simde/x86/avx512/fixupimm.h
@@ -59,11 +59,7 @@ simde_mm_fixupimm_ps (simde__m128 a, simde__m128 b, simde__m128i c, int imm8)
         r_.f32[i] =  SIMDE_MATH_INFINITYF;
         break;
       case 6:
-      #if defined(simde_math_copysignf)
-        r_.f32[i] =  simde_math_copysignf(SIMDE_MATH_INFINITYF, s_.f32[i]);
-      #else
-        r_.f32[i] =  simde_uint32_as_float32((simde_float32_as_uint32(s_.f32[i]) & 0x80000000) | simde_float32_as_uint32(SIMDE_MATH_INFINITYF));
-      #endif
+        r_.f32[i] =  s_.f32[i] < SIMDE_FLOAT32_C(0.0) ? -SIMDE_MATH_INFINITYF : SIMDE_MATH_INFINITYF;
         break;
       case 7:
         r_.f32[i] =  SIMDE_FLOAT32_C(-0.0);
@@ -175,11 +171,7 @@ simde_mm256_fixupimm_ps (simde__m256 a, simde__m256 b, simde__m256i c, int imm8)
         r_.f32[i] =  SIMDE_MATH_INFINITYF;
         break;
       case 6:
-      #if defined(simde_math_copysignf)
-        r_.f32[i] =  simde_math_copysignf(SIMDE_MATH_INFINITYF, s_.f32[i]);
-      #else
-        r_.f32[i] =  simde_uint32_as_float32((simde_float32_as_uint32(s_.f32[i]) & 0x80000000) | simde_float32_as_uint32(SIMDE_MATH_INFINITYF));
-      #endif
+        r_.f32[i] =  s_.f32[i] < SIMDE_FLOAT32_C(0.0) ? -SIMDE_MATH_INFINITYF : SIMDE_MATH_INFINITYF;
         break;
       case 7:
         r_.f32[i] =  SIMDE_FLOAT32_C(-0.0);
@@ -291,11 +283,7 @@ simde_mm512_fixupimm_ps (simde__m512 a, simde__m512 b, simde__m512i c, int imm8)
         r_.f32[i] =  SIMDE_MATH_INFINITYF;
         break;
       case 6:
-      #if defined(simde_math_copysignf)
-        r_.f32[i] =  simde_math_copysignf(SIMDE_MATH_INFINITYF, s_.f32[i]);
-      #else
-        r_.f32[i] =  simde_uint32_as_float32((simde_float32_as_uint32(s_.f32[i]) & 0x80000000) | simde_float32_as_uint32(SIMDE_MATH_INFINITYF));
-      #endif
+        r_.f32[i] =  s_.f32[i] < SIMDE_FLOAT32_C(0.0) ? -SIMDE_MATH_INFINITYF : SIMDE_MATH_INFINITYF;
         break;
       case 7:
         r_.f32[i] =  SIMDE_FLOAT32_C(-0.0);
@@ -401,11 +389,7 @@ simde_mm_fixupimm_ss (simde__m128 a, simde__m128 b, simde__m128i c, int imm8)
       b_.f32[0] =  SIMDE_MATH_INFINITYF;
       break;
     case 6:
-    #if defined(simde_math_copysignf)
-      b_.f32[0] =  simde_math_copysignf(SIMDE_MATH_INFINITYF, s_.f32[0]);
-    #else
-      b_.f32[0] =  simde_uint32_as_float32((simde_float32_as_uint32(s_.f32[0]) & 0x80000000) | simde_float32_as_uint32(SIMDE_MATH_INFINITYF));
-    #endif
+      b_.f32[0] =  s_.f32[0] < SIMDE_FLOAT32_C(0.0) ? -SIMDE_MATH_INFINITYF : SIMDE_MATH_INFINITYF;
       break;
     case 7:
       b_.f32[0] =  SIMDE_FLOAT32_C(-0.0);
@@ -516,11 +500,7 @@ simde_mm_fixupimm_pd (simde__m128d a, simde__m128d b, simde__m128i c, int imm8)
         r_.f64[i] =  SIMDE_MATH_INFINITY;
         break;
       case 6:
-      #if defined(simde_math_copysign)
-        r_.f64[i] =  simde_math_copysign(SIMDE_MATH_INFINITY, s_.f64[i]);
-      #else
-        r_.f64[i] =  simde_uint64_as_float64((simde_float64_as_uint64(s_.f64[i]) & 0x8000000000000000) | simde_float64_as_uint64(SIMDE_MATH_INFINITY));
-      #endif
+        r_.f64[i] =  s_.f64[i] < SIMDE_FLOAT64_C(0.0) ? -SIMDE_MATH_INFINITY : SIMDE_MATH_INFINITY;
         break;
       case 7:
         r_.f64[i] =  SIMDE_FLOAT64_C(-0.0);
@@ -632,11 +612,7 @@ simde_mm256_fixupimm_pd (simde__m256d a, simde__m256d b, simde__m256i c, int imm
         r_.f64[i] =  SIMDE_MATH_INFINITY;
         break;
       case 6:
-      #if defined(simde_math_copysign)
-        r_.f64[i] =  simde_math_copysign(SIMDE_MATH_INFINITY, s_.f64[i]);
-      #else
-        r_.f64[i] =  simde_uint64_as_float64((simde_float64_as_uint64(s_.f64[i]) & 0x8000000000000000) | simde_float64_as_uint64(SIMDE_MATH_INFINITY));
-      #endif
+        r_.f64[i] =  s_.f64[i] < SIMDE_FLOAT64_C(0.0) ? -SIMDE_MATH_INFINITY : SIMDE_MATH_INFINITY;
         break;
       case 7:
         r_.f64[i] =  SIMDE_FLOAT64_C(-0.0);
@@ -748,11 +724,7 @@ simde_mm512_fixupimm_pd (simde__m512d a, simde__m512d b, simde__m512i c, int imm
         r_.f64[i] =  SIMDE_MATH_INFINITY;
         break;
       case 6:
-      #if defined(simde_math_copysign)
-        r_.f64[i] =  simde_math_copysign(SIMDE_MATH_INFINITY, s_.f64[i]);
-      #else
-        r_.f64[i] =  simde_uint64_as_float64((simde_float64_as_uint64(s_.f64[i]) & 0x8000000000000000) | simde_float64_as_uint64(SIMDE_MATH_INFINITY));
-      #endif
+        r_.f64[i] =  s_.f64[i] < SIMDE_FLOAT64_C(0.0) ? -SIMDE_MATH_INFINITY : SIMDE_MATH_INFINITY;
         break;
       case 7:
         r_.f64[i] =  SIMDE_FLOAT64_C(-0.0);
@@ -861,11 +833,7 @@ simde_mm_fixupimm_sd (simde__m128d a, simde__m128d b, simde__m128i c, int imm8)
       b_.f64[0] =  SIMDE_MATH_INFINITY;
       break;
     case 6:
-    #if defined(simde_math_copysign)
-      b_.f64[0] =  simde_math_copysign(SIMDE_MATH_INFINITY, s_.f64[0]);
-    #else
-      b_.f64[0] =  simde_uint64_as_float64((simde_float64_as_uint64(s_.f64[0]) & 0x8000000000000000) | simde_float64_as_uint64(SIMDE_MATH_INFINITY));
-    #endif
+      b_.f64[0] =  s_.f64[0] < SIMDE_FLOAT64_C(0.0) ? -SIMDE_MATH_INFINITY : SIMDE_MATH_INFINITY;
       break;
     case 7:
       b_.f64[0] =  SIMDE_FLOAT64_C(-0.0);

--- a/simde/x86/avx512/fixupimm_round.h
+++ b/simde/x86/avx512/fixupimm_round.h
@@ -9,30 +9,6 @@ HEDLEY_DIAGNOSTIC_PUSH
 SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
 SIMDE_BEGIN_DECLS_
 
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m512
-simde_mm512_fixupimm_round_ps (simde__m512 a, simde__m512 b, simde__m512i c, int imm8, int sae)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
-    SIMDE_REQUIRE_CONSTANT(sae) {
-  simde__m512 r;
-
-  if (sae & SIMDE_MM_FROUND_NO_EXC) {
-    #if defined(SIMDE_HAVE_FENV_H)
-      fenv_t envp;
-      int x = feholdexcept(&envp);
-      r = simde_mm512_fixupimm_ps(a, b, c, imm8);
-      if (HEDLEY_LIKELY(x == 0))
-        fesetenv(&envp);
-    #else
-      r = simde_mm512_fixupimm_ps(a, b, c, imm8);
-    #endif
-  }
-  else {
-    r = simde_mm512_fixupimm_ps(a, b, c, imm8);
-  }
-
-  return r;
-}
 #if defined(SIMDE_X86_AVX512F_NATIVE)
   #define simde_mm512_fixupimm_round_ps(a, b, c, imm8, sae) _mm512_fixupimm_round_ps(a, b, c, imm8, sae)
 #elif defined(SIMDE_FAST_EXCEPTIONS)
@@ -58,36 +34,37 @@ simde_mm512_fixupimm_round_ps (simde__m512 a, simde__m512 b, simde__m512i c, int
   #else
     #define simde_mm512_fixupimm_round_ps(a, b, c, imm8, sae) simde_mm512_fixupimm_ps(a, b, c, imm8)
   #endif
+#else
+  SIMDE_FUNCTION_ATTRIBUTES
+  simde__m512
+  simde_mm512_fixupimm_round_ps (simde__m512 a, simde__m512 b, simde__m512i c, int imm8, int sae)
+      SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+      SIMDE_REQUIRE_CONSTANT(sae) {
+    simde__m512 r;
+
+    if (sae & SIMDE_MM_FROUND_NO_EXC) {
+      #if defined(SIMDE_HAVE_FENV_H)
+        fenv_t envp;
+        int x = feholdexcept(&envp);
+        r = simde_mm512_fixupimm_ps(a, b, c, imm8);
+        if (HEDLEY_LIKELY(x == 0))
+          fesetenv(&envp);
+      #else
+        r = simde_mm512_fixupimm_ps(a, b, c, imm8);
+      #endif
+    }
+    else {
+      r = simde_mm512_fixupimm_ps(a, b, c, imm8);
+    }
+
+    return r;
+  }
 #endif
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
   #undef _mm512_fixupimm_round_ps
   #define _mm512_fixupimm_round_ps(a, b, c, imm8, sae) simde_mm512_fixupimm_round_ps(a, b, c, imm8, sae)
 #endif
 
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m512
-simde_mm512_mask_fixupimm_round_ps (simde__m512 a, simde__mmask16 k, simde__m512 b, simde__m512i c, int imm8, int sae)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
-    SIMDE_REQUIRE_CONSTANT(sae) {
-  simde__m512 r;
-
-  if (sae & SIMDE_MM_FROUND_NO_EXC) {
-    #if defined(SIMDE_HAVE_FENV_H)
-      fenv_t envp;
-      int x = feholdexcept(&envp);
-      r = simde_mm512_mask_fixupimm_ps(a, k, b, c, imm8);
-      if (HEDLEY_LIKELY(x == 0))
-        fesetenv(&envp);
-    #else
-      r = simde_mm512_mask_fixupimm_ps(a, k, b, c, imm8);
-    #endif
-  }
-  else {
-    r = simde_mm512_mask_fixupimm_ps(a, k, b, c, imm8);
-  }
-
-  return r;
-}
 #if defined(SIMDE_X86_AVX512F_NATIVE)
   #define simde_mm512_mask_fixupimm_round_ps(a, k, b, c, imm8, sae) _mm512_mask_fixupimm_round_ps(a, k, b, c, imm8, sae)
 #elif defined(SIMDE_FAST_EXCEPTIONS)
@@ -113,36 +90,37 @@ simde_mm512_mask_fixupimm_round_ps (simde__m512 a, simde__mmask16 k, simde__m512
   #else
     #define simde_mm512_mask_fixupimm_round_ps(a, k, b, c, imm8, sae) simde_mm512_mask_fixupimm_ps(a, k, b, c, imm8)
   #endif
+#else
+  SIMDE_FUNCTION_ATTRIBUTES
+  simde__m512
+  simde_mm512_mask_fixupimm_round_ps (simde__m512 a, simde__mmask16 k, simde__m512 b, simde__m512i c, int imm8, int sae)
+      SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+      SIMDE_REQUIRE_CONSTANT(sae) {
+    simde__m512 r;
+
+    if (sae & SIMDE_MM_FROUND_NO_EXC) {
+      #if defined(SIMDE_HAVE_FENV_H)
+        fenv_t envp;
+        int x = feholdexcept(&envp);
+        r = simde_mm512_mask_fixupimm_ps(a, k, b, c, imm8);
+        if (HEDLEY_LIKELY(x == 0))
+          fesetenv(&envp);
+      #else
+        r = simde_mm512_mask_fixupimm_ps(a, k, b, c, imm8);
+      #endif
+    }
+    else {
+      r = simde_mm512_mask_fixupimm_ps(a, k, b, c, imm8);
+    }
+
+    return r;
+  }
 #endif
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
   #undef _mm512_mask_fixupimm_round_ps
   #define _mm512_mask_fixupimm_round_ps(a, k, b, c, imm8, sae) simde_mm512_mask_fixupimm_round_ps(a, k, b, c, imm8, sae)
 #endif
 
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m512
-simde_mm512_maskz_fixupimm_round_ps (simde__mmask16 k, simde__m512 a, simde__m512 b, simde__m512i c, int imm8, int sae)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
-    SIMDE_REQUIRE_CONSTANT(sae) {
-  simde__m512 r;
-
-  if (sae & SIMDE_MM_FROUND_NO_EXC) {
-    #if defined(SIMDE_HAVE_FENV_H)
-      fenv_t envp;
-      int x = feholdexcept(&envp);
-      r = simde_mm512_maskz_fixupimm_ps(k, a, b, c, imm8);
-      if (HEDLEY_LIKELY(x == 0))
-        fesetenv(&envp);
-    #else
-      r = simde_mm512_maskz_fixupimm_ps(k, a, b, c, imm8);
-    #endif
-  }
-  else {
-    r = simde_mm512_maskz_fixupimm_ps(k, a, b, c, imm8);
-  }
-
-  return r;
-}
 #if defined(SIMDE_X86_AVX512F_NATIVE)
   #define simde_mm512_maskz_fixupimm_round_ps(k, a, b, c, imm8, sae) _mm512_maskz_fixupimm_round_ps(k, a, b, c, imm8, sae)
 #elif defined(SIMDE_FAST_EXCEPTIONS)
@@ -168,36 +146,37 @@ simde_mm512_maskz_fixupimm_round_ps (simde__mmask16 k, simde__m512 a, simde__m51
   #else
     #define simde_mm512_maskz_fixupimm_round_ps(k, a, b, c, imm8, sae) simde_mm512_maskz_fixupimm_ps(k, a, b, c, imm8)
   #endif
+#else
+  SIMDE_FUNCTION_ATTRIBUTES
+  simde__m512
+  simde_mm512_maskz_fixupimm_round_ps (simde__mmask16 k, simde__m512 a, simde__m512 b, simde__m512i c, int imm8, int sae)
+      SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+      SIMDE_REQUIRE_CONSTANT(sae) {
+    simde__m512 r;
+
+    if (sae & SIMDE_MM_FROUND_NO_EXC) {
+      #if defined(SIMDE_HAVE_FENV_H)
+        fenv_t envp;
+        int x = feholdexcept(&envp);
+        r = simde_mm512_maskz_fixupimm_ps(k, a, b, c, imm8);
+        if (HEDLEY_LIKELY(x == 0))
+          fesetenv(&envp);
+      #else
+        r = simde_mm512_maskz_fixupimm_ps(k, a, b, c, imm8);
+      #endif
+    }
+    else {
+      r = simde_mm512_maskz_fixupimm_ps(k, a, b, c, imm8);
+    }
+
+    return r;
+  }
 #endif
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
   #undef _mm512_maskz_fixupimm_round_ps
   #define _mm512_maskz_fixupimm_round_ps(k, a, b, c, imm8, sae) simde_mm512_maskz_fixupimm_round_ps(k, a, b, c, imm8, sae)
 #endif
 
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m512d
-simde_mm512_fixupimm_round_pd (simde__m512d a, simde__m512d b, simde__m512i c, int imm8, int sae)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
-    SIMDE_REQUIRE_CONSTANT(sae) {
-  simde__m512d r;
-
-  if (sae & SIMDE_MM_FROUND_NO_EXC) {
-    #if defined(SIMDE_HAVE_FENV_H)
-      fenv_t envp;
-      int x = feholdexcept(&envp);
-      r = simde_mm512_fixupimm_pd(a, b, c, imm8);
-      if (HEDLEY_LIKELY(x == 0))
-        fesetenv(&envp);
-    #else
-      r = simde_mm512_fixupimm_pd(a, b, c, imm8);
-    #endif
-  }
-  else {
-    r = simde_mm512_fixupimm_pd(a, b, c, imm8);
-  }
-
-  return r;
-}
 #if defined(SIMDE_X86_AVX512F_NATIVE)
   #define simde_mm512_fixupimm_round_pd(a, b, c, imm8, sae) _mm512_fixupimm_round_pd(a, b, c, imm8, sae)
 #elif defined(SIMDE_FAST_EXCEPTIONS)
@@ -223,36 +202,37 @@ simde_mm512_fixupimm_round_pd (simde__m512d a, simde__m512d b, simde__m512i c, i
   #else
     #define simde_mm512_fixupimm_round_pd(a, b, c, imm8, sae) simde_mm512_fixupimm_pd(a, b, c, imm8)
   #endif
+#else
+  SIMDE_FUNCTION_ATTRIBUTES
+  simde__m512d
+  simde_mm512_fixupimm_round_pd (simde__m512d a, simde__m512d b, simde__m512i c, int imm8, int sae)
+      SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+      SIMDE_REQUIRE_CONSTANT(sae) {
+    simde__m512d r;
+
+    if (sae & SIMDE_MM_FROUND_NO_EXC) {
+      #if defined(SIMDE_HAVE_FENV_H)
+        fenv_t envp;
+        int x = feholdexcept(&envp);
+        r = simde_mm512_fixupimm_pd(a, b, c, imm8);
+        if (HEDLEY_LIKELY(x == 0))
+          fesetenv(&envp);
+      #else
+        r = simde_mm512_fixupimm_pd(a, b, c, imm8);
+      #endif
+    }
+    else {
+      r = simde_mm512_fixupimm_pd(a, b, c, imm8);
+    }
+
+    return r;
+  }
 #endif
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
   #undef _mm512_fixupimm_round_pd
   #define _mm512_fixupimm_round_pd(a, b, c, imm8, sae) simde_mm512_fixupimm_round_pd(a, b, c, imm8, sae)
 #endif
 
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m512d
-simde_mm512_mask_fixupimm_round_pd (simde__m512d a, simde__mmask8 k, simde__m512d b, simde__m512i c, int imm8, int sae)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
-    SIMDE_REQUIRE_CONSTANT(sae) {
-  simde__m512d r;
-
-  if (sae & SIMDE_MM_FROUND_NO_EXC) {
-    #if defined(SIMDE_HAVE_FENV_H)
-      fenv_t envp;
-      int x = feholdexcept(&envp);
-      r = simde_mm512_mask_fixupimm_pd(a, k, b, c, imm8);
-      if (HEDLEY_LIKELY(x == 0))
-        fesetenv(&envp);
-    #else
-      r = simde_mm512_mask_fixupimm_pd(a, k, b, c, imm8);
-    #endif
-  }
-  else {
-    r = simde_mm512_mask_fixupimm_pd(a, k, b, c, imm8);
-  }
-
-  return r;
-}
 #if defined(SIMDE_X86_AVX512F_NATIVE)
   #define simde_mm512_mask_fixupimm_round_pd(a, k, b, c, imm8, sae) _mm512_mask_fixupimm_round_pd(a, k, b, c, imm8, sae)
 #elif defined(SIMDE_FAST_EXCEPTIONS)
@@ -278,36 +258,37 @@ simde_mm512_mask_fixupimm_round_pd (simde__m512d a, simde__mmask8 k, simde__m512
   #else
     #define simde_mm512_mask_fixupimm_round_pd(a, k, b, c, imm8, sae) simde_mm512_mask_fixupimm_pd(a, k, b, c, imm8)
   #endif
+#else
+  SIMDE_FUNCTION_ATTRIBUTES
+  simde__m512d
+  simde_mm512_mask_fixupimm_round_pd (simde__m512d a, simde__mmask8 k, simde__m512d b, simde__m512i c, int imm8, int sae)
+      SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+      SIMDE_REQUIRE_CONSTANT(sae) {
+    simde__m512d r;
+
+    if (sae & SIMDE_MM_FROUND_NO_EXC) {
+      #if defined(SIMDE_HAVE_FENV_H)
+        fenv_t envp;
+        int x = feholdexcept(&envp);
+        r = simde_mm512_mask_fixupimm_pd(a, k, b, c, imm8);
+        if (HEDLEY_LIKELY(x == 0))
+          fesetenv(&envp);
+      #else
+        r = simde_mm512_mask_fixupimm_pd(a, k, b, c, imm8);
+      #endif
+    }
+    else {
+      r = simde_mm512_mask_fixupimm_pd(a, k, b, c, imm8);
+    }
+
+    return r;
+  }
 #endif
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
   #undef _mm512_mask_fixupimm_round_pd
   #define _mm512_mask_fixupimm_round_pd(a, k, b, c, imm8, sae) simde_mm512_mask_fixupimm_round_pd(a, k, b, c, imm8, sae)
 #endif
 
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m512d
-simde_mm512_maskz_fixupimm_round_pd (simde__mmask8 k, simde__m512d a, simde__m512d b, simde__m512i c, int imm8, int sae)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
-    SIMDE_REQUIRE_CONSTANT(sae) {
-  simde__m512d r;
-
-  if (sae & SIMDE_MM_FROUND_NO_EXC) {
-    #if defined(SIMDE_HAVE_FENV_H)
-      fenv_t envp;
-      int x = feholdexcept(&envp);
-      r = simde_mm512_maskz_fixupimm_pd(k, a, b, c, imm8);
-      if (HEDLEY_LIKELY(x == 0))
-        fesetenv(&envp);
-    #else
-      r = simde_mm512_maskz_fixupimm_pd(k, a, b, c, imm8);
-    #endif
-  }
-  else {
-    r = simde_mm512_maskz_fixupimm_pd(k, a, b, c, imm8);
-  }
-
-  return r;
-}
 #if defined(SIMDE_X86_AVX512F_NATIVE)
   #define simde_mm512_maskz_fixupimm_round_pd(k, a, b, c, imm8, sae) _mm512_maskz_fixupimm_round_pd(k, a, b, c, imm8, sae)
 #elif defined(SIMDE_FAST_EXCEPTIONS)
@@ -333,36 +314,37 @@ simde_mm512_maskz_fixupimm_round_pd (simde__mmask8 k, simde__m512d a, simde__m51
   #else
     #define simde_mm512_maskz_fixupimm_round_pd(k, a, b, c, imm8, sae) simde_mm512_maskz_fixupimm_pd(k, a, b, c, imm8)
   #endif
+#else
+  SIMDE_FUNCTION_ATTRIBUTES
+  simde__m512d
+  simde_mm512_maskz_fixupimm_round_pd (simde__mmask8 k, simde__m512d a, simde__m512d b, simde__m512i c, int imm8, int sae)
+      SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+      SIMDE_REQUIRE_CONSTANT(sae) {
+    simde__m512d r;
+
+    if (sae & SIMDE_MM_FROUND_NO_EXC) {
+      #if defined(SIMDE_HAVE_FENV_H)
+        fenv_t envp;
+        int x = feholdexcept(&envp);
+        r = simde_mm512_maskz_fixupimm_pd(k, a, b, c, imm8);
+        if (HEDLEY_LIKELY(x == 0))
+          fesetenv(&envp);
+      #else
+        r = simde_mm512_maskz_fixupimm_pd(k, a, b, c, imm8);
+      #endif
+    }
+    else {
+      r = simde_mm512_maskz_fixupimm_pd(k, a, b, c, imm8);
+    }
+
+    return r;
+  }
 #endif
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
   #undef _mm512_maskz_fixupimm_round_pd
   #define _mm512_maskz_fixupimm_round_pd(k, a, b, c, imm8, sae) simde_mm512_maskz_fixupimm_round_pd(k, a, b, c, imm8, sae)
 #endif
 
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128
-simde_mm_fixupimm_round_ss (simde__m128 a, simde__m128 b, simde__m128i c, int imm8, int sae)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 15)
-    SIMDE_REQUIRE_CONSTANT(sae) {
-  simde__m128 r;
-
-  if (sae & SIMDE_MM_FROUND_NO_EXC) {
-    #if defined(SIMDE_HAVE_FENV_H)
-      fenv_t envp;
-      int x = feholdexcept(&envp);
-      r = simde_mm_fixupimm_ss(a, b, c, imm8);
-      if (HEDLEY_LIKELY(x == 0))
-        fesetenv(&envp);
-    #else
-      r = simde_mm_fixupimm_ss(a, b, c, imm8);
-    #endif
-  }
-  else {
-    r = simde_mm_fixupimm_ss(a, b, c, imm8);
-  }
-
-  return r;
-}
 #if defined(SIMDE_X86_AVX512F_NATIVE)
   #define simde_mm_fixupimm_round_ss(a, b, c, imm8, sae) _mm_fixupimm_round_ss(a, b, c, imm8, sae)
 #elif defined(SIMDE_FAST_EXCEPTIONS)
@@ -388,36 +370,37 @@ simde_mm_fixupimm_round_ss (simde__m128 a, simde__m128 b, simde__m128i c, int im
   #else
     #define simde_mm_fixupimm_round_ss(a, b, c, imm8, sae) simde_mm_fixupimm_ss(a, b, c, imm8)
   #endif
+#else
+  SIMDE_FUNCTION_ATTRIBUTES
+  simde__m128
+  simde_mm_fixupimm_round_ss (simde__m128 a, simde__m128 b, simde__m128i c, int imm8, int sae)
+      SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 15)
+      SIMDE_REQUIRE_CONSTANT(sae) {
+    simde__m128 r;
+
+    if (sae & SIMDE_MM_FROUND_NO_EXC) {
+      #if defined(SIMDE_HAVE_FENV_H)
+        fenv_t envp;
+        int x = feholdexcept(&envp);
+        r = simde_mm_fixupimm_ss(a, b, c, imm8);
+        if (HEDLEY_LIKELY(x == 0))
+          fesetenv(&envp);
+      #else
+        r = simde_mm_fixupimm_ss(a, b, c, imm8);
+      #endif
+    }
+    else {
+      r = simde_mm_fixupimm_ss(a, b, c, imm8);
+    }
+
+    return r;
+  }
 #endif
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
   #undef _mm_fixupimm_round_ss
   #define _mm_fixupimm_round_ss(a, b, c, imm8, sae) simde_mm_fixupimm_round_ss(a, b, c, imm8, sae)
 #endif
 
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128
-simde_mm_mask_fixupimm_round_ss (simde__m128 a, simde__mmask8 k, simde__m128 b, simde__m128i c, int imm8, int sae)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 15)
-    SIMDE_REQUIRE_CONSTANT(sae) {
-  simde__m128 r;
-
-  if (sae & SIMDE_MM_FROUND_NO_EXC) {
-    #if defined(SIMDE_HAVE_FENV_H)
-      fenv_t envp;
-      int x = feholdexcept(&envp);
-      r = simde_mm_mask_fixupimm_ss(a, k, b, c, imm8);
-      if (HEDLEY_LIKELY(x == 0))
-        fesetenv(&envp);
-    #else
-      r = simde_mm_mask_fixupimm_ss(a, k, b, c, imm8);
-    #endif
-  }
-  else {
-    r = simde_mm_mask_fixupimm_ss(a, k, b, c, imm8);
-  }
-
-  return r;
-}
 #if defined(SIMDE_X86_AVX512F_NATIVE)
   #define simde_mm_mask_fixupimm_round_ss(a, k, b, c, imm8, sae) _mm_mask_fixupimm_round_ss(a, k, b, c, imm8, sae)
 #elif defined(SIMDE_FAST_EXCEPTIONS)
@@ -443,36 +426,37 @@ simde_mm_mask_fixupimm_round_ss (simde__m128 a, simde__mmask8 k, simde__m128 b, 
   #else
     #define simde_mm_mask_fixupimm_round_ss(a, k, b, c, imm8, sae) simde_mm_mask_fixupimm_ss(a, k, b, c, imm8)
   #endif
+#else
+  SIMDE_FUNCTION_ATTRIBUTES
+  simde__m128
+  simde_mm_mask_fixupimm_round_ss (simde__m128 a, simde__mmask8 k, simde__m128 b, simde__m128i c, int imm8, int sae)
+      SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 15)
+      SIMDE_REQUIRE_CONSTANT(sae) {
+    simde__m128 r;
+
+    if (sae & SIMDE_MM_FROUND_NO_EXC) {
+      #if defined(SIMDE_HAVE_FENV_H)
+        fenv_t envp;
+        int x = feholdexcept(&envp);
+        r = simde_mm_mask_fixupimm_ss(a, k, b, c, imm8);
+        if (HEDLEY_LIKELY(x == 0))
+          fesetenv(&envp);
+      #else
+        r = simde_mm_mask_fixupimm_ss(a, k, b, c, imm8);
+      #endif
+    }
+    else {
+      r = simde_mm_mask_fixupimm_ss(a, k, b, c, imm8);
+    }
+
+    return r;
+  }
 #endif
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
   #undef _mm_mask_fixupimm_round_ss
   #define _mm_mask_fixupimm_round_ss(a, k, b, c, imm8, sae) simde_mm_mask_fixupimm_round_ss(a, k, b, c, imm8, sae)
 #endif
 
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128
-simde_mm_maskz_fixupimm_round_ss (simde__mmask8 k, simde__m128 a, simde__m128 b, simde__m128i c, int imm8, int sae)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 15)
-    SIMDE_REQUIRE_CONSTANT(sae) {
-  simde__m128 r;
-
-  if (sae & SIMDE_MM_FROUND_NO_EXC) {
-    #if defined(SIMDE_HAVE_FENV_H)
-      fenv_t envp;
-      int x = feholdexcept(&envp);
-      r = simde_mm_maskz_fixupimm_ss(k, a, b, c, imm8);
-      if (HEDLEY_LIKELY(x == 0))
-        fesetenv(&envp);
-    #else
-      r = simde_mm_maskz_fixupimm_ss(k, a, b, c, imm8);
-    #endif
-  }
-  else {
-    r = simde_mm_maskz_fixupimm_ss(k, a, b, c, imm8);
-  }
-
-  return r;
-}
 #if defined(SIMDE_X86_AVX512F_NATIVE)
   #define simde_mm_maskz_fixupimm_round_ss(k, a, b, c, imm8, sae) _mm_maskz_fixupimm_round_ss(k, a, b, c, imm8, sae)
 #elif defined(SIMDE_FAST_EXCEPTIONS)
@@ -498,36 +482,37 @@ simde_mm_maskz_fixupimm_round_ss (simde__mmask8 k, simde__m128 a, simde__m128 b,
   #else
     #define simde_mm_maskz_fixupimm_round_ss(k, a, b, c, imm8, sae) simde_mm_maskz_fixupimm_ss(k, a, b, c, imm8)
   #endif
+#else
+  SIMDE_FUNCTION_ATTRIBUTES
+  simde__m128
+  simde_mm_maskz_fixupimm_round_ss (simde__mmask8 k, simde__m128 a, simde__m128 b, simde__m128i c, int imm8, int sae)
+      SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 15)
+      SIMDE_REQUIRE_CONSTANT(sae) {
+    simde__m128 r;
+
+    if (sae & SIMDE_MM_FROUND_NO_EXC) {
+      #if defined(SIMDE_HAVE_FENV_H)
+        fenv_t envp;
+        int x = feholdexcept(&envp);
+        r = simde_mm_maskz_fixupimm_ss(k, a, b, c, imm8);
+        if (HEDLEY_LIKELY(x == 0))
+          fesetenv(&envp);
+      #else
+        r = simde_mm_maskz_fixupimm_ss(k, a, b, c, imm8);
+      #endif
+    }
+    else {
+      r = simde_mm_maskz_fixupimm_ss(k, a, b, c, imm8);
+    }
+
+    return r;
+  }
 #endif
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
   #undef _mm_maskz_fixupimm_round_ss
   #define _mm_maskz_fixupimm_round_ss(k, a, b, c, imm8, sae) simde_mm_maskz_fixupimm_round_ss(k, a, b, c, imm8, sae)
 #endif
 
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_fixupimm_round_sd (simde__m128d a, simde__m128d b, simde__m128i c, int imm8, int sae)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 15)
-    SIMDE_REQUIRE_CONSTANT(sae) {
-  simde__m128d r;
-
-  if (sae & SIMDE_MM_FROUND_NO_EXC) {
-    #if defined(SIMDE_HAVE_FENV_H)
-      fenv_t envp;
-      int x = feholdexcept(&envp);
-      r = simde_mm_fixupimm_sd(a, b, c, imm8);
-      if (HEDLEY_LIKELY(x == 0))
-        fesetenv(&envp);
-    #else
-      r = simde_mm_fixupimm_sd(a, b, c, imm8);
-    #endif
-  }
-  else {
-    r = simde_mm_fixupimm_sd(a, b, c, imm8);
-  }
-
-  return r;
-}
 #if defined(SIMDE_X86_AVX512F_NATIVE)
   #define simde_mm_fixupimm_round_sd(a, b, c, imm8, sae) _mm_fixupimm_round_sd(a, b, c, imm8, sae)
 #elif defined(SIMDE_FAST_EXCEPTIONS)
@@ -553,36 +538,37 @@ simde_mm_fixupimm_round_sd (simde__m128d a, simde__m128d b, simde__m128i c, int 
   #else
     #define simde_mm_fixupimm_round_sd(a, b, c, imm8, sae) simde_mm_fixupimm_sd(a, b, c, imm8)
   #endif
+#else
+  SIMDE_FUNCTION_ATTRIBUTES
+  simde__m128d
+  simde_mm_fixupimm_round_sd (simde__m128d a, simde__m128d b, simde__m128i c, int imm8, int sae)
+      SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 15)
+      SIMDE_REQUIRE_CONSTANT(sae) {
+    simde__m128d r;
+
+    if (sae & SIMDE_MM_FROUND_NO_EXC) {
+      #if defined(SIMDE_HAVE_FENV_H)
+        fenv_t envp;
+        int x = feholdexcept(&envp);
+        r = simde_mm_fixupimm_sd(a, b, c, imm8);
+        if (HEDLEY_LIKELY(x == 0))
+          fesetenv(&envp);
+      #else
+        r = simde_mm_fixupimm_sd(a, b, c, imm8);
+      #endif
+    }
+    else {
+      r = simde_mm_fixupimm_sd(a, b, c, imm8);
+    }
+
+    return r;
+  }
 #endif
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
   #undef _mm_fixupimm_round_sd
   #define _mm_fixupimm_round_sd(a, b, c, imm8, sae) simde_mm_fixupimm_round_sd(a, b, c, imm8, sae)
 #endif
 
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_mask_fixupimm_round_sd (simde__m128d a, simde__mmask8 k, simde__m128d b, simde__m128i c, int imm8, int sae)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 15)
-    SIMDE_REQUIRE_CONSTANT(sae) {
-  simde__m128d r;
-
-  if (sae & SIMDE_MM_FROUND_NO_EXC) {
-    #if defined(SIMDE_HAVE_FENV_H)
-      fenv_t envp;
-      int x = feholdexcept(&envp);
-      r = simde_mm_mask_fixupimm_sd(a, k, b, c, imm8);
-      if (HEDLEY_LIKELY(x == 0))
-        fesetenv(&envp);
-    #else
-      r = simde_mm_mask_fixupimm_sd(a, k, b, c, imm8);
-    #endif
-  }
-  else {
-    r = simde_mm_mask_fixupimm_sd(a, k, b, c, imm8);
-  }
-
-  return r;
-}
 #if defined(SIMDE_X86_AVX512F_NATIVE)
   #define simde_mm_mask_fixupimm_round_sd(a, k, b, c, imm8, sae) _mm_mask_fixupimm_round_sd(a, k, b, c, imm8, sae)
 #elif defined(SIMDE_FAST_EXCEPTIONS)
@@ -608,36 +594,37 @@ simde_mm_mask_fixupimm_round_sd (simde__m128d a, simde__mmask8 k, simde__m128d b
   #else
     #define simde_mm_mask_fixupimm_round_sd(a, k, b, c, imm8, sae) simde_mm_mask_fixupimm_sd(a, k, b, c, imm8)
   #endif
+#else
+  SIMDE_FUNCTION_ATTRIBUTES
+  simde__m128d
+  simde_mm_mask_fixupimm_round_sd (simde__m128d a, simde__mmask8 k, simde__m128d b, simde__m128i c, int imm8, int sae)
+      SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 15)
+      SIMDE_REQUIRE_CONSTANT(sae) {
+    simde__m128d r;
+
+    if (sae & SIMDE_MM_FROUND_NO_EXC) {
+      #if defined(SIMDE_HAVE_FENV_H)
+        fenv_t envp;
+        int x = feholdexcept(&envp);
+        r = simde_mm_mask_fixupimm_sd(a, k, b, c, imm8);
+        if (HEDLEY_LIKELY(x == 0))
+          fesetenv(&envp);
+      #else
+        r = simde_mm_mask_fixupimm_sd(a, k, b, c, imm8);
+      #endif
+    }
+    else {
+      r = simde_mm_mask_fixupimm_sd(a, k, b, c, imm8);
+    }
+
+    return r;
+  }
 #endif
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
   #undef _mm_mask_fixupimm_round_sd
   #define _mm_mask_fixupimm_round_sd(a, k, b, c, imm8, sae) simde_mm_mask_fixupimm_round_sd(a, k, b, c, imm8, sae)
 #endif
 
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_maskz_fixupimm_round_sd (simde__mmask8 k, simde__m128d a, simde__m128d b, simde__m128i c, int imm8, int sae)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 15)
-    SIMDE_REQUIRE_CONSTANT(sae) {
-  simde__m128d r;
-
-  if (sae & SIMDE_MM_FROUND_NO_EXC) {
-    #if defined(SIMDE_HAVE_FENV_H)
-      fenv_t envp;
-      int x = feholdexcept(&envp);
-      r = simde_mm_maskz_fixupimm_sd(k, a, b, c, imm8);
-      if (HEDLEY_LIKELY(x == 0))
-        fesetenv(&envp);
-    #else
-      r = simde_mm_maskz_fixupimm_sd(k, a, b, c, imm8);
-    #endif
-  }
-  else {
-    r = simde_mm_maskz_fixupimm_sd(k, a, b, c, imm8);
-  }
-
-  return r;
-}
 #if defined(SIMDE_X86_AVX512F_NATIVE)
   #define simde_mm_maskz_fixupimm_round_sd(k, a, b, c, imm8, sae) _mm_maskz_fixupimm_round_sd(k, a, b, c, imm8, sae)
 #elif defined(SIMDE_FAST_EXCEPTIONS)
@@ -663,6 +650,31 @@ simde_mm_maskz_fixupimm_round_sd (simde__mmask8 k, simde__m128d a, simde__m128d 
   #else
     #define simde_mm_maskz_fixupimm_round_sd(k, a, b, c, imm8, sae) simde_mm_maskz_fixupimm_sd(k, a, b, c, imm8)
   #endif
+#else
+  SIMDE_FUNCTION_ATTRIBUTES
+  simde__m128d
+  simde_mm_maskz_fixupimm_round_sd (simde__mmask8 k, simde__m128d a, simde__m128d b, simde__m128i c, int imm8, int sae)
+      SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 15)
+      SIMDE_REQUIRE_CONSTANT(sae) {
+    simde__m128d r;
+
+    if (sae & SIMDE_MM_FROUND_NO_EXC) {
+      #if defined(SIMDE_HAVE_FENV_H)
+        fenv_t envp;
+        int x = feholdexcept(&envp);
+        r = simde_mm_maskz_fixupimm_sd(k, a, b, c, imm8);
+        if (HEDLEY_LIKELY(x == 0))
+          fesetenv(&envp);
+      #else
+        r = simde_mm_maskz_fixupimm_sd(k, a, b, c, imm8);
+      #endif
+    }
+    else {
+      r = simde_mm_maskz_fixupimm_sd(k, a, b, c, imm8);
+    }
+
+    return r;
+  }
 #endif
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
   #undef _mm_maskz_fixupimm_round_sd

--- a/simde/x86/avx512/fixupimm_round.h
+++ b/simde/x86/avx512/fixupimm_round.h
@@ -1,0 +1,675 @@
+#if !defined(SIMDE_X86_AVX512_FIXUPIMM_ROUND_H)
+#define SIMDE_X86_AVX512_FIXUPIMM_ROUND_H
+
+#include "types.h"
+#include "fixupimm.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_fixupimm_round_ps (simde__m512 a, simde__m512 b, simde__m512i c, int imm8, int sae)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+    SIMDE_REQUIRE_CONSTANT(sae) {
+  simde__m512 r;
+
+  if (sae & SIMDE_MM_FROUND_NO_EXC) {
+    #if defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = simde_mm512_fixupimm_ps(a, b, c, imm8);
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = simde_mm512_fixupimm_ps(a, b, c, imm8);
+    #endif
+  }
+  else {
+    r = simde_mm512_fixupimm_ps(a, b, c, imm8);
+  }
+
+  return r;
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_fixupimm_round_ps(a, b, c, imm8, sae) _mm512_fixupimm_round_ps(a, b, c, imm8, sae)
+#elif defined(SIMDE_FAST_EXCEPTIONS)
+  #define simde_mm512_fixupimm_round_ps(a, b, c, imm8, sae) simde_mm512_fixupimm_ps(a, b, c, imm8)
+#elif defined(SIMDE_STATEMENT_EXPR_)
+  #if defined(SIMDE_HAVE_FENV_H)
+    #define simde_mm512_fixupimm_round_ps(a, b, c, imm8, sae) SIMDE_STATEMENT_EXPR_(({ \
+      simde__m512 simde_mm512_fixupimm_round_ps_r; \
+      \
+      if (sae & SIMDE_MM_FROUND_NO_EXC) { \
+        fenv_t simde_mm512_fixupimm_round_ps_envp; \
+        int simde_mm512_fixupimm_round_ps_x = feholdexcept(&simde_mm512_fixupimm_round_ps_envp); \
+        simde_mm512_fixupimm_round_ps_r = simde_mm512_fixupimm_ps(a, b, c, imm8); \
+        if (HEDLEY_LIKELY(simde_mm512_fixupimm_round_ps_x == 0)) \
+          fesetenv(&simde_mm512_fixupimm_round_ps_envp); \
+      } \
+      else { \
+        simde_mm512_fixupimm_round_ps_r = simde_mm512_fixupimm_ps(a, b, c, imm8); \
+      } \
+      \
+      simde_mm512_fixupimm_round_ps_r; \
+    }))
+  #else
+    #define simde_mm512_fixupimm_round_ps(a, b, c, imm8, sae) simde_mm512_fixupimm_ps(a, b, c, imm8)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_fixupimm_round_ps
+  #define _mm512_fixupimm_round_ps(a, b, c, imm8, sae) simde_mm512_fixupimm_round_ps(a, b, c, imm8, sae)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_fixupimm_round_ps (simde__m512 a, simde__mmask16 k, simde__m512 b, simde__m512i c, int imm8, int sae)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+    SIMDE_REQUIRE_CONSTANT(sae) {
+  simde__m512 r;
+
+  if (sae & SIMDE_MM_FROUND_NO_EXC) {
+    #if defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = simde_mm512_mask_fixupimm_ps(a, k, b, c, imm8);
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = simde_mm512_mask_fixupimm_ps(a, k, b, c, imm8);
+    #endif
+  }
+  else {
+    r = simde_mm512_mask_fixupimm_ps(a, k, b, c, imm8);
+  }
+
+  return r;
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_mask_fixupimm_round_ps(a, k, b, c, imm8, sae) _mm512_mask_fixupimm_round_ps(a, k, b, c, imm8, sae)
+#elif defined(SIMDE_FAST_EXCEPTIONS)
+  #define simde_mm512_mask_fixupimm_round_ps(a, k, b, c, imm8, sae) simde_mm512_mask_fixupimm_ps(a, k, b, c, imm8)
+#elif defined(SIMDE_STATEMENT_EXPR_)
+  #if defined(SIMDE_HAVE_FENV_H)
+    #define simde_mm512_mask_fixupimm_round_ps(a, k, b, c, imm8, sae) SIMDE_STATEMENT_EXPR_(({ \
+      simde__m512 simde_mm512_mask_fixupimm_round_ps_r; \
+      \
+      if (sae & SIMDE_MM_FROUND_NO_EXC) { \
+        fenv_t simde_mm512_mask_fixupimm_round_ps_envp; \
+        int simde_mm512_mask_fixupimm_round_ps_x = feholdexcept(&simde_mm512_mask_fixupimm_round_ps_envp); \
+        simde_mm512_mask_fixupimm_round_ps_r = simde_mm512_mask_fixupimm_ps(a, k, b, c, imm8); \
+        if (HEDLEY_LIKELY(simde_mm512_mask_fixupimm_round_ps_x == 0)) \
+          fesetenv(&simde_mm512_mask_fixupimm_round_ps_envp); \
+      } \
+      else { \
+        simde_mm512_mask_fixupimm_round_ps_r = simde_mm512_mask_fixupimm_ps(a, k, b, c, imm8); \
+      } \
+      \
+      simde_mm512_mask_fixupimm_round_ps_r; \
+    }))
+  #else
+    #define simde_mm512_mask_fixupimm_round_ps(a, k, b, c, imm8, sae) simde_mm512_mask_fixupimm_ps(a, k, b, c, imm8)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_fixupimm_round_ps
+  #define _mm512_mask_fixupimm_round_ps(a, k, b, c, imm8, sae) simde_mm512_mask_fixupimm_round_ps(a, k, b, c, imm8, sae)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_maskz_fixupimm_round_ps (simde__mmask16 k, simde__m512 a, simde__m512 b, simde__m512i c, int imm8, int sae)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+    SIMDE_REQUIRE_CONSTANT(sae) {
+  simde__m512 r;
+
+  if (sae & SIMDE_MM_FROUND_NO_EXC) {
+    #if defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = simde_mm512_maskz_fixupimm_ps(k, a, b, c, imm8);
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = simde_mm512_maskz_fixupimm_ps(k, a, b, c, imm8);
+    #endif
+  }
+  else {
+    r = simde_mm512_maskz_fixupimm_ps(k, a, b, c, imm8);
+  }
+
+  return r;
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_maskz_fixupimm_round_ps(k, a, b, c, imm8, sae) _mm512_maskz_fixupimm_round_ps(k, a, b, c, imm8, sae)
+#elif defined(SIMDE_FAST_EXCEPTIONS)
+  #define simde_mm512_maskz_fixupimm_round_ps(k, a, b, c, imm8, sae) simde_mm512_maskz_fixupimm_ps(k, a, b, c, imm8)
+#elif defined(SIMDE_STATEMENT_EXPR_)
+  #if defined(SIMDE_HAVE_FENV_H)
+    #define simde_mm512_maskz_fixupimm_round_ps(k, a, b, c, imm8, sae) SIMDE_STATEMENT_EXPR_(({ \
+      simde__m512 simde_mm512_maskz_fixupimm_round_ps_r; \
+      \
+      if (sae & SIMDE_MM_FROUND_NO_EXC) { \
+        fenv_t simde_mm512_maskz_fixupimm_round_ps_envp; \
+        int simde_mm512_maskz_fixupimm_round_ps_x = feholdexcept(&simde_mm512_maskz_fixupimm_round_ps_envp); \
+        simde_mm512_maskz_fixupimm_round_ps_r = simde_mm512_maskz_fixupimm_ps(k, a, b, c, imm8); \
+        if (HEDLEY_LIKELY(simde_mm512_maskz_fixupimm_round_ps_x == 0)) \
+          fesetenv(&simde_mm512_maskz_fixupimm_round_ps_envp); \
+      } \
+      else { \
+        simde_mm512_maskz_fixupimm_round_ps_r = simde_mm512_maskz_fixupimm_ps(k, a, b, c, imm8); \
+      } \
+      \
+      simde_mm512_maskz_fixupimm_round_ps_r; \
+    }))
+  #else
+    #define simde_mm512_maskz_fixupimm_round_ps(k, a, b, c, imm8, sae) simde_mm512_maskz_fixupimm_ps(k, a, b, c, imm8)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_fixupimm_round_ps
+  #define _mm512_maskz_fixupimm_round_ps(k, a, b, c, imm8, sae) simde_mm512_maskz_fixupimm_round_ps(k, a, b, c, imm8, sae)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_fixupimm_round_pd (simde__m512d a, simde__m512d b, simde__m512i c, int imm8, int sae)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+    SIMDE_REQUIRE_CONSTANT(sae) {
+  simde__m512d r;
+
+  if (sae & SIMDE_MM_FROUND_NO_EXC) {
+    #if defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = simde_mm512_fixupimm_pd(a, b, c, imm8);
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = simde_mm512_fixupimm_pd(a, b, c, imm8);
+    #endif
+  }
+  else {
+    r = simde_mm512_fixupimm_pd(a, b, c, imm8);
+  }
+
+  return r;
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_fixupimm_round_pd(a, b, c, imm8, sae) _mm512_fixupimm_round_pd(a, b, c, imm8, sae)
+#elif defined(SIMDE_FAST_EXCEPTIONS)
+  #define simde_mm512_fixupimm_round_pd(a, b, c, imm8, sae) simde_mm512_fixupimm_pd(a, b, c, imm8)
+#elif defined(SIMDE_STATEMENT_EXPR_)
+  #if defined(SIMDE_HAVE_FENV_H)
+    #define simde_mm512_fixupimm_round_pd(a, b, c, imm8, sae) SIMDE_STATEMENT_EXPR_(({ \
+      simde__m512d simde_mm512_fixupimm_round_pd_r; \
+      \
+      if (sae & SIMDE_MM_FROUND_NO_EXC) { \
+        fenv_t simde_mm512_fixupimm_round_pd_envp; \
+        int simde_mm512_fixupimm_round_pd_x = feholdexcept(&simde_mm512_fixupimm_round_pd_envp); \
+        simde_mm512_fixupimm_round_pd_r = simde_mm512_fixupimm_pd(a, b, c, imm8); \
+        if (HEDLEY_LIKELY(simde_mm512_fixupimm_round_pd_x == 0)) \
+          fesetenv(&simde_mm512_fixupimm_round_pd_envp); \
+      } \
+      else { \
+        simde_mm512_fixupimm_round_pd_r = simde_mm512_fixupimm_pd(a, b, c, imm8); \
+      } \
+      \
+      simde_mm512_fixupimm_round_pd_r; \
+    }))
+  #else
+    #define simde_mm512_fixupimm_round_pd(a, b, c, imm8, sae) simde_mm512_fixupimm_pd(a, b, c, imm8)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_fixupimm_round_pd
+  #define _mm512_fixupimm_round_pd(a, b, c, imm8, sae) simde_mm512_fixupimm_round_pd(a, b, c, imm8, sae)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_fixupimm_round_pd (simde__m512d a, simde__mmask8 k, simde__m512d b, simde__m512i c, int imm8, int sae)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+    SIMDE_REQUIRE_CONSTANT(sae) {
+  simde__m512d r;
+
+  if (sae & SIMDE_MM_FROUND_NO_EXC) {
+    #if defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = simde_mm512_mask_fixupimm_pd(a, k, b, c, imm8);
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = simde_mm512_mask_fixupimm_pd(a, k, b, c, imm8);
+    #endif
+  }
+  else {
+    r = simde_mm512_mask_fixupimm_pd(a, k, b, c, imm8);
+  }
+
+  return r;
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_mask_fixupimm_round_pd(a, k, b, c, imm8, sae) _mm512_mask_fixupimm_round_pd(a, k, b, c, imm8, sae)
+#elif defined(SIMDE_FAST_EXCEPTIONS)
+  #define simde_mm512_mask_fixupimm_round_pd(a, k, b, c, imm8, sae) simde_mm512_mask_fixupimm_pd(a, k, b, c, imm8)
+#elif defined(SIMDE_STATEMENT_EXPR_)
+  #if defined(SIMDE_HAVE_FENV_H)
+    #define simde_mm512_mask_fixupimm_round_pd(a, k, b, c, imm8, sae) SIMDE_STATEMENT_EXPR_(({ \
+      simde__m512d simde_mm512_mask_fixupimm_round_pd_r; \
+      \
+      if (sae & SIMDE_MM_FROUND_NO_EXC) { \
+        fenv_t simde_mm512_mask_fixupimm_round_pd_envp; \
+        int simde_mm512_mask_fixupimm_round_pd_x = feholdexcept(&simde_mm512_mask_fixupimm_round_pd_envp); \
+        simde_mm512_mask_fixupimm_round_pd_r = simde_mm512_mask_fixupimm_pd(a, k, b, c, imm8); \
+        if (HEDLEY_LIKELY(simde_mm512_mask_fixupimm_round_pd_x == 0)) \
+          fesetenv(&simde_mm512_mask_fixupimm_round_pd_envp); \
+      } \
+      else { \
+        simde_mm512_mask_fixupimm_round_pd_r = simde_mm512_mask_fixupimm_pd(a, k, b, c, imm8); \
+      } \
+      \
+      simde_mm512_mask_fixupimm_round_pd_r; \
+    }))
+  #else
+    #define simde_mm512_mask_fixupimm_round_pd(a, k, b, c, imm8, sae) simde_mm512_mask_fixupimm_pd(a, k, b, c, imm8)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_fixupimm_round_pd
+  #define _mm512_mask_fixupimm_round_pd(a, k, b, c, imm8, sae) simde_mm512_mask_fixupimm_round_pd(a, k, b, c, imm8, sae)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_maskz_fixupimm_round_pd (simde__mmask8 k, simde__m512d a, simde__m512d b, simde__m512i c, int imm8, int sae)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+    SIMDE_REQUIRE_CONSTANT(sae) {
+  simde__m512d r;
+
+  if (sae & SIMDE_MM_FROUND_NO_EXC) {
+    #if defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = simde_mm512_maskz_fixupimm_pd(k, a, b, c, imm8);
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = simde_mm512_maskz_fixupimm_pd(k, a, b, c, imm8);
+    #endif
+  }
+  else {
+    r = simde_mm512_maskz_fixupimm_pd(k, a, b, c, imm8);
+  }
+
+  return r;
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_maskz_fixupimm_round_pd(k, a, b, c, imm8, sae) _mm512_maskz_fixupimm_round_pd(k, a, b, c, imm8, sae)
+#elif defined(SIMDE_FAST_EXCEPTIONS)
+  #define simde_mm512_maskz_fixupimm_round_pd(k, a, b, c, imm8, sae) simde_mm512_maskz_fixupimm_pd(k, a, b, c, imm8)
+#elif defined(SIMDE_STATEMENT_EXPR_)
+  #if defined(SIMDE_HAVE_FENV_H)
+    #define simde_mm512_maskz_fixupimm_round_pd(k, a, b, c, imm8, sae) SIMDE_STATEMENT_EXPR_(({ \
+      simde__m512d simde_mm512_maskz_fixupimm_round_pd_r; \
+      \
+      if (sae & SIMDE_MM_FROUND_NO_EXC) { \
+        fenv_t simde_mm512_maskz_fixupimm_round_pd_envp; \
+        int simde_mm512_maskz_fixupimm_round_pd_x = feholdexcept(&simde_mm512_maskz_fixupimm_round_pd_envp); \
+        simde_mm512_maskz_fixupimm_round_pd_r = simde_mm512_maskz_fixupimm_pd(k, a, b, c, imm8); \
+        if (HEDLEY_LIKELY(simde_mm512_maskz_fixupimm_round_pd_x == 0)) \
+          fesetenv(&simde_mm512_maskz_fixupimm_round_pd_envp); \
+      } \
+      else { \
+        simde_mm512_maskz_fixupimm_round_pd_r = simde_mm512_maskz_fixupimm_pd(k, a, b, c, imm8); \
+      } \
+      \
+      simde_mm512_maskz_fixupimm_round_pd_r; \
+    }))
+  #else
+    #define simde_mm512_maskz_fixupimm_round_pd(k, a, b, c, imm8, sae) simde_mm512_maskz_fixupimm_pd(k, a, b, c, imm8)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_fixupimm_round_pd
+  #define _mm512_maskz_fixupimm_round_pd(k, a, b, c, imm8, sae) simde_mm512_maskz_fixupimm_round_pd(k, a, b, c, imm8, sae)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_fixupimm_round_ss (simde__m128 a, simde__m128 b, simde__m128i c, int imm8, int sae)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 15)
+    SIMDE_REQUIRE_CONSTANT(sae) {
+  simde__m128 r;
+
+  if (sae & SIMDE_MM_FROUND_NO_EXC) {
+    #if defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = simde_mm_fixupimm_ss(a, b, c, imm8);
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = simde_mm_fixupimm_ss(a, b, c, imm8);
+    #endif
+  }
+  else {
+    r = simde_mm_fixupimm_ss(a, b, c, imm8);
+  }
+
+  return r;
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm_fixupimm_round_ss(a, b, c, imm8, sae) _mm_fixupimm_round_ss(a, b, c, imm8, sae)
+#elif defined(SIMDE_FAST_EXCEPTIONS)
+  #define simde_mm_fixupimm_round_ss(a, b, c, imm8, sae) simde_mm_fixupimm_ss(a, b, c, imm8)
+#elif defined(SIMDE_STATEMENT_EXPR_)
+  #if defined(SIMDE_HAVE_FENV_H)
+    #define simde_mm_fixupimm_round_ss(a, b, c, imm8, sae) SIMDE_STATEMENT_EXPR_(({ \
+      simde__m128 simde_mm_fixupimm_round_ss_r; \
+      \
+      if (sae & SIMDE_MM_FROUND_NO_EXC) { \
+        fenv_t simde_mm_fixupimm_round_ss_envp; \
+        int simde_mm_fixupimm_round_ss_x = feholdexcept(&simde_mm_fixupimm_round_ss_envp); \
+        simde_mm_fixupimm_round_ss_r = simde_mm_fixupimm_ss(a, b, c, imm8); \
+        if (HEDLEY_LIKELY(simde_mm_fixupimm_round_ss_x == 0)) \
+          fesetenv(&simde_mm_fixupimm_round_ss_envp); \
+      } \
+      else { \
+        simde_mm_fixupimm_round_ss_r = simde_mm_fixupimm_ss(a, b, c, imm8); \
+      } \
+      \
+      simde_mm_fixupimm_round_ss_r; \
+    }))
+  #else
+    #define simde_mm_fixupimm_round_ss(a, b, c, imm8, sae) simde_mm_fixupimm_ss(a, b, c, imm8)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fixupimm_round_ss
+  #define _mm_fixupimm_round_ss(a, b, c, imm8, sae) simde_mm_fixupimm_round_ss(a, b, c, imm8, sae)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_mask_fixupimm_round_ss (simde__m128 a, simde__mmask8 k, simde__m128 b, simde__m128i c, int imm8, int sae)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 15)
+    SIMDE_REQUIRE_CONSTANT(sae) {
+  simde__m128 r;
+
+  if (sae & SIMDE_MM_FROUND_NO_EXC) {
+    #if defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = simde_mm_mask_fixupimm_ss(a, k, b, c, imm8);
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = simde_mm_mask_fixupimm_ss(a, k, b, c, imm8);
+    #endif
+  }
+  else {
+    r = simde_mm_mask_fixupimm_ss(a, k, b, c, imm8);
+  }
+
+  return r;
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm_mask_fixupimm_round_ss(a, k, b, c, imm8, sae) _mm_mask_fixupimm_round_ss(a, k, b, c, imm8, sae)
+#elif defined(SIMDE_FAST_EXCEPTIONS)
+  #define simde_mm_mask_fixupimm_round_ss(a, k, b, c, imm8, sae) simde_mm_mask_fixupimm_ss(a, k, b, c, imm8)
+#elif defined(SIMDE_STATEMENT_EXPR_)
+  #if defined(SIMDE_HAVE_FENV_H)
+    #define simde_mm_mask_fixupimm_round_ss(a, k, b, c, imm8, sae) SIMDE_STATEMENT_EXPR_(({ \
+      simde__m128 simde_mm_mask_fixupimm_round_ss_r; \
+      \
+      if (sae & SIMDE_MM_FROUND_NO_EXC) { \
+        fenv_t simde_mm_mask_fixupimm_round_ss_envp; \
+        int simde_mm_mask_fixupimm_round_ss_x = feholdexcept(&simde_mm_mask_fixupimm_round_ss_envp); \
+        simde_mm_mask_fixupimm_round_ss_r = simde_mm_mask_fixupimm_ss(a, k, b, c, imm8); \
+        if (HEDLEY_LIKELY(simde_mm_mask_fixupimm_round_ss_x == 0)) \
+          fesetenv(&simde_mm_mask_fixupimm_round_ss_envp); \
+      } \
+      else { \
+        simde_mm_mask_fixupimm_round_ss_r = simde_mm_mask_fixupimm_ss(a, k, b, c, imm8); \
+      } \
+      \
+      simde_mm_mask_fixupimm_round_ss_r; \
+    }))
+  #else
+    #define simde_mm_mask_fixupimm_round_ss(a, k, b, c, imm8, sae) simde_mm_mask_fixupimm_ss(a, k, b, c, imm8)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_fixupimm_round_ss
+  #define _mm_mask_fixupimm_round_ss(a, k, b, c, imm8, sae) simde_mm_mask_fixupimm_round_ss(a, k, b, c, imm8, sae)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_maskz_fixupimm_round_ss (simde__mmask8 k, simde__m128 a, simde__m128 b, simde__m128i c, int imm8, int sae)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 15)
+    SIMDE_REQUIRE_CONSTANT(sae) {
+  simde__m128 r;
+
+  if (sae & SIMDE_MM_FROUND_NO_EXC) {
+    #if defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = simde_mm_maskz_fixupimm_ss(k, a, b, c, imm8);
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = simde_mm_maskz_fixupimm_ss(k, a, b, c, imm8);
+    #endif
+  }
+  else {
+    r = simde_mm_maskz_fixupimm_ss(k, a, b, c, imm8);
+  }
+
+  return r;
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm_maskz_fixupimm_round_ss(k, a, b, c, imm8, sae) _mm_maskz_fixupimm_round_ss(k, a, b, c, imm8, sae)
+#elif defined(SIMDE_FAST_EXCEPTIONS)
+  #define simde_mm_maskz_fixupimm_round_ss(k, a, b, c, imm8, sae) simde_mm_maskz_fixupimm_ss(k, a, b, c, imm8)
+#elif defined(SIMDE_STATEMENT_EXPR_)
+  #if defined(SIMDE_HAVE_FENV_H)
+    #define simde_mm_maskz_fixupimm_round_ss(k, a, b, c, imm8, sae) SIMDE_STATEMENT_EXPR_(({ \
+      simde__m128 simde_mm_maskz_fixupimm_round_ss_r; \
+      \
+      if (sae & SIMDE_MM_FROUND_NO_EXC) { \
+        fenv_t simde_mm_maskz_fixupimm_round_ss_envp; \
+        int simde_mm_maskz_fixupimm_round_ss_x = feholdexcept(&simde_mm_maskz_fixupimm_round_ss_envp); \
+        simde_mm_maskz_fixupimm_round_ss_r = simde_mm_maskz_fixupimm_ss(k, a, b, c, imm8); \
+        if (HEDLEY_LIKELY(simde_mm_maskz_fixupimm_round_ss_x == 0)) \
+          fesetenv(&simde_mm_maskz_fixupimm_round_ss_envp); \
+      } \
+      else { \
+        simde_mm_maskz_fixupimm_round_ss_r = simde_mm_maskz_fixupimm_ss(k, a, b, c, imm8); \
+      } \
+      \
+      simde_mm_maskz_fixupimm_round_ss_r; \
+    }))
+  #else
+    #define simde_mm_maskz_fixupimm_round_ss(k, a, b, c, imm8, sae) simde_mm_maskz_fixupimm_ss(k, a, b, c, imm8)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_fixupimm_round_ss
+  #define _mm_maskz_fixupimm_round_ss(k, a, b, c, imm8, sae) simde_mm_maskz_fixupimm_round_ss(k, a, b, c, imm8, sae)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_fixupimm_round_sd (simde__m128d a, simde__m128d b, simde__m128i c, int imm8, int sae)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 15)
+    SIMDE_REQUIRE_CONSTANT(sae) {
+  simde__m128d r;
+
+  if (sae & SIMDE_MM_FROUND_NO_EXC) {
+    #if defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = simde_mm_fixupimm_sd(a, b, c, imm8);
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = simde_mm_fixupimm_sd(a, b, c, imm8);
+    #endif
+  }
+  else {
+    r = simde_mm_fixupimm_sd(a, b, c, imm8);
+  }
+
+  return r;
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm_fixupimm_round_sd(a, b, c, imm8, sae) _mm_fixupimm_round_sd(a, b, c, imm8, sae)
+#elif defined(SIMDE_FAST_EXCEPTIONS)
+  #define simde_mm_fixupimm_round_sd(a, b, c, imm8, sae) simde_mm_fixupimm_sd(a, b, c, imm8)
+#elif defined(SIMDE_STATEMENT_EXPR_)
+  #if defined(SIMDE_HAVE_FENV_H)
+    #define simde_mm_fixupimm_round_sd(a, b, c, imm8, sae) SIMDE_STATEMENT_EXPR_(({ \
+      simde__m128d simde_mm_fixupimm_round_sd_r; \
+      \
+      if (sae & SIMDE_MM_FROUND_NO_EXC) { \
+        fenv_t simde_mm_fixupimm_round_sd_envp; \
+        int simde_mm_fixupimm_round_sd_x = feholdexcept(&simde_mm_fixupimm_round_sd_envp); \
+        simde_mm_fixupimm_round_sd_r = simde_mm_fixupimm_sd(a, b, c, imm8); \
+        if (HEDLEY_LIKELY(simde_mm_fixupimm_round_sd_x == 0)) \
+          fesetenv(&simde_mm_fixupimm_round_sd_envp); \
+      } \
+      else { \
+        simde_mm_fixupimm_round_sd_r = simde_mm_fixupimm_sd(a, b, c, imm8); \
+      } \
+      \
+      simde_mm_fixupimm_round_sd_r; \
+    }))
+  #else
+    #define simde_mm_fixupimm_round_sd(a, b, c, imm8, sae) simde_mm_fixupimm_sd(a, b, c, imm8)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fixupimm_round_sd
+  #define _mm_fixupimm_round_sd(a, b, c, imm8, sae) simde_mm_fixupimm_round_sd(a, b, c, imm8, sae)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_mask_fixupimm_round_sd (simde__m128d a, simde__mmask8 k, simde__m128d b, simde__m128i c, int imm8, int sae)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 15)
+    SIMDE_REQUIRE_CONSTANT(sae) {
+  simde__m128d r;
+
+  if (sae & SIMDE_MM_FROUND_NO_EXC) {
+    #if defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = simde_mm_mask_fixupimm_sd(a, k, b, c, imm8);
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = simde_mm_mask_fixupimm_sd(a, k, b, c, imm8);
+    #endif
+  }
+  else {
+    r = simde_mm_mask_fixupimm_sd(a, k, b, c, imm8);
+  }
+
+  return r;
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm_mask_fixupimm_round_sd(a, k, b, c, imm8, sae) _mm_mask_fixupimm_round_sd(a, k, b, c, imm8, sae)
+#elif defined(SIMDE_FAST_EXCEPTIONS)
+  #define simde_mm_mask_fixupimm_round_sd(a, k, b, c, imm8, sae) simde_mm_mask_fixupimm_sd(a, k, b, c, imm8)
+#elif defined(SIMDE_STATEMENT_EXPR_)
+  #if defined(SIMDE_HAVE_FENV_H)
+    #define simde_mm_mask_fixupimm_round_sd(a, k, b, c, imm8, sae) SIMDE_STATEMENT_EXPR_(({ \
+      simde__m128d simde_mm_mask_fixupimm_round_sd_r; \
+      \
+      if (sae & SIMDE_MM_FROUND_NO_EXC) { \
+        fenv_t simde_mm_mask_fixupimm_round_sd_envp; \
+        int simde_mm_mask_fixupimm_round_sd_x = feholdexcept(&simde_mm_mask_fixupimm_round_sd_envp); \
+        simde_mm_mask_fixupimm_round_sd_r = simde_mm_mask_fixupimm_sd(a, k, b, c, imm8); \
+        if (HEDLEY_LIKELY(simde_mm_mask_fixupimm_round_sd_x == 0)) \
+          fesetenv(&simde_mm_mask_fixupimm_round_sd_envp); \
+      } \
+      else { \
+        simde_mm_mask_fixupimm_round_sd_r = simde_mm_mask_fixupimm_sd(a, k, b, c, imm8); \
+      } \
+      \
+      simde_mm_mask_fixupimm_round_sd_r; \
+    }))
+  #else
+    #define simde_mm_mask_fixupimm_round_sd(a, k, b, c, imm8, sae) simde_mm_mask_fixupimm_sd(a, k, b, c, imm8)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_fixupimm_round_sd
+  #define _mm_mask_fixupimm_round_sd(a, k, b, c, imm8, sae) simde_mm_mask_fixupimm_round_sd(a, k, b, c, imm8, sae)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_maskz_fixupimm_round_sd (simde__mmask8 k, simde__m128d a, simde__m128d b, simde__m128i c, int imm8, int sae)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 15)
+    SIMDE_REQUIRE_CONSTANT(sae) {
+  simde__m128d r;
+
+  if (sae & SIMDE_MM_FROUND_NO_EXC) {
+    #if defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = simde_mm_maskz_fixupimm_sd(k, a, b, c, imm8);
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = simde_mm_maskz_fixupimm_sd(k, a, b, c, imm8);
+    #endif
+  }
+  else {
+    r = simde_mm_maskz_fixupimm_sd(k, a, b, c, imm8);
+  }
+
+  return r;
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm_maskz_fixupimm_round_sd(k, a, b, c, imm8, sae) _mm_maskz_fixupimm_round_sd(k, a, b, c, imm8, sae)
+#elif defined(SIMDE_FAST_EXCEPTIONS)
+  #define simde_mm_maskz_fixupimm_round_sd(k, a, b, c, imm8, sae) simde_mm_maskz_fixupimm_sd(k, a, b, c, imm8)
+#elif defined(SIMDE_STATEMENT_EXPR_)
+  #if defined(SIMDE_HAVE_FENV_H)
+    #define simde_mm_maskz_fixupimm_round_sd(k, a, b, c, imm8, sae) SIMDE_STATEMENT_EXPR_(({ \
+      simde__m128d simde_mm_maskz_fixupimm_round_sd_r; \
+      \
+      if (sae & SIMDE_MM_FROUND_NO_EXC) { \
+        fenv_t simde_mm_maskz_fixupimm_round_sd_envp; \
+        int simde_mm_maskz_fixupimm_round_sd_x = feholdexcept(&simde_mm_maskz_fixupimm_round_sd_envp); \
+        simde_mm_maskz_fixupimm_round_sd_r = simde_mm_maskz_fixupimm_sd(k, a, b, c, imm8); \
+        if (HEDLEY_LIKELY(simde_mm_maskz_fixupimm_round_sd_x == 0)) \
+          fesetenv(&simde_mm_maskz_fixupimm_round_sd_envp); \
+      } \
+      else { \
+        simde_mm_maskz_fixupimm_round_sd_r = simde_mm_maskz_fixupimm_sd(k, a, b, c, imm8); \
+      } \
+      \
+      simde_mm_maskz_fixupimm_round_sd_r; \
+    }))
+  #else
+    #define simde_mm_maskz_fixupimm_round_sd(k, a, b, c, imm8, sae) simde_mm_maskz_fixupimm_sd(k, a, b, c, imm8)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_fixupimm_round_sd
+  #define _mm_maskz_fixupimm_round_sd(k, a, b, c, imm8, sae) simde_mm_maskz_fixupimm_round_sd(k, a, b, c, imm8, sae)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_FIXUPIMM_ROUND_H) */

--- a/test/x86/avx512/fixupimm.c
+++ b/test/x86/avx512/fixupimm.c
@@ -130,8 +130,286 @@ test_simde_mm_fixupimm_ps (SIMDE_MUNIT_TEST_ARGS) {
 #endif
 }
 
+static int
+test_simde_mm_mask_fixupimm_ps (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde_float32 a[4];
+    const simde__mmask8 k;
+    const simde_float32 b[4];
+    const int32_t c[4];
+    const int imm8;
+    const simde_float32 r[4];
+  } test_vec[] = {
+    { {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    23.48),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   523.55) },
+      UINT8_C( 56),
+      { SIMDE_FLOAT32_C(   814.83),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -987.74) },
+      { -INT32_C(  1062186756), -INT32_C(    13150401),  INT32_C(   518961091), -INT32_C(   970966419) },
+       INT32_C(         106),
+      {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    23.48),            SIMDE_MATH_NANF,     -SIMDE_MATH_INFINITYF } },
+    { { SIMDE_FLOAT32_C(   167.41), SIMDE_FLOAT32_C(  -298.70), SIMDE_FLOAT32_C(    73.34), SIMDE_FLOAT32_C(  -860.50) },
+      UINT8_C(168),
+      { SIMDE_FLOAT32_C(  -151.65), SIMDE_FLOAT32_C(  -558.71), SIMDE_FLOAT32_C(  -472.09), SIMDE_FLOAT32_C(  -613.35) },
+      {  INT32_C(   597534342),  INT32_C(  1360845833),  INT32_C(    72177076),  INT32_C(  1564675589) },
+       INT32_C(          69),
+      { SIMDE_FLOAT32_C(   167.41), SIMDE_FLOAT32_C(  -298.70), SIMDE_FLOAT32_C(    73.34), SIMDE_FLOAT32_C(     1.57) } },
+    { { SIMDE_FLOAT32_C(  -954.81), SIMDE_FLOAT32_C(  -400.16), SIMDE_FLOAT32_C(  -515.11), SIMDE_FLOAT32_C(   674.37) },
+      UINT8_C( 48),
+      { SIMDE_FLOAT32_C(  -640.90), SIMDE_FLOAT32_C(  -783.28), SIMDE_FLOAT32_C(   990.54), SIMDE_FLOAT32_C(   -77.93) },
+      {  INT32_C(  1584032062), -INT32_C(  1735470033), -INT32_C(   333564346), -INT32_C(  1342881325) },
+       INT32_C(          94),
+      { SIMDE_FLOAT32_C(  -954.81), SIMDE_FLOAT32_C(  -400.16), SIMDE_FLOAT32_C(  -515.11), SIMDE_FLOAT32_C(   674.37) } },
+    { { SIMDE_FLOAT32_C(  -839.98), SIMDE_FLOAT32_C(   384.67), SIMDE_FLOAT32_C(  -872.97), SIMDE_FLOAT32_C(   560.86) },
+      UINT8_C(147),
+      { SIMDE_FLOAT32_C(   200.25), SIMDE_FLOAT32_C(   749.68), SIMDE_FLOAT32_C(   -70.41), SIMDE_FLOAT32_C(  -172.70) },
+      { -INT32_C(  1432242073),  INT32_C(   904783381),  INT32_C(  1265835490),  INT32_C(  1551618696) },
+       INT32_C(          96),
+      { SIMDE_FLOAT32_C(     1.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -872.97), SIMDE_FLOAT32_C(   560.86) } },
+    { { SIMDE_FLOAT32_C(  -226.84), SIMDE_FLOAT32_C(   416.74), SIMDE_FLOAT32_C(  -649.15), SIMDE_FLOAT32_C(  -412.01) },
+      UINT8_C( 49),
+      { SIMDE_FLOAT32_C(   623.67), SIMDE_FLOAT32_C(   586.37), SIMDE_FLOAT32_C(  -399.76), SIMDE_FLOAT32_C(  -208.92) },
+      { -INT32_C(  2089653874),  INT32_C(  2093600792),  INT32_C(  1021533571), -INT32_C(   447639810) },
+       INT32_C(         123),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   416.74), SIMDE_FLOAT32_C(  -649.15), SIMDE_FLOAT32_C(  -412.01) } },
+    { { SIMDE_FLOAT32_C(  -712.33), SIMDE_FLOAT32_C(   673.58), SIMDE_FLOAT32_C(   -69.41), SIMDE_FLOAT32_C(   136.02) },
+      UINT8_C(250),
+      { SIMDE_FLOAT32_C(  -885.13), SIMDE_FLOAT32_C(   458.50), SIMDE_FLOAT32_C(   522.67), SIMDE_FLOAT32_C(  -839.94) },
+      { -INT32_C(  1899225069),  INT32_C(   530656381),  INT32_C(   732877506),  INT32_C(   356790596) },
+       INT32_C(         251),
+      { SIMDE_FLOAT32_C(  -712.33), SIMDE_FLOAT32_C(   458.50), SIMDE_FLOAT32_C(   -69.41),      SIMDE_MATH_INFINITYF } },
+    { { SIMDE_FLOAT32_C(  -941.67), SIMDE_FLOAT32_C(  -992.44), SIMDE_FLOAT32_C(   834.43), SIMDE_FLOAT32_C(  -582.57) },
+      UINT8_C(163),
+      { SIMDE_FLOAT32_C(  -775.72), SIMDE_FLOAT32_C(   824.97), SIMDE_FLOAT32_C(   339.51), SIMDE_FLOAT32_C(  -615.70) },
+      {  INT32_C(   640767700),  INT32_C(    61713467),  INT32_C(  1695983429), -INT32_C(  1595759500) },
+       INT32_C(          69),
+      {     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(  -992.44), SIMDE_FLOAT32_C(   834.43), SIMDE_FLOAT32_C(  -582.57) } },
+    { { SIMDE_FLOAT32_C(   209.64), SIMDE_FLOAT32_C(   466.53), SIMDE_FLOAT32_C(   945.16), SIMDE_FLOAT32_C(  -590.11) },
+      UINT8_C(176),
+      { SIMDE_FLOAT32_C(   216.22), SIMDE_FLOAT32_C(  -125.25), SIMDE_FLOAT32_C(   237.19), SIMDE_FLOAT32_C(   989.38) },
+      { -INT32_C(   756982898),  INT32_C(   160619632), -INT32_C(  1948436940),  INT32_C(   348521319) },
+       INT32_C(         176),
+      { SIMDE_FLOAT32_C(   209.64), SIMDE_FLOAT32_C(   466.53), SIMDE_FLOAT32_C(   945.16), SIMDE_FLOAT32_C(  -590.11) } },
+  };
+
+  simde__m128 a, b, r;
+  simde__m128i c;
+
+  a = simde_mm_loadu_ps(test_vec[0].a);
+  b = simde_mm_loadu_ps(test_vec[0].b);
+  c = simde_x_mm_loadu_epi32(test_vec[0].c);
+  r = simde_mm_mask_fixupimm_ps(a, test_vec[0].k, b, c, INT32_C(         106));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[0].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[1].a);
+  b = simde_mm_loadu_ps(test_vec[1].b);
+  c = simde_x_mm_loadu_epi32(test_vec[1].c);
+  r = simde_mm_mask_fixupimm_ps(a, test_vec[1].k, b, c, INT32_C(          69));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[1].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[2].a);
+  b = simde_mm_loadu_ps(test_vec[2].b);
+  c = simde_x_mm_loadu_epi32(test_vec[2].c);
+  r = simde_mm_mask_fixupimm_ps(a, test_vec[2].k, b, c, INT32_C(          94));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[2].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[3].a);
+  b = simde_mm_loadu_ps(test_vec[3].b);
+  c = simde_x_mm_loadu_epi32(test_vec[3].c);
+  r = simde_mm_mask_fixupimm_ps(a, test_vec[3].k, b, c, INT32_C(          96));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[3].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[4].a);
+  b = simde_mm_loadu_ps(test_vec[4].b);
+  c = simde_x_mm_loadu_epi32(test_vec[4].c);
+  r = simde_mm_mask_fixupimm_ps(a, test_vec[4].k, b, c, INT32_C(         123));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[4].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[5].a);
+  b = simde_mm_loadu_ps(test_vec[5].b);
+  c = simde_x_mm_loadu_epi32(test_vec[5].c);
+  r = simde_mm_mask_fixupimm_ps(a, test_vec[5].k, b, c, INT32_C(         251));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[5].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[6].a);
+  b = simde_mm_loadu_ps(test_vec[6].b);
+  c = simde_x_mm_loadu_epi32(test_vec[6].c);
+  r = simde_mm_mask_fixupimm_ps(a, test_vec[6].k, b, c, INT32_C(          69));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[6].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[7].a);
+  b = simde_mm_loadu_ps(test_vec[7].b);
+  c = simde_x_mm_loadu_epi32(test_vec[7].c);
+  r = simde_mm_mask_fixupimm_ps(a, test_vec[7].k, b, c, INT32_C(         176));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float32 values[8 * 2 * sizeof(simde__m128)];
+  simde_test_x86_random_f32x4_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__m128 a = simde_test_x86_random_extract_f32x4(i, 2, 0, values);
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m128 b = simde_test_x86_random_extract_f32x4(i, 2, 1, values);
+    simde__m128i c = simde_test_x86_random_i32x4();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    simde__m128 r;
+    SIMDE_CONSTIFY_256_(simde_mm_mask_fixupimm_ps, r, simde_mm_setzero_ps(), imm8, a, k, b, c);
+
+    simde_test_x86_write_f32x4(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x4(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x4(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x4(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm_maskz_fixupimm_ps (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde__mmask8 k;
+    const simde_float32 a[4];
+    const simde_float32 b[4];
+    const int32_t c[4];
+    const int imm8;
+    const simde_float32 r[4];
+  } test_vec[] = {
+    { UINT8_C(124),
+      {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   638.62),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -132.35) },
+      { SIMDE_FLOAT32_C(   380.68),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -115.28) },
+      {  INT32_C(    89279609),  INT32_C(  1064433692),  INT32_C(   831920124),  INT32_C(  1881735017) },
+       INT32_C(         173),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(  -132.35) } },
+    { UINT8_C(106),
+      { SIMDE_FLOAT32_C(   -96.63), SIMDE_FLOAT32_C(  -711.38), SIMDE_FLOAT32_C(   -45.21), SIMDE_FLOAT32_C(  -751.31) },
+      { SIMDE_FLOAT32_C(  -590.46), SIMDE_FLOAT32_C(  -177.78), SIMDE_FLOAT32_C(  -944.81), SIMDE_FLOAT32_C(  -564.35) },
+      { -INT32_C(  1439743690),  INT32_C(  1841087159),  INT32_C(   770062561), -INT32_C(  2092307317) },
+       INT32_C(          93),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(     0.00),            SIMDE_MATH_NANF } },
+    { UINT8_C( 31),
+      { SIMDE_FLOAT32_C(   787.86), SIMDE_FLOAT32_C(   287.26), SIMDE_FLOAT32_C(    -7.95), SIMDE_FLOAT32_C(  -547.62) },
+      { SIMDE_FLOAT32_C(   459.87), SIMDE_FLOAT32_C(  -641.82), SIMDE_FLOAT32_C(   120.92), SIMDE_FLOAT32_C(   976.19) },
+      { -INT32_C(   652288335),  INT32_C(  1458752334),  INT32_C(   932011254),  INT32_C(  1324234636) },
+       INT32_C(         244),
+      { SIMDE_FLOAT32_C(     1.57),     -SIMDE_MATH_INFINITYF,            SIMDE_MATH_NANF,     -SIMDE_MATH_INFINITYF } },
+    { UINT8_C( 66),
+      { SIMDE_FLOAT32_C(   -62.56), SIMDE_FLOAT32_C(   669.91), SIMDE_FLOAT32_C(  -683.46), SIMDE_FLOAT32_C(   363.85) },
+      { SIMDE_FLOAT32_C(  -988.00), SIMDE_FLOAT32_C(   193.28), SIMDE_FLOAT32_C(   703.87), SIMDE_FLOAT32_C(  -318.33) },
+      { -INT32_C(  1490110627), -INT32_C(  1154512069), -INT32_C(   580104449),  INT32_C(   925582700) },
+       INT32_C(          56),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00) } },
+    { UINT8_C( 15),
+      { SIMDE_FLOAT32_C(  -168.10), SIMDE_FLOAT32_C(   811.95), SIMDE_FLOAT32_C(   549.32), SIMDE_FLOAT32_C(  -787.42) },
+      { SIMDE_FLOAT32_C(   257.19), SIMDE_FLOAT32_C(  -112.09), SIMDE_FLOAT32_C(    97.30), SIMDE_FLOAT32_C(  -839.44) },
+      {  INT32_C(  1413881957), -INT32_C(  1615906193),  INT32_C(   519893351), -INT32_C(  1436966113) },
+       INT32_C(         211),
+      {      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(    97.30), SIMDE_FLOAT32_C(     1.00) } },
+    { UINT8_C(128),
+      { SIMDE_FLOAT32_C(   176.53), SIMDE_FLOAT32_C(  -947.91), SIMDE_FLOAT32_C(  -590.75), SIMDE_FLOAT32_C(   586.07) },
+      { SIMDE_FLOAT32_C(  -125.69), SIMDE_FLOAT32_C(  -535.56), SIMDE_FLOAT32_C(  -978.29), SIMDE_FLOAT32_C(  -337.83) },
+      { -INT32_C(  1278833017), -INT32_C(   214565179), -INT32_C(  1285995374), -INT32_C(   987583094) },
+       INT32_C(          92),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00) } },
+    { UINT8_C(189),
+      { SIMDE_FLOAT32_C(   751.71), SIMDE_FLOAT32_C(    13.77), SIMDE_FLOAT32_C(   114.55), SIMDE_FLOAT32_C(   211.58) },
+      { SIMDE_FLOAT32_C(   371.94), SIMDE_FLOAT32_C(  -764.53), SIMDE_FLOAT32_C(   187.77), SIMDE_FLOAT32_C(  -690.62) },
+      { -INT32_C(  1537118902), -INT32_C(  1028115432), -INT32_C(   481740459), -INT32_C(    39191297) },
+       INT32_C(          49),
+      { SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(     1.57) } },
+    { UINT8_C(245),
+      { SIMDE_FLOAT32_C(   905.38), SIMDE_FLOAT32_C(   504.31), SIMDE_FLOAT32_C(   673.23), SIMDE_FLOAT32_C(   917.38) },
+      { SIMDE_FLOAT32_C(  -302.41), SIMDE_FLOAT32_C(   377.10), SIMDE_FLOAT32_C(  -400.95), SIMDE_FLOAT32_C(   529.50) },
+      {  INT32_C(  1688338498), -INT32_C(   249167931), -INT32_C(  1170480307),  INT32_C(  2027085636) },
+       INT32_C(         152),
+      {     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(     0.00) } },
+  };
+
+  simde__m128 a, b, r;
+  simde__m128i c;
+
+  a = simde_mm_loadu_ps(test_vec[0].a);
+  b = simde_mm_loadu_ps(test_vec[0].b);
+  c = simde_x_mm_loadu_epi32(test_vec[0].c);
+  r = simde_mm_maskz_fixupimm_ps(test_vec[0].k, a, b, c, INT32_C(         173));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[0].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[1].a);
+  b = simde_mm_loadu_ps(test_vec[1].b);
+  c = simde_x_mm_loadu_epi32(test_vec[1].c);
+  r = simde_mm_maskz_fixupimm_ps(test_vec[1].k, a, b, c, INT32_C(          93));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[1].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[2].a);
+  b = simde_mm_loadu_ps(test_vec[2].b);
+  c = simde_x_mm_loadu_epi32(test_vec[2].c);
+  r = simde_mm_maskz_fixupimm_ps(test_vec[2].k, a, b, c, INT32_C(         244));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[2].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[3].a);
+  b = simde_mm_loadu_ps(test_vec[3].b);
+  c = simde_x_mm_loadu_epi32(test_vec[3].c);
+  r = simde_mm_maskz_fixupimm_ps(test_vec[3].k, a, b, c, INT32_C(          56));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[3].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[4].a);
+  b = simde_mm_loadu_ps(test_vec[4].b);
+  c = simde_x_mm_loadu_epi32(test_vec[4].c);
+  r = simde_mm_maskz_fixupimm_ps(test_vec[4].k, a, b, c, INT32_C(         211));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[4].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[5].a);
+  b = simde_mm_loadu_ps(test_vec[5].b);
+  c = simde_x_mm_loadu_epi32(test_vec[5].c);
+  r = simde_mm_maskz_fixupimm_ps(test_vec[5].k, a, b, c, INT32_C(          92));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[5].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[6].a);
+  b = simde_mm_loadu_ps(test_vec[6].b);
+  c = simde_x_mm_loadu_epi32(test_vec[6].c);
+  r = simde_mm_maskz_fixupimm_ps(test_vec[6].k, a, b, c, INT32_C(          49));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[6].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[7].a);
+  b = simde_mm_loadu_ps(test_vec[7].b);
+  c = simde_x_mm_loadu_epi32(test_vec[7].c);
+  r = simde_mm_maskz_fixupimm_ps(test_vec[7].k, a, b, c, INT32_C(         152));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float32 values[8 * 2 * sizeof(simde__m128)];
+  simde_test_x86_random_f32x4_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m128 a = simde_test_x86_random_extract_f32x4(i, 2, 0, values);
+    simde__m128 b = simde_test_x86_random_extract_f32x4(i, 2, 1, values);
+    simde__m128i c = simde_test_x86_random_i32x4();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    simde__m128 r;
+    SIMDE_CONSTIFY_256_(simde_mm_maskz_fixupimm_ps, r, simde_mm_setzero_ps(), imm8, k, a, b, c);
+
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_f32x4(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x4(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x4(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x4(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
 SIMDE_TEST_FUNC_LIST_BEGIN
   SIMDE_TEST_FUNC_LIST_ENTRY(mm_fixupimm_ps)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_mask_fixupimm_ps)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_maskz_fixupimm_ps)
 SIMDE_TEST_FUNC_LIST_END
 
 #include <test/x86/avx512/test-avx512-footer.h>

--- a/test/x86/avx512/fixupimm.c
+++ b/test/x86/avx512/fixupimm.c
@@ -1,0 +1,137 @@
+#define SIMDE_TEST_X86_AVX512_INSN fixupimm
+
+#include <test/x86/avx512/test-avx512.h>
+#include <simde/x86/avx512/fixupimm.h>
+
+static int
+test_simde_mm_fixupimm_ps (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde_float32 a[4];
+    const simde_float32 b[4];
+    const int32_t c[4];
+    const int imm8;
+    const simde_float32 r[4];
+  } test_vec[] = {
+    { {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   201.54),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   881.13) },
+      { SIMDE_FLOAT32_C(   -46.40),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   174.98) },
+      { -INT32_C(   408511845),  INT32_C(  1587971559), -INT32_C(   627447801),  INT32_C(  2001924042) },
+       INT32_C(           9),
+      { SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(    -0.00) } },
+    { { SIMDE_FLOAT32_C(   664.12), SIMDE_FLOAT32_C(  -562.89), SIMDE_FLOAT32_C(   663.33), SIMDE_FLOAT32_C(   970.48) },
+      { SIMDE_FLOAT32_C(   603.80), SIMDE_FLOAT32_C(  -265.96), SIMDE_FLOAT32_C(  -984.77), SIMDE_FLOAT32_C(   917.02) },
+      { -INT32_C(   718677047),  INT32_C(   781642408),  INT32_C(    34931302), -INT32_C(  2081834084) },
+       INT32_C(          65),
+      { SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(     0.00) } },
+    { { SIMDE_FLOAT32_C(   517.09), SIMDE_FLOAT32_C(  -513.21), SIMDE_FLOAT32_C(  -326.22), SIMDE_FLOAT32_C(  -832.74) },
+      { SIMDE_FLOAT32_C(  -388.67), SIMDE_FLOAT32_C(   -81.18), SIMDE_FLOAT32_C(   227.41), SIMDE_FLOAT32_C(  -456.50) },
+      {  INT32_C(  1126398840),  INT32_C(  1941599594),  INT32_C(  1252359041), -INT32_C(    14627242) },
+       INT32_C(         184),
+      {            SIMDE_MATH_NANF,            SIMDE_MATH_NANF,     -SIMDE_MATH_INFINITYF,  SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00) } },
+    { { SIMDE_FLOAT32_C(  -446.07), SIMDE_FLOAT32_C(  -715.24), SIMDE_FLOAT32_C(  -742.45), SIMDE_FLOAT32_C(  -938.47) },
+      { SIMDE_FLOAT32_C(   179.77), SIMDE_FLOAT32_C(   -73.95), SIMDE_FLOAT32_C(    38.40), SIMDE_FLOAT32_C(   117.23) },
+      {  INT32_C(  1428177592),  INT32_C(  1071123198),  INT32_C(   310885018), -INT32_C(  1621775819) },
+       INT32_C(          32),
+      {      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(    38.40), SIMDE_FLOAT32_C(    -1.00) } },
+    { { SIMDE_FLOAT32_C(  -872.41), SIMDE_FLOAT32_C(   469.38), SIMDE_FLOAT32_C(    -1.64), SIMDE_FLOAT32_C(    81.20) },
+      { SIMDE_FLOAT32_C(   969.80), SIMDE_FLOAT32_C(   475.02), SIMDE_FLOAT32_C(  -743.82), SIMDE_FLOAT32_C(   633.92) },
+      { -INT32_C(   504580214),  INT32_C(  1038093445),  INT32_C(  2069564866),  INT32_C(  1322286160) },
+       INT32_C(         134),
+      { SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(     0.50),     -SIMDE_MATH_INFINITYF } },
+    { { SIMDE_FLOAT32_C(   912.13), SIMDE_FLOAT32_C(   919.50), SIMDE_FLOAT32_C(   604.40), SIMDE_FLOAT32_C(   515.94) },
+      { SIMDE_FLOAT32_C(  -346.46), SIMDE_FLOAT32_C(   619.63), SIMDE_FLOAT32_C(   432.96), SIMDE_FLOAT32_C(  -829.36) },
+      { -INT32_C(  1758325662), -INT32_C(   550074177),  INT32_C(   578832535), -INT32_C(  2080150273) },
+       INT32_C(         120),
+      { SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(     1.57),            SIMDE_MATH_NANF,     -SIMDE_MATH_INFINITYF } },
+    { { SIMDE_FLOAT32_C(  -893.58), SIMDE_FLOAT32_C(  -893.27), SIMDE_FLOAT32_C(  -662.11), SIMDE_FLOAT32_C(  -282.25) },
+      { SIMDE_FLOAT32_C(    25.55), SIMDE_FLOAT32_C(   565.30), SIMDE_FLOAT32_C(   261.25), SIMDE_FLOAT32_C(   579.48) },
+      {  INT32_C(  1085677040),  INT32_C(   529434265), -INT32_C(  1858135250), -INT32_C(   282562256) },
+       INT32_C(         249),
+      {     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(   565.30), SIMDE_FLOAT32_C(    -1.00), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00) } },
+    { { SIMDE_FLOAT32_C(   850.06), SIMDE_FLOAT32_C(   518.80), SIMDE_FLOAT32_C(   641.02), SIMDE_FLOAT32_C(    29.83) },
+      { SIMDE_FLOAT32_C(  -555.15), SIMDE_FLOAT32_C(  -320.59), SIMDE_FLOAT32_C(  -852.94), SIMDE_FLOAT32_C(  -427.56) },
+      { -INT32_C(  1481421145),  INT32_C(   858502843), -INT32_C(  1989218919), -INT32_C(  1547033590) },
+       INT32_C(         170),
+      { SIMDE_FLOAT32_C(    -0.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    -1.00),            SIMDE_MATH_NANF } },
+  };
+
+  simde__m128 a, b, r;
+  simde__m128i c;
+
+  a = simde_mm_loadu_ps(test_vec[0].a);
+  b = simde_mm_loadu_ps(test_vec[0].b);
+  c = simde_x_mm_loadu_epi32(test_vec[0].c);
+  r = simde_mm_fixupimm_ps(a, b, c, INT32_C(           9));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[0].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[1].a);
+  b = simde_mm_loadu_ps(test_vec[1].b);
+  c = simde_x_mm_loadu_epi32(test_vec[1].c);
+  r = simde_mm_fixupimm_ps(a, b, c, INT32_C(          65));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[1].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[2].a);
+  b = simde_mm_loadu_ps(test_vec[2].b);
+  c = simde_x_mm_loadu_epi32(test_vec[2].c);
+  r = simde_mm_fixupimm_ps(a, b, c, INT32_C(         184));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[2].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[3].a);
+  b = simde_mm_loadu_ps(test_vec[3].b);
+  c = simde_x_mm_loadu_epi32(test_vec[3].c);
+  r = simde_mm_fixupimm_ps(a, b, c, INT32_C(          32));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[3].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[4].a);
+  b = simde_mm_loadu_ps(test_vec[4].b);
+  c = simde_x_mm_loadu_epi32(test_vec[4].c);
+  r = simde_mm_fixupimm_ps(a, b, c, INT32_C(         134));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[4].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[5].a);
+  b = simde_mm_loadu_ps(test_vec[5].b);
+  c = simde_x_mm_loadu_epi32(test_vec[5].c);
+  r = simde_mm_fixupimm_ps(a, b, c, INT32_C(         120));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[5].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[6].a);
+  b = simde_mm_loadu_ps(test_vec[6].b);
+  c = simde_x_mm_loadu_epi32(test_vec[6].c);
+  r = simde_mm_fixupimm_ps(a, b, c, INT32_C(         249));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[6].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[7].a);
+  b = simde_mm_loadu_ps(test_vec[7].b);
+  c = simde_x_mm_loadu_epi32(test_vec[7].c);
+  r = simde_mm_fixupimm_ps(a, b, c, INT32_C(         170));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float32 values[8 * 2 * sizeof(simde__m128)];
+  simde_test_x86_random_f32x4_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__m128 a = simde_test_x86_random_extract_f32x4(i, 2, 0, values);
+    simde__m128 b = simde_test_x86_random_extract_f32x4(i, 2, 1, values);
+    simde__m128i c = simde_test_x86_random_i32x4();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    simde__m128 r;
+    SIMDE_CONSTIFY_256_(simde_mm_fixupimm_ps, r, simde_mm_setzero_ps(), imm8, a, b, c);
+
+    simde_test_x86_write_f32x4(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_f32x4(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x4(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x4(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+SIMDE_TEST_FUNC_LIST_BEGIN
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_fixupimm_ps)
+SIMDE_TEST_FUNC_LIST_END
+
+#include <test/x86/avx512/test-avx512-footer.h>

--- a/test/x86/avx512/fixupimm.c
+++ b/test/x86/avx512/fixupimm.c
@@ -2,6 +2,7 @@
 
 #include <test/x86/avx512/test-avx512.h>
 #include <simde/x86/avx512/fixupimm.h>
+#include <simde/x86/avx512/setzero.h>
 
 static int
 test_simde_mm_fixupimm_ps (SIMDE_MUNIT_TEST_ARGS) {
@@ -43,16 +44,16 @@ test_simde_mm_fixupimm_ps (SIMDE_MUNIT_TEST_ARGS) {
       { -INT32_C(  1758325662), -INT32_C(   550074177),  INT32_C(   578832535), -INT32_C(  2080150273) },
        INT32_C(         120),
       { SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(     1.57),            SIMDE_MATH_NANF,     -SIMDE_MATH_INFINITYF } },
-    { { SIMDE_FLOAT32_C(  -893.58), SIMDE_FLOAT32_C(  -893.27), SIMDE_FLOAT32_C(  -662.11), SIMDE_FLOAT32_C(  -282.25) },
-      { SIMDE_FLOAT32_C(    25.55), SIMDE_FLOAT32_C(   565.30), SIMDE_FLOAT32_C(   261.25), SIMDE_FLOAT32_C(   579.48) },
-      {  INT32_C(  1085677040),  INT32_C(   529434265), -INT32_C(  1858135250), -INT32_C(   282562256) },
-       INT32_C(         249),
-      {     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(   565.30), SIMDE_FLOAT32_C(    -1.00), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00) } },
-    { { SIMDE_FLOAT32_C(   850.06), SIMDE_FLOAT32_C(   518.80), SIMDE_FLOAT32_C(   641.02), SIMDE_FLOAT32_C(    29.83) },
-      { SIMDE_FLOAT32_C(  -555.15), SIMDE_FLOAT32_C(  -320.59), SIMDE_FLOAT32_C(  -852.94), SIMDE_FLOAT32_C(  -427.56) },
-      { -INT32_C(  1481421145),  INT32_C(   858502843), -INT32_C(  1989218919), -INT32_C(  1547033590) },
-       INT32_C(         170),
-      { SIMDE_FLOAT32_C(    -0.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    -1.00),            SIMDE_MATH_NANF } },
+    { { SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00) },
+      { SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(     0.00) },
+      { -INT32_C(  1289243822), -INT32_C(  1566703114), -INT32_C(  1814574289), -INT32_C(   993823156) },
+       INT32_C(           6),
+      { SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(    90.00),      SIMDE_MATH_INFINITYF } },
+    { { SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00) },
+      { SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(     0.00) },
+      {  INT32_C(   442678001), -INT32_C(  1898682214), -INT32_C(  1314041761), -INT32_C(   110767101) },
+       INT32_C(         213),
+      { SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(     0.00),      SIMDE_MATH_INFINITYF,     -SIMDE_MATH_INFINITYF } },
   };
 
   simde__m128 a, b, r;
@@ -97,13 +98,13 @@ test_simde_mm_fixupimm_ps (SIMDE_MUNIT_TEST_ARGS) {
   a = simde_mm_loadu_ps(test_vec[6].a);
   b = simde_mm_loadu_ps(test_vec[6].b);
   c = simde_x_mm_loadu_epi32(test_vec[6].c);
-  r = simde_mm_fixupimm_ps(a, b, c, INT32_C(         249));
+  r = simde_mm_fixupimm_ps(a, b, c, INT32_C(           6));
   simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[6].r), 1);
 
   a = simde_mm_loadu_ps(test_vec[7].a);
   b = simde_mm_loadu_ps(test_vec[7].b);
   c = simde_x_mm_loadu_epi32(test_vec[7].c);
-  r = simde_mm_fixupimm_ps(a, b, c, INT32_C(         170));
+  r = simde_mm_fixupimm_ps(a, b, c, INT32_C(         213));
   simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[7].r), 1);
 
   return 0;
@@ -112,9 +113,9 @@ test_simde_mm_fixupimm_ps (SIMDE_MUNIT_TEST_ARGS) {
   simde_float32 values[8 * 2 * sizeof(simde__m128)];
   simde_test_x86_random_f32x4_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
 
-  for (size_t i = 0 ; i < 8 ; i++) {
-    simde__m128 a = simde_test_x86_random_extract_f32x4(i, 2, 0, values);
-    simde__m128 b = simde_test_x86_random_extract_f32x4(i, 2, 1, values);
+  for (size_t i = 0 ; i < 2 ; i++) {
+    simde__m128 a = simde_mm_set_ps(SIMDE_FLOAT32_C(0.0), SIMDE_FLOAT32_C(0.0), SIMDE_FLOAT32_C(1.0), SIMDE_FLOAT32_C(1.0));
+    simde__m128 b = simde_mm_set_ps(SIMDE_FLOAT32_C(0.0), SIMDE_FLOAT32_C(1.0), SIMDE_FLOAT32_C(0.0), SIMDE_FLOAT32_C(1.0));
     simde__m128i c = simde_test_x86_random_i32x4();
     int32_t imm8 = simde_test_codegen_random_i32() & 255;
     simde__m128 r;
@@ -406,10 +407,1543 @@ test_simde_mm_maskz_fixupimm_ps (SIMDE_MUNIT_TEST_ARGS) {
 #endif
 }
 
+static int
+test_simde_mm256_fixupimm_ps (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde_float32 a[8];
+    const simde_float32 b[8];
+    const int32_t c[8];
+    const int imm8;
+    const simde_float32 r[8];
+  } test_vec[] = {
+    { {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -717.50),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -862.43),
+        SIMDE_FLOAT32_C(  -740.31), SIMDE_FLOAT32_C(  -981.92), SIMDE_FLOAT32_C(   395.85), SIMDE_FLOAT32_C(  -866.87) },
+      { SIMDE_FLOAT32_C(  -920.35),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -757.57),
+        SIMDE_FLOAT32_C(   266.74), SIMDE_FLOAT32_C(  -725.14), SIMDE_FLOAT32_C(   112.06), SIMDE_FLOAT32_C(   327.58) },
+      {  INT32_C(   778834093),  INT32_C(   354272015), -INT32_C(    78709799), -INT32_C(   165808334),  INT32_C(   871982277),  INT32_C(   444242987),  INT32_C(   453967824), -INT32_C(   692770008) },
+       INT32_C(          59),
+      { SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(    -1.00),     -SIMDE_MATH_INFINITYF,
+                   SIMDE_MATH_NANF, SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(   112.06), SIMDE_FLOAT32_C(     1.57) } },
+    { { SIMDE_FLOAT32_C(  -543.90), SIMDE_FLOAT32_C(  -832.07), SIMDE_FLOAT32_C(  -172.54), SIMDE_FLOAT32_C(  -212.80),
+        SIMDE_FLOAT32_C(   110.31), SIMDE_FLOAT32_C(   254.25), SIMDE_FLOAT32_C(   616.87), SIMDE_FLOAT32_C(  -886.83) },
+      { SIMDE_FLOAT32_C(  -780.07), SIMDE_FLOAT32_C(   724.14), SIMDE_FLOAT32_C(  -604.09), SIMDE_FLOAT32_C(  -796.62),
+        SIMDE_FLOAT32_C(  -291.37), SIMDE_FLOAT32_C(   242.20), SIMDE_FLOAT32_C(   593.52), SIMDE_FLOAT32_C(  -398.18) },
+      { -INT32_C(  1100996123),  INT32_C(  1337568796),  INT32_C(  1799739046),  INT32_C(  1721712187), -INT32_C(  1417668134),  INT32_C(  1103531545), -INT32_C(   199787591), -INT32_C(  2109858659) },
+       INT32_C(          61),
+      { SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00),     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.50),     -SIMDE_MATH_INFINITYF,
+        SIMDE_FLOAT32_C(     0.50),     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00),            SIMDE_MATH_NANF } },
+    { { SIMDE_FLOAT32_C(   524.71), SIMDE_FLOAT32_C(  -255.94), SIMDE_FLOAT32_C(  -260.61), SIMDE_FLOAT32_C(   784.39),
+        SIMDE_FLOAT32_C(  -237.86), SIMDE_FLOAT32_C(  -864.77), SIMDE_FLOAT32_C(   917.52), SIMDE_FLOAT32_C(  -158.21) },
+      { SIMDE_FLOAT32_C(  -793.92), SIMDE_FLOAT32_C(  -112.64), SIMDE_FLOAT32_C(    84.22), SIMDE_FLOAT32_C(   472.81),
+        SIMDE_FLOAT32_C(   162.22), SIMDE_FLOAT32_C(  -803.72), SIMDE_FLOAT32_C(  -199.61), SIMDE_FLOAT32_C(   618.32) },
+      { -INT32_C(   206964403),  INT32_C(   173993679),  INT32_C(   124845357),  INT32_C(   817033239),  INT32_C(   930183550), -INT32_C(  1859417612), -INT32_C(   502043995),  INT32_C(  1430016776) },
+       INT32_C(          76),
+      {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(  -260.61),            SIMDE_MATH_NANF,
+                   SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -803.72),            SIMDE_MATH_NANF,      SIMDE_MATH_INFINITYF } },
+    { { SIMDE_FLOAT32_C(  -635.79), SIMDE_FLOAT32_C(   627.86), SIMDE_FLOAT32_C(  -594.48), SIMDE_FLOAT32_C(   474.52),
+        SIMDE_FLOAT32_C(  -117.90), SIMDE_FLOAT32_C(  -977.61), SIMDE_FLOAT32_C(   587.68), SIMDE_FLOAT32_C(   102.04) },
+      { SIMDE_FLOAT32_C(   746.53), SIMDE_FLOAT32_C(   983.59), SIMDE_FLOAT32_C(   305.42), SIMDE_FLOAT32_C(  -544.84),
+        SIMDE_FLOAT32_C(   225.79), SIMDE_FLOAT32_C(  -101.06), SIMDE_FLOAT32_C(    56.98), SIMDE_FLOAT32_C(  -249.50) },
+      {  INT32_C(    19310548), -INT32_C(  1157064796),  INT32_C(   116112263),  INT32_C(   675110196), -INT32_C(  1950717466), -INT32_C(   613560877),  INT32_C(  1831971361),  INT32_C(  1669953935) },
+       INT32_C(          32),
+      { SIMDE_FLOAT32_C(  -635.79), SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(  -594.48), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.50),      SIMDE_MATH_INFINITYF,            SIMDE_MATH_NANF } },
+    { { SIMDE_FLOAT32_C(   643.00), SIMDE_FLOAT32_C(   796.36), SIMDE_FLOAT32_C(  -465.10), SIMDE_FLOAT32_C(  -594.86),
+        SIMDE_FLOAT32_C(   931.60), SIMDE_FLOAT32_C(  -547.58), SIMDE_FLOAT32_C(   246.93), SIMDE_FLOAT32_C(  -862.33) },
+      { SIMDE_FLOAT32_C(   339.78), SIMDE_FLOAT32_C(  -668.85), SIMDE_FLOAT32_C(   610.49), SIMDE_FLOAT32_C(  -498.00),
+        SIMDE_FLOAT32_C(  -472.57), SIMDE_FLOAT32_C(  -589.12), SIMDE_FLOAT32_C(  -879.69), SIMDE_FLOAT32_C(  -108.36) },
+      { -INT32_C(   830444217),  INT32_C(  1557425192), -INT32_C(  1350298935),  INT32_C(  1312439931),  INT32_C(   757704460), -INT32_C(   509978031), -INT32_C(   196860716),  INT32_C(   465152468) },
+       INT32_C(          22),
+      { SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00),
+        SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(  -589.12),     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.50) } },
+    { { SIMDE_FLOAT32_C(  -961.26), SIMDE_FLOAT32_C(  -474.17), SIMDE_FLOAT32_C(  -633.84), SIMDE_FLOAT32_C(   -79.16),
+        SIMDE_FLOAT32_C(  -451.78), SIMDE_FLOAT32_C(   953.84), SIMDE_FLOAT32_C(  -977.12), SIMDE_FLOAT32_C(  -705.25) },
+      { SIMDE_FLOAT32_C(   937.43), SIMDE_FLOAT32_C(   328.30), SIMDE_FLOAT32_C(  -250.09), SIMDE_FLOAT32_C(   163.22),
+        SIMDE_FLOAT32_C(  -772.76), SIMDE_FLOAT32_C(   806.89), SIMDE_FLOAT32_C(   913.73), SIMDE_FLOAT32_C(   870.24) },
+      {  INT32_C(  1872412326),  INT32_C(  1260265168),  INT32_C(  1771657309),  INT32_C(  1368834815), -INT32_C(   248369123),  INT32_C(   686126676),  INT32_C(   893624095),  INT32_C(  2138254809) },
+       INT32_C(         235),
+      {      SIMDE_MATH_INFINITYF,     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(    -1.00),      SIMDE_MATH_INFINITYF,
+        SIMDE_FLOAT32_C(  -772.76),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    -0.00) } },
+    { { SIMDE_FLOAT32_C(   603.25), SIMDE_FLOAT32_C(  -551.38), SIMDE_FLOAT32_C(  -724.63), SIMDE_FLOAT32_C(   534.85),
+        SIMDE_FLOAT32_C(   -98.96), SIMDE_FLOAT32_C(   522.30), SIMDE_FLOAT32_C(   672.52), SIMDE_FLOAT32_C(  -759.19) },
+      { SIMDE_FLOAT32_C(   853.45), SIMDE_FLOAT32_C(   283.01), SIMDE_FLOAT32_C(  -257.19), SIMDE_FLOAT32_C(  -619.12),
+        SIMDE_FLOAT32_C(   693.89), SIMDE_FLOAT32_C(  -136.88), SIMDE_FLOAT32_C(   272.52), SIMDE_FLOAT32_C(   732.63) },
+      { -INT32_C(  1996092372),  INT32_C(  1676844900),  INT32_C(  2125760609),  INT32_C(   225437368),  INT32_C(  2083870045), -INT32_C(   843941388), -INT32_C(  1857280602),  INT32_C(  1598831155) },
+       INT32_C(          70),
+      { SIMDE_FLOAT32_C(     0.00),      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(     1.57),
+        SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(    -1.00),      SIMDE_MATH_INFINITYF } },
+    { { SIMDE_FLOAT32_C(   388.95), SIMDE_FLOAT32_C(   638.68), SIMDE_FLOAT32_C(  -346.52), SIMDE_FLOAT32_C(   937.17),
+        SIMDE_FLOAT32_C(   592.52), SIMDE_FLOAT32_C(  -323.64), SIMDE_FLOAT32_C(  -768.07), SIMDE_FLOAT32_C(   529.95) },
+      { SIMDE_FLOAT32_C(  -995.34), SIMDE_FLOAT32_C(   -18.16), SIMDE_FLOAT32_C(  -306.83), SIMDE_FLOAT32_C(  -768.10),
+        SIMDE_FLOAT32_C(  -211.27), SIMDE_FLOAT32_C(  -393.10), SIMDE_FLOAT32_C(  -897.87), SIMDE_FLOAT32_C(  -608.02) },
+      {  INT32_C(  1376639729),  INT32_C(   449954402),  INT32_C(    86458536), -INT32_C(  1987945067),  INT32_C(  2086024406), -INT32_C(  1945263527),  INT32_C(   585849308), -INT32_C(  1664298069) },
+       INT32_C(         173),
+      {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(     1.00),      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(    -1.00),
+        SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(    90.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    90.00) } },
+  };
+
+  simde__m256 a, b, r;
+  simde__m256i c;
+
+  a = simde_mm256_loadu_ps(test_vec[0].a);
+  b = simde_mm256_loadu_ps(test_vec[0].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[0].c);
+  r = simde_mm256_fixupimm_ps(a, b, c, INT32_C(          59));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[0].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[1].a);
+  b = simde_mm256_loadu_ps(test_vec[1].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[1].c);
+  r = simde_mm256_fixupimm_ps(a, b, c, INT32_C(          61));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[1].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[2].a);
+  b = simde_mm256_loadu_ps(test_vec[2].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[2].c);
+  r = simde_mm256_fixupimm_ps(a, b, c, INT32_C(          76));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[2].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[3].a);
+  b = simde_mm256_loadu_ps(test_vec[3].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[3].c);
+  r = simde_mm256_fixupimm_ps(a, b, c, INT32_C(          32));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[3].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[4].a);
+  b = simde_mm256_loadu_ps(test_vec[4].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[4].c);
+  r = simde_mm256_fixupimm_ps(a, b, c, INT32_C(          22));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[4].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[5].a);
+  b = simde_mm256_loadu_ps(test_vec[5].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[5].c);
+  r = simde_mm256_fixupimm_ps(a, b, c, INT32_C(         235));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[5].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[6].a);
+  b = simde_mm256_loadu_ps(test_vec[6].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[6].c);
+  r = simde_mm256_fixupimm_ps(a, b, c, INT32_C(          70));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[6].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[7].a);
+  b = simde_mm256_loadu_ps(test_vec[7].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[7].c);
+  r = simde_mm256_fixupimm_ps(a, b, c, INT32_C(         173));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float32 values[8 * 2 * sizeof(simde__m256)];
+  simde_test_x86_random_f32x8_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__m256 a = simde_test_x86_random_extract_f32x8(i, 2, 0, values);
+    simde__m256 b = simde_test_x86_random_extract_f32x8(i, 2, 1, values);
+    simde__m256i c = simde_test_x86_random_i32x8();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    simde__m256 r;
+    SIMDE_CONSTIFY_256_(simde_mm256_fixupimm_ps, r, simde_mm256_setzero_ps(), imm8, a, b, c);
+
+    simde_test_x86_write_f32x8(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_f32x8(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x8(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x8(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_mask_fixupimm_ps (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde_float32 a[8];
+    const simde__mmask8 k;
+    const simde_float32 b[8];
+    const int32_t c[8];
+    const int imm8;
+    const simde_float32 r[8];
+  } test_vec[] = {
+    { {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -701.09),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -192.64),
+        SIMDE_FLOAT32_C(  -447.73), SIMDE_FLOAT32_C(  -514.77), SIMDE_FLOAT32_C(  -642.51), SIMDE_FLOAT32_C(  -424.83) },
+      UINT8_C(180),
+      { SIMDE_FLOAT32_C(   471.49),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -677.28),
+        SIMDE_FLOAT32_C(  -276.38), SIMDE_FLOAT32_C(  -462.43), SIMDE_FLOAT32_C(  -239.73), SIMDE_FLOAT32_C(  -354.30) },
+      { -INT32_C(  1317828619), -INT32_C(  1442836490),  INT32_C(   718401157),  INT32_C(  1057338427), -INT32_C(    85827389),  INT32_C(  1211196643), -INT32_C(  1129387323), -INT32_C(  1150287674) },
+       INT32_C(         135),
+      {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -701.09),      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(  -192.64),
+        SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -642.51), SIMDE_FLOAT32_C(     0.50) } },
+    { { SIMDE_FLOAT32_C(  -213.42), SIMDE_FLOAT32_C(   235.52), SIMDE_FLOAT32_C(  -616.19), SIMDE_FLOAT32_C(    64.87),
+        SIMDE_FLOAT32_C(  -497.47), SIMDE_FLOAT32_C(   660.86), SIMDE_FLOAT32_C(   -68.87), SIMDE_FLOAT32_C(  -443.85) },
+      UINT8_C(243),
+      { SIMDE_FLOAT32_C(   891.56), SIMDE_FLOAT32_C(  -909.49), SIMDE_FLOAT32_C(  -692.78), SIMDE_FLOAT32_C(   691.38),
+        SIMDE_FLOAT32_C(  -378.80), SIMDE_FLOAT32_C(   606.71), SIMDE_FLOAT32_C(   445.52), SIMDE_FLOAT32_C(  -694.43) },
+      {  INT32_C(  1517889644), -INT32_C(  1365924871),  INT32_C(   141677736),  INT32_C(   468413622), -INT32_C(  1998572387), -INT32_C(   498164510), -INT32_C(   244774643), -INT32_C(   488315019) },
+       INT32_C(          16),
+      {      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(  -616.19), SIMDE_FLOAT32_C(    64.87),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00),            SIMDE_MATH_NANF } },
+    { { SIMDE_FLOAT32_C(   905.62), SIMDE_FLOAT32_C(   -67.52), SIMDE_FLOAT32_C(   112.93), SIMDE_FLOAT32_C(  -542.11),
+        SIMDE_FLOAT32_C(   417.71), SIMDE_FLOAT32_C(   470.42), SIMDE_FLOAT32_C(    33.06), SIMDE_FLOAT32_C(  -110.80) },
+      UINT8_C(  0),
+      { SIMDE_FLOAT32_C(  -604.83), SIMDE_FLOAT32_C(  -390.12), SIMDE_FLOAT32_C(   211.92), SIMDE_FLOAT32_C(   118.79),
+        SIMDE_FLOAT32_C(   147.45), SIMDE_FLOAT32_C(   972.19), SIMDE_FLOAT32_C(   764.49), SIMDE_FLOAT32_C(   934.03) },
+      { -INT32_C(  1498892334), -INT32_C(  1789022167), -INT32_C(   801998692), -INT32_C(   172836264),  INT32_C(   285381640), -INT32_C(   444075011),  INT32_C(   905275863),  INT32_C(  2000027301) },
+       INT32_C(         182),
+      { SIMDE_FLOAT32_C(   905.62), SIMDE_FLOAT32_C(   -67.52), SIMDE_FLOAT32_C(   112.93), SIMDE_FLOAT32_C(  -542.11),
+        SIMDE_FLOAT32_C(   417.71), SIMDE_FLOAT32_C(   470.42), SIMDE_FLOAT32_C(    33.06), SIMDE_FLOAT32_C(  -110.80) } },
+    { { SIMDE_FLOAT32_C(   207.71), SIMDE_FLOAT32_C(  -851.70), SIMDE_FLOAT32_C(    -1.10), SIMDE_FLOAT32_C(   710.23),
+        SIMDE_FLOAT32_C(   809.17), SIMDE_FLOAT32_C(   930.03), SIMDE_FLOAT32_C(  -733.61), SIMDE_FLOAT32_C(   700.73) },
+      UINT8_C(142),
+      { SIMDE_FLOAT32_C(  -979.45), SIMDE_FLOAT32_C(  -426.40), SIMDE_FLOAT32_C(   392.11), SIMDE_FLOAT32_C(  -358.25),
+        SIMDE_FLOAT32_C(  -819.69), SIMDE_FLOAT32_C(  -162.38), SIMDE_FLOAT32_C(   -52.68), SIMDE_FLOAT32_C(  -914.07) },
+      { -INT32_C(   215321477),  INT32_C(  1632369318),  INT32_C(  1080639660),  INT32_C(   893287234),  INT32_C(  1796023042),  INT32_C(   370164248),  INT32_C(  1439467639),  INT32_C(   568634278) },
+       INT32_C(          31),
+      { SIMDE_FLOAT32_C(   207.71), SIMDE_FLOAT32_C(  -426.40),     -SIMDE_MATH_INFINITYF,      SIMDE_MATH_INFINITYF,
+        SIMDE_FLOAT32_C(   809.17), SIMDE_FLOAT32_C(   930.03), SIMDE_FLOAT32_C(  -733.61), SIMDE_FLOAT32_C(  -914.07) } },
+    { { SIMDE_FLOAT32_C(   770.10), SIMDE_FLOAT32_C(  -939.75), SIMDE_FLOAT32_C(  -456.19), SIMDE_FLOAT32_C(   187.81),
+        SIMDE_FLOAT32_C(   530.68), SIMDE_FLOAT32_C(   576.87), SIMDE_FLOAT32_C(  -922.99), SIMDE_FLOAT32_C(   925.85) },
+      UINT8_C(  9),
+      { SIMDE_FLOAT32_C(  -813.24), SIMDE_FLOAT32_C(   288.94), SIMDE_FLOAT32_C(    44.64), SIMDE_FLOAT32_C(   334.21),
+        SIMDE_FLOAT32_C(   261.13), SIMDE_FLOAT32_C(  -190.87), SIMDE_FLOAT32_C(   268.25), SIMDE_FLOAT32_C(  -531.16) },
+      { -INT32_C(  1598740641),  INT32_C(   199423632),  INT32_C(  1460475956),  INT32_C(  1735358501),  INT32_C(   299795849), -INT32_C(    38325166),  INT32_C(   639490072),  INT32_C(  1261429740) },
+       INT32_C(          10),
+      { SIMDE_FLOAT32_C(   770.10), SIMDE_FLOAT32_C(  -939.75), SIMDE_FLOAT32_C(  -456.19),      SIMDE_MATH_INFINITYF,
+        SIMDE_FLOAT32_C(   530.68), SIMDE_FLOAT32_C(   576.87), SIMDE_FLOAT32_C(  -922.99), SIMDE_FLOAT32_C(   925.85) } },
+    { { SIMDE_FLOAT32_C(   -42.56), SIMDE_FLOAT32_C(  -732.85), SIMDE_FLOAT32_C(  -820.93), SIMDE_FLOAT32_C(  -233.39),
+        SIMDE_FLOAT32_C(  -802.82), SIMDE_FLOAT32_C(  -554.54), SIMDE_FLOAT32_C(  -532.66), SIMDE_FLOAT32_C(  -782.27) },
+      UINT8_C(219),
+      { SIMDE_FLOAT32_C(    19.06), SIMDE_FLOAT32_C(   859.44), SIMDE_FLOAT32_C(  -140.53), SIMDE_FLOAT32_C(   199.37),
+        SIMDE_FLOAT32_C(  -302.94), SIMDE_FLOAT32_C(   806.79), SIMDE_FLOAT32_C(   285.30), SIMDE_FLOAT32_C(  -532.83) },
+      { -INT32_C(   435181874),  INT32_C(   738944691),  INT32_C(  1521840853), -INT32_C(  2069051824),  INT32_C(  1436330621), -INT32_C(  1438530617), -INT32_C(   676033294),  INT32_C(  1186090616) },
+       INT32_C(         244),
+      { SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -820.93), SIMDE_FLOAT32_C(     0.00),
+             SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(  -554.54), SIMDE_FLOAT32_C(     1.57),     -SIMDE_MATH_INFINITYF } },
+    { { SIMDE_FLOAT32_C(   867.05), SIMDE_FLOAT32_C(   829.11), SIMDE_FLOAT32_C(   654.98), SIMDE_FLOAT32_C(   397.72),
+        SIMDE_FLOAT32_C(   405.99), SIMDE_FLOAT32_C(   731.99), SIMDE_FLOAT32_C(   323.57), SIMDE_FLOAT32_C(   592.74) },
+      UINT8_C( 39),
+      { SIMDE_FLOAT32_C(    20.93), SIMDE_FLOAT32_C(  -631.79), SIMDE_FLOAT32_C(   -73.04), SIMDE_FLOAT32_C(  -717.94),
+        SIMDE_FLOAT32_C(   177.34), SIMDE_FLOAT32_C(  -804.80), SIMDE_FLOAT32_C(  -249.11), SIMDE_FLOAT32_C(  -865.22) },
+      { -INT32_C(  1443048393),  INT32_C(  1341740937), -INT32_C(  1379107325), -INT32_C(   579591910), -INT32_C(   288350622),  INT32_C(   560375762),  INT32_C(   454405210),  INT32_C(   256097752) },
+       INT32_C(         145),
+      { SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(   397.72),
+        SIMDE_FLOAT32_C(   405.99), SIMDE_FLOAT32_C(  -804.80), SIMDE_FLOAT32_C(   323.57), SIMDE_FLOAT32_C(   592.74) } },
+    { { SIMDE_FLOAT32_C(  -537.65), SIMDE_FLOAT32_C(   -70.04), SIMDE_FLOAT32_C(   -98.61), SIMDE_FLOAT32_C(  -340.47),
+        SIMDE_FLOAT32_C(   375.42), SIMDE_FLOAT32_C(   368.72), SIMDE_FLOAT32_C(  -122.75), SIMDE_FLOAT32_C(  -605.52) },
+      UINT8_C(150),
+      { SIMDE_FLOAT32_C(   228.17), SIMDE_FLOAT32_C(   736.72), SIMDE_FLOAT32_C(   593.85), SIMDE_FLOAT32_C(   925.23),
+        SIMDE_FLOAT32_C(   543.52), SIMDE_FLOAT32_C(  -120.85), SIMDE_FLOAT32_C(  -607.60), SIMDE_FLOAT32_C(   410.57) },
+      {  INT32_C(   815425970),  INT32_C(  1447708469), -INT32_C(   625465156), -INT32_C(  1616009224), -INT32_C(  1158033907), -INT32_C(  1584261661), -INT32_C(  1758289320),  INT32_C(   204361050) },
+       INT32_C(         182),
+      { SIMDE_FLOAT32_C(  -537.65),      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(  -340.47),
+        SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(   368.72), SIMDE_FLOAT32_C(  -122.75), SIMDE_FLOAT32_C(  -605.52) } },
+  };
+
+  simde__m256 a, b, r;
+  simde__m256i c;
+
+  a = simde_mm256_loadu_ps(test_vec[0].a);
+  b = simde_mm256_loadu_ps(test_vec[0].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[0].c);
+  r = simde_mm256_mask_fixupimm_ps(a, test_vec[0].k, b, c, INT32_C(         135));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[0].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[1].a);
+  b = simde_mm256_loadu_ps(test_vec[1].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[1].c);
+  r = simde_mm256_mask_fixupimm_ps(a, test_vec[1].k, b, c, INT32_C(          16));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[1].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[2].a);
+  b = simde_mm256_loadu_ps(test_vec[2].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[2].c);
+  r = simde_mm256_mask_fixupimm_ps(a, test_vec[2].k, b, c, INT32_C(         182));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[2].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[3].a);
+  b = simde_mm256_loadu_ps(test_vec[3].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[3].c);
+  r = simde_mm256_mask_fixupimm_ps(a, test_vec[3].k, b, c, INT32_C(          31));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[3].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[4].a);
+  b = simde_mm256_loadu_ps(test_vec[4].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[4].c);
+  r = simde_mm256_mask_fixupimm_ps(a, test_vec[4].k, b, c, INT32_C(          10));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[4].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[5].a);
+  b = simde_mm256_loadu_ps(test_vec[5].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[5].c);
+  r = simde_mm256_mask_fixupimm_ps(a, test_vec[5].k, b, c, INT32_C(         244));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[5].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[6].a);
+  b = simde_mm256_loadu_ps(test_vec[6].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[6].c);
+  r = simde_mm256_mask_fixupimm_ps(a, test_vec[6].k, b, c, INT32_C(         145));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[6].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[7].a);
+  b = simde_mm256_loadu_ps(test_vec[7].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[7].c);
+  r = simde_mm256_mask_fixupimm_ps(a, test_vec[7].k, b, c, INT32_C(         182));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float32 values[8 * 2 * sizeof(simde__m256)];
+  simde_test_x86_random_f32x8_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__m256 a = simde_test_x86_random_extract_f32x8(i, 2, 0, values);
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m256 b = simde_test_x86_random_extract_f32x8(i, 2, 1, values);
+    simde__m256i c = simde_test_x86_random_i32x8();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    simde__m256 r;
+    SIMDE_CONSTIFY_256_(simde_mm256_mask_fixupimm_ps, r, simde_mm256_setzero_ps(), imm8, a, k, b, c);
+
+    simde_test_x86_write_f32x8(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x8(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x8(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x8(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm256_maskz_fixupimm_ps (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde__mmask8 k;
+    const simde_float32 a[8];
+    const simde_float32 b[8];
+    const int32_t c[8];
+    const int imm8;
+    const simde_float32 r[8];
+  } test_vec[] = {
+    { UINT8_C( 69),
+      {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   940.69),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -989.43),
+        SIMDE_FLOAT32_C(  -775.07), SIMDE_FLOAT32_C(  -593.92), SIMDE_FLOAT32_C(  -620.41), SIMDE_FLOAT32_C(    43.35) },
+      { SIMDE_FLOAT32_C(  -596.35),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   277.21),
+        SIMDE_FLOAT32_C(  -589.86), SIMDE_FLOAT32_C(    41.85), SIMDE_FLOAT32_C(  -572.85), SIMDE_FLOAT32_C(   447.23) },
+      { -INT32_C(   266951678),  INT32_C(  1046758520), -INT32_C(  1658184077), -INT32_C(   227928870), -INT32_C(   776419921), -INT32_C(   668170996),  INT32_C(  1544174320),  INT32_C(  2141363325) },
+       INT32_C(          64),
+      {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(     0.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(     0.00) } },
+    { UINT8_C(252),
+      { SIMDE_FLOAT32_C(    50.98), SIMDE_FLOAT32_C(   -52.38), SIMDE_FLOAT32_C(  -835.14), SIMDE_FLOAT32_C(  -418.31),
+        SIMDE_FLOAT32_C(   915.06), SIMDE_FLOAT32_C(   249.74), SIMDE_FLOAT32_C(   801.60), SIMDE_FLOAT32_C(  -744.22) },
+      { SIMDE_FLOAT32_C(   225.98), SIMDE_FLOAT32_C(  -157.56), SIMDE_FLOAT32_C(   113.96), SIMDE_FLOAT32_C(   471.85),
+        SIMDE_FLOAT32_C(   608.79), SIMDE_FLOAT32_C(   917.82), SIMDE_FLOAT32_C(  -800.62), SIMDE_FLOAT32_C(  -150.47) },
+      { -INT32_C(   244320301),  INT32_C(   902499617),  INT32_C(  1038466423), -INT32_C(    79055242),  INT32_C(   501948899), -INT32_C(   929413076), -INT32_C(  1576527126),  INT32_C(  1570750601) },
+       INT32_C(         183),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00),
+        SIMDE_FLOAT32_C(   608.79), SIMDE_FLOAT32_C(    90.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(     1.57) } },
+    { UINT8_C( 27),
+      { SIMDE_FLOAT32_C(   858.50), SIMDE_FLOAT32_C(  -868.27), SIMDE_FLOAT32_C(  -139.90), SIMDE_FLOAT32_C(  -916.57),
+        SIMDE_FLOAT32_C(  -462.20), SIMDE_FLOAT32_C(   239.69), SIMDE_FLOAT32_C(   126.79), SIMDE_FLOAT32_C(   -58.54) },
+      { SIMDE_FLOAT32_C(   974.53), SIMDE_FLOAT32_C(    64.32), SIMDE_FLOAT32_C(  -781.34), SIMDE_FLOAT32_C(  -615.33),
+        SIMDE_FLOAT32_C(  -893.82), SIMDE_FLOAT32_C(  -354.19), SIMDE_FLOAT32_C(   831.90), SIMDE_FLOAT32_C(   157.16) },
+      { -INT32_C(   678228454), -INT32_C(  1454518029),  INT32_C(   999049241),  INT32_C(  2087168308),  INT32_C(  1583755076), -INT32_C(   135854025), -INT32_C(  1230027609), -INT32_C(  1378777197) },
+       INT32_C(         149),
+      { SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(    90.00),
+        SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00) } },
+    { UINT8_C( 52),
+      { SIMDE_FLOAT32_C(   593.43), SIMDE_FLOAT32_C(   996.76), SIMDE_FLOAT32_C(   738.85), SIMDE_FLOAT32_C(   508.50),
+        SIMDE_FLOAT32_C(   246.50), SIMDE_FLOAT32_C(   540.45), SIMDE_FLOAT32_C(   764.28), SIMDE_FLOAT32_C(  -527.52) },
+      { SIMDE_FLOAT32_C(  -617.11), SIMDE_FLOAT32_C(  -121.76), SIMDE_FLOAT32_C(   944.33), SIMDE_FLOAT32_C(   991.68),
+        SIMDE_FLOAT32_C(  -203.94), SIMDE_FLOAT32_C(  -856.29), SIMDE_FLOAT32_C(  -158.79), SIMDE_FLOAT32_C(  -345.44) },
+      {  INT32_C(   441332434),  INT32_C(  1749977534),  INT32_C(   531417840),  INT32_C(   961940016),  INT32_C(   920669681), -INT32_C(  2067163396), -INT32_C(   870746520), -INT32_C(   872307974) },
+       INT32_C(         212),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   944.33), SIMDE_FLOAT32_C(     0.00),
+            -SIMDE_MATH_INFINITYF,     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00) } },
+    { UINT8_C(216),
+      { SIMDE_FLOAT32_C(  -724.56), SIMDE_FLOAT32_C(   701.31), SIMDE_FLOAT32_C(  -262.00), SIMDE_FLOAT32_C(  -186.76),
+        SIMDE_FLOAT32_C(   -59.01), SIMDE_FLOAT32_C(   864.78), SIMDE_FLOAT32_C(   754.70), SIMDE_FLOAT32_C(   -84.47) },
+      { SIMDE_FLOAT32_C(   -70.90), SIMDE_FLOAT32_C(   973.36), SIMDE_FLOAT32_C(   300.20), SIMDE_FLOAT32_C(    35.28),
+        SIMDE_FLOAT32_C(  -380.82), SIMDE_FLOAT32_C(   132.10), SIMDE_FLOAT32_C(  -807.56), SIMDE_FLOAT32_C(  -787.39) },
+      {  INT32_C(    13171253), -INT32_C(  1338972250), -INT32_C(  1969067715), -INT32_C(   527968182),  INT32_C(   390597537), -INT32_C(   971959004),  INT32_C(  1704648214), -INT32_C(    96653883) },
+       INT32_C(          39),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00),
+        SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(     0.00),      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     1.00) } },
+    { UINT8_C(236),
+      { SIMDE_FLOAT32_C(   128.86), SIMDE_FLOAT32_C(   931.29), SIMDE_FLOAT32_C(   721.11), SIMDE_FLOAT32_C(  -624.64),
+        SIMDE_FLOAT32_C(   471.74), SIMDE_FLOAT32_C(   485.39), SIMDE_FLOAT32_C(  -152.15), SIMDE_FLOAT32_C(   854.63) },
+      { SIMDE_FLOAT32_C(  -636.37), SIMDE_FLOAT32_C(  -207.82), SIMDE_FLOAT32_C(   846.32), SIMDE_FLOAT32_C(   159.69),
+        SIMDE_FLOAT32_C(   -64.11), SIMDE_FLOAT32_C(  -312.47), SIMDE_FLOAT32_C(   814.25), SIMDE_FLOAT32_C(   211.33) },
+      { -INT32_C(  1809220053), -INT32_C(   119622880),  INT32_C(  1167703866),  INT32_C(   476753927), -INT32_C(  1607323454), -INT32_C(   127559733), -INT32_C(   652255276), -INT32_C(  2050626214) },
+       INT32_C(         108),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(   159.69),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(     0.00) } },
+    { UINT8_C(162),
+      { SIMDE_FLOAT32_C(  -611.17), SIMDE_FLOAT32_C(  -447.75), SIMDE_FLOAT32_C(  -975.43), SIMDE_FLOAT32_C(   329.83),
+        SIMDE_FLOAT32_C(  -582.97), SIMDE_FLOAT32_C(   779.27), SIMDE_FLOAT32_C(  -754.65), SIMDE_FLOAT32_C(   346.13) },
+      { SIMDE_FLOAT32_C(   752.63), SIMDE_FLOAT32_C(   545.55), SIMDE_FLOAT32_C(  -618.59), SIMDE_FLOAT32_C(  -628.19),
+        SIMDE_FLOAT32_C(  -322.35), SIMDE_FLOAT32_C(  -426.15), SIMDE_FLOAT32_C(  -415.58), SIMDE_FLOAT32_C(   806.52) },
+      { -INT32_C(  1210284552), -INT32_C(   809623010), -INT32_C(  1131291764), -INT32_C(  1517866739), -INT32_C(   176586858), -INT32_C(  1940958305),  INT32_C(   133747736), -INT32_C(   425097746) },
+       INT32_C(          10),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00) } },
+    { UINT8_C(167),
+      { SIMDE_FLOAT32_C(  -494.85), SIMDE_FLOAT32_C(  -694.47), SIMDE_FLOAT32_C(  -818.12), SIMDE_FLOAT32_C(   976.89),
+        SIMDE_FLOAT32_C(   790.92), SIMDE_FLOAT32_C(    29.73), SIMDE_FLOAT32_C(   831.52), SIMDE_FLOAT32_C(  -845.45) },
+      { SIMDE_FLOAT32_C(   821.90), SIMDE_FLOAT32_C(   677.84), SIMDE_FLOAT32_C(   314.24), SIMDE_FLOAT32_C(  -242.21),
+        SIMDE_FLOAT32_C(  -634.64), SIMDE_FLOAT32_C(   128.49), SIMDE_FLOAT32_C(   969.12), SIMDE_FLOAT32_C(  -245.80) },
+      {  INT32_C(   909375323), -INT32_C(  1186664312), -INT32_C(   145757833), -INT32_C(  1248443038),  INT32_C(  1775116948), -INT32_C(  1604856549),  INT32_C(    61488510),  INT32_C(   900453082) },
+       INT32_C(         202),
+      {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(     0.00),      SIMDE_MATH_INFINITYF } },
+  };
+
+  simde__m256 a, b, r;
+  simde__m256i c;
+
+  a = simde_mm256_loadu_ps(test_vec[0].a);
+  b = simde_mm256_loadu_ps(test_vec[0].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[0].c);
+  r = simde_mm256_maskz_fixupimm_ps(test_vec[0].k, a, b, c, INT32_C(          64));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[0].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[1].a);
+  b = simde_mm256_loadu_ps(test_vec[1].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[1].c);
+  r = simde_mm256_maskz_fixupimm_ps(test_vec[1].k, a, b, c, INT32_C(         183));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[1].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[2].a);
+  b = simde_mm256_loadu_ps(test_vec[2].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[2].c);
+  r = simde_mm256_maskz_fixupimm_ps(test_vec[2].k, a, b, c, INT32_C(         149));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[2].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[3].a);
+  b = simde_mm256_loadu_ps(test_vec[3].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[3].c);
+  r = simde_mm256_maskz_fixupimm_ps(test_vec[3].k, a, b, c, INT32_C(         212));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[3].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[4].a);
+  b = simde_mm256_loadu_ps(test_vec[4].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[4].c);
+  r = simde_mm256_maskz_fixupimm_ps(test_vec[4].k, a, b, c, INT32_C(          39));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[4].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[5].a);
+  b = simde_mm256_loadu_ps(test_vec[5].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[5].c);
+  r = simde_mm256_maskz_fixupimm_ps(test_vec[5].k, a, b, c, INT32_C(         108));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[5].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[6].a);
+  b = simde_mm256_loadu_ps(test_vec[6].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[6].c);
+  r = simde_mm256_maskz_fixupimm_ps(test_vec[6].k, a, b, c, INT32_C(          10));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[6].r), 1);
+
+  a = simde_mm256_loadu_ps(test_vec[7].a);
+  b = simde_mm256_loadu_ps(test_vec[7].b);
+  c = simde_x_mm256_loadu_epi32(test_vec[7].c);
+  r = simde_mm256_maskz_fixupimm_ps(test_vec[7].k, a, b, c, INT32_C(         202));
+  simde_test_x86_assert_equal_f32x8(r, simde_mm256_loadu_ps(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float32 values[8 * 2 * sizeof(simde__m256)];
+  simde_test_x86_random_f32x8_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m256 a = simde_test_x86_random_extract_f32x8(i, 2, 0, values);
+    simde__m256 b = simde_test_x86_random_extract_f32x8(i, 2, 1, values);
+    simde__m256i c = simde_test_x86_random_i32x8();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    simde__m256 r;
+    SIMDE_CONSTIFY_256_(simde_mm256_maskz_fixupimm_ps, r, simde_mm256_setzero_ps(), imm8, k, a, b, c);
+
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_f32x8(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x8(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x8(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x8(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm512_fixupimm_ps (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde_float32 a[16];
+    const simde_float32 b[16];
+    const int32_t c[16];
+    const int imm8;
+    const simde_float32 r[16];
+  } test_vec[] = {
+    { {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -653.08),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -140.64),
+        SIMDE_FLOAT32_C(  -825.82), SIMDE_FLOAT32_C(  -279.01), SIMDE_FLOAT32_C(   902.12), SIMDE_FLOAT32_C(  -376.10),
+        SIMDE_FLOAT32_C(   812.35), SIMDE_FLOAT32_C(  -490.82), SIMDE_FLOAT32_C(  -666.64), SIMDE_FLOAT32_C(  -639.79),
+        SIMDE_FLOAT32_C(   715.91), SIMDE_FLOAT32_C(  -962.06), SIMDE_FLOAT32_C(   524.79), SIMDE_FLOAT32_C(   -57.63) },
+      { SIMDE_FLOAT32_C(  -611.63),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -962.93),
+        SIMDE_FLOAT32_C(  -810.24), SIMDE_FLOAT32_C(  -361.16), SIMDE_FLOAT32_C(  -655.64), SIMDE_FLOAT32_C(  -360.58),
+        SIMDE_FLOAT32_C(   652.40), SIMDE_FLOAT32_C(  -561.63), SIMDE_FLOAT32_C(  -896.90), SIMDE_FLOAT32_C(   595.45),
+        SIMDE_FLOAT32_C(    59.08), SIMDE_FLOAT32_C(   135.17), SIMDE_FLOAT32_C(  -174.98), SIMDE_FLOAT32_C(   291.83) },
+      {  INT32_C(    65344024), -INT32_C(  1043000603),  INT32_C(   310236860),  INT32_C(  1073926926),  INT32_C(  1299399004),  INT32_C(   912095120), -INT32_C(  1084049800),  INT32_C(   855801371),
+         INT32_C(  1966532752), -INT32_C(  1237971974), -INT32_C(   271993631), -INT32_C(   483406969), -INT32_C(  1674534388), -INT32_C(  1831629286),  INT32_C(  1599157572),  INT32_C(  1150440627) },
+       INT32_C(          60),
+      {            SIMDE_MATH_NANF,      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(  -140.64),
+        SIMDE_FLOAT32_C(     1.57),     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00),            SIMDE_MATH_NANF,
+        SIMDE_FLOAT32_C(    -0.00),     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00),
+        SIMDE_FLOAT32_C(    -1.00), SIMDE_FLOAT32_C(    -1.00), SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00),     -SIMDE_MATH_INFINITYF } },
+    { { SIMDE_FLOAT32_C(   482.09), SIMDE_FLOAT32_C(   735.25), SIMDE_FLOAT32_C(  -848.81), SIMDE_FLOAT32_C(   656.27),
+        SIMDE_FLOAT32_C(  -543.76), SIMDE_FLOAT32_C(  -946.69), SIMDE_FLOAT32_C(  -719.83), SIMDE_FLOAT32_C(  -731.41),
+        SIMDE_FLOAT32_C(  -437.51), SIMDE_FLOAT32_C(  -386.47), SIMDE_FLOAT32_C(  -371.20), SIMDE_FLOAT32_C(  -721.60),
+        SIMDE_FLOAT32_C(  -348.52), SIMDE_FLOAT32_C(  -846.41), SIMDE_FLOAT32_C(   220.77), SIMDE_FLOAT32_C(    39.85) },
+      { SIMDE_FLOAT32_C(   463.28), SIMDE_FLOAT32_C(   704.75), SIMDE_FLOAT32_C(    76.92), SIMDE_FLOAT32_C(   653.03),
+        SIMDE_FLOAT32_C(  -656.41), SIMDE_FLOAT32_C(   421.28), SIMDE_FLOAT32_C(  -707.55), SIMDE_FLOAT32_C(   995.99),
+        SIMDE_FLOAT32_C(   859.65), SIMDE_FLOAT32_C(  -604.45), SIMDE_FLOAT32_C(   591.44), SIMDE_FLOAT32_C(   -81.27),
+        SIMDE_FLOAT32_C(   530.72), SIMDE_FLOAT32_C(  -583.54), SIMDE_FLOAT32_C(  -789.43), SIMDE_FLOAT32_C(    12.82) },
+      { -INT32_C(  1259540269),  INT32_C(   732149156), -INT32_C(  1928408191), -INT32_C(  1893056907),  INT32_C(   287505868), -INT32_C(   445615310),  INT32_C(    53019591), -INT32_C(  1623596085),
+         INT32_C(  2001938131),  INT32_C(  1554184155),  INT32_C(  1072345290), -INT32_C(  1144056594),  INT32_C(  1137504529),  INT32_C(   740834404),  INT32_C(   187650623),  INT32_C(   145385781) },
+       INT32_C(         143),
+      { SIMDE_FLOAT32_C(     0.50),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(  -656.41), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    -1.00),
+        SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(    90.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(     0.50),
+            -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(    39.85) } },
+    { { SIMDE_FLOAT32_C(  -848.28), SIMDE_FLOAT32_C(  -638.24), SIMDE_FLOAT32_C(  -330.91), SIMDE_FLOAT32_C(  -392.04),
+        SIMDE_FLOAT32_C(  -584.93), SIMDE_FLOAT32_C(   -50.74), SIMDE_FLOAT32_C(  -123.45), SIMDE_FLOAT32_C(   -22.44),
+        SIMDE_FLOAT32_C(   562.79), SIMDE_FLOAT32_C(   505.35), SIMDE_FLOAT32_C(   255.96), SIMDE_FLOAT32_C(  -785.73),
+        SIMDE_FLOAT32_C(   658.94), SIMDE_FLOAT32_C(  -523.27), SIMDE_FLOAT32_C(   254.12), SIMDE_FLOAT32_C(   122.21) },
+      { SIMDE_FLOAT32_C(  -818.52), SIMDE_FLOAT32_C(  -668.97), SIMDE_FLOAT32_C(  -224.75), SIMDE_FLOAT32_C(  -474.93),
+        SIMDE_FLOAT32_C(   752.31), SIMDE_FLOAT32_C(    67.70), SIMDE_FLOAT32_C(  -478.94), SIMDE_FLOAT32_C(   611.97),
+        SIMDE_FLOAT32_C(   463.25), SIMDE_FLOAT32_C(  -887.50), SIMDE_FLOAT32_C(  -469.30), SIMDE_FLOAT32_C(    -6.03),
+        SIMDE_FLOAT32_C(  -471.04), SIMDE_FLOAT32_C(  -258.73), SIMDE_FLOAT32_C(  -993.21), SIMDE_FLOAT32_C(  -319.32) },
+      { -INT32_C(  1094245900), -INT32_C(  1073827375), -INT32_C(   696595003),  INT32_C(   572081854), -INT32_C(  1035058813), -INT32_C(   926056813),  INT32_C(  1993373671),  INT32_C(  1776308085),
+         INT32_C(  1093183344),  INT32_C(   486614616), -INT32_C(  1309443085),  INT32_C(  1171459266), -INT32_C(   519626162), -INT32_C(  2018847328), -INT32_C(  1040352692),  INT32_C(   975953354) },
+       INT32_C(         133),
+      { SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00),     -SIMDE_MATH_INFINITYF,            SIMDE_MATH_NANF,
+        SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(    90.00),     -SIMDE_MATH_INFINITYF,      SIMDE_MATH_INFINITYF,
+            -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(  -469.30),      SIMDE_MATH_INFINITYF,
+        SIMDE_FLOAT32_C(  -471.04), SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(  -993.21), SIMDE_FLOAT32_C(     1.00) } },
+    { { SIMDE_FLOAT32_C(   103.02), SIMDE_FLOAT32_C(  -324.12), SIMDE_FLOAT32_C(   288.63), SIMDE_FLOAT32_C(   518.09),
+        SIMDE_FLOAT32_C(   625.14), SIMDE_FLOAT32_C(  -834.82), SIMDE_FLOAT32_C(  -504.35), SIMDE_FLOAT32_C(   187.94),
+        SIMDE_FLOAT32_C(   670.53), SIMDE_FLOAT32_C(   751.61), SIMDE_FLOAT32_C(   402.21), SIMDE_FLOAT32_C(   329.47),
+        SIMDE_FLOAT32_C(  -771.66), SIMDE_FLOAT32_C(  -343.67), SIMDE_FLOAT32_C(  -548.31), SIMDE_FLOAT32_C(  -590.18) },
+      { SIMDE_FLOAT32_C(   -12.64), SIMDE_FLOAT32_C(   226.93), SIMDE_FLOAT32_C(   -65.11), SIMDE_FLOAT32_C(  -260.33),
+        SIMDE_FLOAT32_C(  -705.37), SIMDE_FLOAT32_C(   455.95), SIMDE_FLOAT32_C(  -648.36), SIMDE_FLOAT32_C(   757.88),
+        SIMDE_FLOAT32_C(   568.45), SIMDE_FLOAT32_C(  -117.66), SIMDE_FLOAT32_C(  -248.14), SIMDE_FLOAT32_C(  -902.59),
+        SIMDE_FLOAT32_C(   623.60), SIMDE_FLOAT32_C(  -241.35), SIMDE_FLOAT32_C(  -221.92), SIMDE_FLOAT32_C(  -273.37) },
+      {  INT32_C(  1828420985), -INT32_C(  1172443400),  INT32_C(  1241510139), -INT32_C(  1305868526),  INT32_C(   674878684),  INT32_C(   434779727), -INT32_C(  1722608364), -INT32_C(   512307352),
+         INT32_C(  1162703180),  INT32_C(  1543465568),  INT32_C(  1839529818), -INT32_C(   501232122), -INT32_C(   234202717), -INT32_C(  1559497585),  INT32_C(  1899781641),  INT32_C(  2052240174) },
+       INT32_C(          36),
+      { SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(    -1.00),            SIMDE_MATH_NANF,
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   455.95), SIMDE_FLOAT32_C(    -1.00), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00),
+            -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(     1.57),            SIMDE_MATH_NANF,
+        SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -221.92), SIMDE_FLOAT32_C(     1.00) } },
+    { { SIMDE_FLOAT32_C(   434.53), SIMDE_FLOAT32_C(  -933.28), SIMDE_FLOAT32_C(  -755.28), SIMDE_FLOAT32_C(    59.68),
+        SIMDE_FLOAT32_C(  -768.10), SIMDE_FLOAT32_C(  -259.62), SIMDE_FLOAT32_C(  -752.38), SIMDE_FLOAT32_C(   902.43),
+        SIMDE_FLOAT32_C(  -508.01), SIMDE_FLOAT32_C(   649.83), SIMDE_FLOAT32_C(   231.90), SIMDE_FLOAT32_C(  -279.67),
+        SIMDE_FLOAT32_C(  -693.85), SIMDE_FLOAT32_C(   683.59), SIMDE_FLOAT32_C(   130.14), SIMDE_FLOAT32_C(   293.52) },
+      { SIMDE_FLOAT32_C(   -89.48), SIMDE_FLOAT32_C(  -934.97), SIMDE_FLOAT32_C(  -966.81), SIMDE_FLOAT32_C(   205.16),
+        SIMDE_FLOAT32_C(   520.98), SIMDE_FLOAT32_C(  -615.17), SIMDE_FLOAT32_C(   -36.96), SIMDE_FLOAT32_C(    89.42),
+        SIMDE_FLOAT32_C(   267.17), SIMDE_FLOAT32_C(   714.90), SIMDE_FLOAT32_C(   186.83), SIMDE_FLOAT32_C(  -109.23),
+        SIMDE_FLOAT32_C(  -526.45), SIMDE_FLOAT32_C(   964.91), SIMDE_FLOAT32_C(   617.40), SIMDE_FLOAT32_C(   908.08) },
+      {  INT32_C(  1692385033), -INT32_C(   992902210), -INT32_C(   173608878), -INT32_C(   639127479), -INT32_C(  1367543131),  INT32_C(  2116073808), -INT32_C(  1862700436),  INT32_C(   454408210),
+         INT32_C(   897578103), -INT32_C(   889630600), -INT32_C(  1967153343), -INT32_C(   178018736), -INT32_C(   391913320),  INT32_C(    90686361),  INT32_C(  1217749046), -INT32_C(  1872516584) },
+       INT32_C(         159),
+      {     -SIMDE_MATH_INFINITYF,     -SIMDE_MATH_INFINITYF,      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     1.57),
+        SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(  -752.38), SIMDE_FLOAT32_C(    89.42),
+                   SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(     0.00),      SIMDE_MATH_INFINITYF,
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   683.59),     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(    -1.00) } },
+    { { SIMDE_FLOAT32_C(  -968.37), SIMDE_FLOAT32_C(   862.12), SIMDE_FLOAT32_C(   -32.24), SIMDE_FLOAT32_C(  -736.47),
+        SIMDE_FLOAT32_C(  -397.51), SIMDE_FLOAT32_C(   215.37), SIMDE_FLOAT32_C(  -834.04), SIMDE_FLOAT32_C(    94.48),
+        SIMDE_FLOAT32_C(  -134.80), SIMDE_FLOAT32_C(   397.86), SIMDE_FLOAT32_C(   814.81), SIMDE_FLOAT32_C(   171.35),
+        SIMDE_FLOAT32_C(    81.45), SIMDE_FLOAT32_C(   -55.05), SIMDE_FLOAT32_C(  -535.13), SIMDE_FLOAT32_C(   991.98) },
+      { SIMDE_FLOAT32_C(     9.98), SIMDE_FLOAT32_C(  -501.94), SIMDE_FLOAT32_C(   197.13), SIMDE_FLOAT32_C(  -469.04),
+        SIMDE_FLOAT32_C(  -117.11), SIMDE_FLOAT32_C(  -839.83), SIMDE_FLOAT32_C(   620.38), SIMDE_FLOAT32_C(  -849.95),
+        SIMDE_FLOAT32_C(   875.07), SIMDE_FLOAT32_C(  -192.79), SIMDE_FLOAT32_C(    40.82), SIMDE_FLOAT32_C(  -651.39),
+        SIMDE_FLOAT32_C(  -227.88), SIMDE_FLOAT32_C(  -341.78), SIMDE_FLOAT32_C(  -743.31), SIMDE_FLOAT32_C(  -196.25) },
+      {  INT32_C(  1960951603), -INT32_C(  1358978978), -INT32_C(   559717818), -INT32_C(   607762622),  INT32_C(  1088433418), -INT32_C(  1501006195), -INT32_C(  1086919648),  INT32_C(    47643599),
+         INT32_C(   427276218), -INT32_C(  1647872425),  INT32_C(   461073368), -INT32_C(  1124711758), -INT32_C(    33695889),  INT32_C(  1839433037),  INT32_C(  1076746609), -INT32_C(  1891433516) },
+       INT32_C(         187),
+      { SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(     0.50),
+        SIMDE_FLOAT32_C(  -397.51),     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.50),            SIMDE_MATH_NANF,
+        SIMDE_FLOAT32_C(   875.07), SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(    40.82), SIMDE_FLOAT32_C(    90.00),
+        SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(  -535.13), SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00) } },
+    { { SIMDE_FLOAT32_C(  -479.66), SIMDE_FLOAT32_C(   224.45), SIMDE_FLOAT32_C(    67.28), SIMDE_FLOAT32_C(   122.84),
+        SIMDE_FLOAT32_C(  -560.17), SIMDE_FLOAT32_C(   233.24), SIMDE_FLOAT32_C(  -782.68), SIMDE_FLOAT32_C(   305.03),
+        SIMDE_FLOAT32_C(  -368.90), SIMDE_FLOAT32_C(  -967.87), SIMDE_FLOAT32_C(  -523.62), SIMDE_FLOAT32_C(   712.56),
+        SIMDE_FLOAT32_C(   -22.92), SIMDE_FLOAT32_C(   -58.75), SIMDE_FLOAT32_C(   704.53), SIMDE_FLOAT32_C(   987.07) },
+      { SIMDE_FLOAT32_C(   439.31), SIMDE_FLOAT32_C(   -98.34), SIMDE_FLOAT32_C(  -481.97), SIMDE_FLOAT32_C(  -677.80),
+        SIMDE_FLOAT32_C(    61.83), SIMDE_FLOAT32_C(  -861.59), SIMDE_FLOAT32_C(  -527.75), SIMDE_FLOAT32_C(   -63.10),
+        SIMDE_FLOAT32_C(   -54.38), SIMDE_FLOAT32_C(   513.07), SIMDE_FLOAT32_C(   285.51), SIMDE_FLOAT32_C(   717.74),
+        SIMDE_FLOAT32_C(  -828.70), SIMDE_FLOAT32_C(   542.20), SIMDE_FLOAT32_C(  -478.51), SIMDE_FLOAT32_C(  -308.36) },
+      {  INT32_C(   145780528), -INT32_C(  1943852070), -INT32_C(   582411667),  INT32_C(  1054492401),  INT32_C(  1034649035),  INT32_C(   712890454), -INT32_C(  1749434148), -INT32_C(  1431740038),
+        -INT32_C(  1414309423), -INT32_C(   231156091), -INT32_C(   506494480), -INT32_C(  1843418681),  INT32_C(  2093992742),  INT32_C(  2141670819), -INT32_C(  2011799539), -INT32_C(  1825390398) },
+       INT32_C(          25),
+      { SIMDE_FLOAT32_C(  -479.66), SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00),
+                   SIMDE_MATH_NANF, SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(     1.00),
+        SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(    -1.00),
+        SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(     0.00),            SIMDE_MATH_NANF } },
+    { { SIMDE_FLOAT32_C(  -233.35), SIMDE_FLOAT32_C(   588.76), SIMDE_FLOAT32_C(   814.48), SIMDE_FLOAT32_C(   206.48),
+        SIMDE_FLOAT32_C(  -178.00), SIMDE_FLOAT32_C(  -968.20), SIMDE_FLOAT32_C(  -488.50), SIMDE_FLOAT32_C(   453.11),
+        SIMDE_FLOAT32_C(  -936.07), SIMDE_FLOAT32_C(   -12.11), SIMDE_FLOAT32_C(   165.66), SIMDE_FLOAT32_C(    41.01),
+        SIMDE_FLOAT32_C(   929.14), SIMDE_FLOAT32_C(  -129.81), SIMDE_FLOAT32_C(    28.08), SIMDE_FLOAT32_C(   368.44) },
+      { SIMDE_FLOAT32_C(   771.86), SIMDE_FLOAT32_C(   546.10), SIMDE_FLOAT32_C(   690.64), SIMDE_FLOAT32_C(  -166.31),
+        SIMDE_FLOAT32_C(   684.51), SIMDE_FLOAT32_C(  -837.11), SIMDE_FLOAT32_C(   770.59), SIMDE_FLOAT32_C(  -369.87),
+        SIMDE_FLOAT32_C(   675.97), SIMDE_FLOAT32_C(    56.10), SIMDE_FLOAT32_C(  -652.14), SIMDE_FLOAT32_C(   847.26),
+        SIMDE_FLOAT32_C(  -401.70), SIMDE_FLOAT32_C(  -130.65), SIMDE_FLOAT32_C(  -461.10), SIMDE_FLOAT32_C(   364.95) },
+      { -INT32_C(  1399753028), -INT32_C(  1097965321),  INT32_C(   810659082),  INT32_C(   481108088),  INT32_C(  2073777261),  INT32_C(  1979953844), -INT32_C(  1962330766), -INT32_C(   685094885),
+        -INT32_C(  1232880706),  INT32_C(   628363547),  INT32_C(   928433599),  INT32_C(  1397949414),  INT32_C(   198111063),  INT32_C(   327340449),  INT32_C(   580815623), -INT32_C(  1829123885) },
+       INT32_C(         131),
+      { SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(     0.50),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    90.00),
+        SIMDE_FLOAT32_C(    -0.00),     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(    -0.00),
+        SIMDE_FLOAT32_C(     0.50),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    -0.00),      SIMDE_MATH_INFINITYF,
+        SIMDE_FLOAT32_C(     0.50),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    -1.00) } },
+  };
+
+  simde__m512 a, b, r;
+  simde__m512i c;
+
+  a = simde_mm512_loadu_ps(test_vec[0].a);
+  b = simde_mm512_loadu_ps(test_vec[0].b);
+  c = simde_mm512_loadu_epi32(test_vec[0].c);
+  r = simde_mm512_fixupimm_ps(a, b, c, INT32_C(          60));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[0].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[1].a);
+  b = simde_mm512_loadu_ps(test_vec[1].b);
+  c = simde_mm512_loadu_epi32(test_vec[1].c);
+  r = simde_mm512_fixupimm_ps(a, b, c, INT32_C(         143));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[1].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[2].a);
+  b = simde_mm512_loadu_ps(test_vec[2].b);
+  c = simde_mm512_loadu_epi32(test_vec[2].c);
+  r = simde_mm512_fixupimm_ps(a, b, c, INT32_C(         133));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[2].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[3].a);
+  b = simde_mm512_loadu_ps(test_vec[3].b);
+  c = simde_mm512_loadu_epi32(test_vec[3].c);
+  r = simde_mm512_fixupimm_ps(a, b, c, INT32_C(          36));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[3].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[4].a);
+  b = simde_mm512_loadu_ps(test_vec[4].b);
+  c = simde_mm512_loadu_epi32(test_vec[4].c);
+  r = simde_mm512_fixupimm_ps(a, b, c, INT32_C(         159));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[4].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[5].a);
+  b = simde_mm512_loadu_ps(test_vec[5].b);
+  c = simde_mm512_loadu_epi32(test_vec[5].c);
+  r = simde_mm512_fixupimm_ps(a, b, c, INT32_C(         187));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[5].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[6].a);
+  b = simde_mm512_loadu_ps(test_vec[6].b);
+  c = simde_mm512_loadu_epi32(test_vec[6].c);
+  r = simde_mm512_fixupimm_ps(a, b, c, INT32_C(          25));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[6].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[7].a);
+  b = simde_mm512_loadu_ps(test_vec[7].b);
+  c = simde_mm512_loadu_epi32(test_vec[7].c);
+  r = simde_mm512_fixupimm_ps(a, b, c, INT32_C(         131));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float32 values[8 * 2 * sizeof(simde__m512)];
+  simde_test_x86_random_f32x16_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__m512 a = simde_test_x86_random_extract_f32x16(i, 2, 0, values);
+    simde__m512 b = simde_test_x86_random_extract_f32x16(i, 2, 1, values);
+    simde__m512i c = simde_test_x86_random_i32x16();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    simde__m512 r;
+    SIMDE_CONSTIFY_256_(simde_mm512_fixupimm_ps, r, simde_mm512_setzero_ps(), imm8, a, b, c);
+
+    simde_test_x86_write_f32x16(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_f32x16(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x16(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x16(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  fprintf(stderr, "-------------------------\n------------------------\n----------------------\n");
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm512_mask_fixupimm_ps (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde_float32 a[16];
+    const simde__mmask16 k;
+    const simde_float32 b[16];
+    const int32_t c[16];
+    const int imm8;
+    const simde_float32 r[16];
+  } test_vec[] = {
+    { {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    11.52),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   929.69),
+        SIMDE_FLOAT32_C(  -164.22), SIMDE_FLOAT32_C(  -671.22), SIMDE_FLOAT32_C(  -338.31), SIMDE_FLOAT32_C(  -943.38),
+        SIMDE_FLOAT32_C(  -204.60), SIMDE_FLOAT32_C(  -242.41), SIMDE_FLOAT32_C(  -153.78), SIMDE_FLOAT32_C(  -370.59),
+        SIMDE_FLOAT32_C(  -911.93), SIMDE_FLOAT32_C(   185.86), SIMDE_FLOAT32_C(   977.68), SIMDE_FLOAT32_C(  -572.82) },
+      UINT16_C(21745),
+      { SIMDE_FLOAT32_C(   601.56),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   151.49),
+        SIMDE_FLOAT32_C(  -526.97), SIMDE_FLOAT32_C(   665.42), SIMDE_FLOAT32_C(  -228.74), SIMDE_FLOAT32_C(  -432.59),
+        SIMDE_FLOAT32_C(  -861.10), SIMDE_FLOAT32_C(   937.48), SIMDE_FLOAT32_C(  -213.33), SIMDE_FLOAT32_C(    83.67),
+        SIMDE_FLOAT32_C(   -69.75), SIMDE_FLOAT32_C(  -946.87), SIMDE_FLOAT32_C(   372.84), SIMDE_FLOAT32_C(   140.85) },
+      {  INT32_C(   313384799),  INT32_C(  1572283312),  INT32_C(  1410692939), -INT32_C(   479587817), -INT32_C(   648402442), -INT32_C(   989262257),  INT32_C(  1641939429),  INT32_C(  1739968520),
+         INT32_C(  1601790639), -INT32_C(   792972923), -INT32_C(  1071328600), -INT32_C(   610038044),  INT32_C(   129301943), -INT32_C(   238240500), -INT32_C(   950883649),  INT32_C(   690882426) },
+       INT32_C(         105),
+      { SIMDE_FLOAT32_C(   601.56), SIMDE_FLOAT32_C(    11.52),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   929.69),
+        SIMDE_FLOAT32_C(    -1.00), SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(  -228.74), SIMDE_FLOAT32_C(    -0.00),
+        SIMDE_FLOAT32_C(  -204.60), SIMDE_FLOAT32_C(  -242.41), SIMDE_FLOAT32_C(  -153.78), SIMDE_FLOAT32_C(  -370.59),
+        SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(   185.86), SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(  -572.82) } },
+    { { SIMDE_FLOAT32_C(    64.65), SIMDE_FLOAT32_C(   971.39), SIMDE_FLOAT32_C(    70.55), SIMDE_FLOAT32_C(   900.43),
+        SIMDE_FLOAT32_C(  -699.83), SIMDE_FLOAT32_C(   732.23), SIMDE_FLOAT32_C(   957.05), SIMDE_FLOAT32_C(    95.57),
+        SIMDE_FLOAT32_C(  -510.17), SIMDE_FLOAT32_C(  -196.74), SIMDE_FLOAT32_C(   724.98), SIMDE_FLOAT32_C(  -422.10),
+        SIMDE_FLOAT32_C(   989.12), SIMDE_FLOAT32_C(   702.66), SIMDE_FLOAT32_C(     5.08), SIMDE_FLOAT32_C(   590.68) },
+      UINT16_C(17880),
+      { SIMDE_FLOAT32_C(     6.22), SIMDE_FLOAT32_C(  -183.08), SIMDE_FLOAT32_C(  -257.83), SIMDE_FLOAT32_C(   479.25),
+        SIMDE_FLOAT32_C(  -517.66), SIMDE_FLOAT32_C(   513.43), SIMDE_FLOAT32_C(  -953.35), SIMDE_FLOAT32_C(  -378.76),
+        SIMDE_FLOAT32_C(   450.92), SIMDE_FLOAT32_C(  -166.68), SIMDE_FLOAT32_C(   704.91), SIMDE_FLOAT32_C(  -618.84),
+        SIMDE_FLOAT32_C(  -113.55), SIMDE_FLOAT32_C(    77.75), SIMDE_FLOAT32_C(   522.02), SIMDE_FLOAT32_C(   951.10) },
+      { -INT32_C(   484998722), -INT32_C(   462291903), -INT32_C(  1948177961), -INT32_C(    62264016),  INT32_C(   816187614), -INT32_C(    46718513), -INT32_C(   744185782),  INT32_C(  1293516174),
+         INT32_C(  1060122878),  INT32_C(    52666668), -INT32_C(    91290422), -INT32_C(   789128974), -INT32_C(  1358848544),  INT32_C(   145504446),  INT32_C(  1742491865), -INT32_C(   877333043) },
+       INT32_C(          37),
+      { SIMDE_FLOAT32_C(    64.65), SIMDE_FLOAT32_C(   971.39), SIMDE_FLOAT32_C(    70.55), SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00),
+        SIMDE_FLOAT32_C(  -699.83), SIMDE_FLOAT32_C(   732.23),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(     1.57),
+                   SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -196.74), SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(  -422.10),
+        SIMDE_FLOAT32_C(   989.12), SIMDE_FLOAT32_C(   702.66),      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(   590.68) } },
+    { { SIMDE_FLOAT32_C(    49.15), SIMDE_FLOAT32_C(  -407.44), SIMDE_FLOAT32_C(   851.52), SIMDE_FLOAT32_C(   349.32),
+        SIMDE_FLOAT32_C(  -675.20), SIMDE_FLOAT32_C(   808.57), SIMDE_FLOAT32_C(  -555.11), SIMDE_FLOAT32_C(  -185.38),
+        SIMDE_FLOAT32_C(  -388.17), SIMDE_FLOAT32_C(  -830.13), SIMDE_FLOAT32_C(   392.52), SIMDE_FLOAT32_C(  -399.05),
+        SIMDE_FLOAT32_C(   872.53), SIMDE_FLOAT32_C(  -602.39), SIMDE_FLOAT32_C(  -808.37), SIMDE_FLOAT32_C(  -121.25) },
+      UINT16_C(11654),
+      { SIMDE_FLOAT32_C(   214.53), SIMDE_FLOAT32_C(   -66.21), SIMDE_FLOAT32_C(  -642.00), SIMDE_FLOAT32_C(   696.86),
+        SIMDE_FLOAT32_C(  -552.78), SIMDE_FLOAT32_C(  -595.35), SIMDE_FLOAT32_C(  -681.90), SIMDE_FLOAT32_C(   898.14),
+        SIMDE_FLOAT32_C(   237.97), SIMDE_FLOAT32_C(  -976.99), SIMDE_FLOAT32_C(  -720.70), SIMDE_FLOAT32_C(  -875.58),
+        SIMDE_FLOAT32_C(   100.77), SIMDE_FLOAT32_C(   801.32), SIMDE_FLOAT32_C(  -924.49), SIMDE_FLOAT32_C(  -850.08) },
+      { -INT32_C(   466464683),  INT32_C(  1102849099), -INT32_C(   169960204), -INT32_C(   147940277), -INT32_C(  2125985883),  INT32_C(   594941294), -INT32_C(   351822879),  INT32_C(  1125748205),
+         INT32_C(   690441182),  INT32_C(  1667949679), -INT32_C(   866563712), -INT32_C(  1966897179), -INT32_C(    66385010),  INT32_C(    35619105),  INT32_C(   183314205), -INT32_C(  1840445772) },
+       INT32_C(          81),
+      { SIMDE_FLOAT32_C(    49.15), SIMDE_FLOAT32_C(   -66.21),      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(   349.32),
+        SIMDE_FLOAT32_C(  -675.20), SIMDE_FLOAT32_C(   808.57), SIMDE_FLOAT32_C(  -555.11),     -SIMDE_MATH_INFINITYF,
+                   SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -830.13), SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(     1.00),
+        SIMDE_FLOAT32_C(   872.53), SIMDE_FLOAT32_C(  -602.39), SIMDE_FLOAT32_C(  -808.37), SIMDE_FLOAT32_C(  -121.25) } },
+    { { SIMDE_FLOAT32_C(  -606.12), SIMDE_FLOAT32_C(   927.04), SIMDE_FLOAT32_C(   499.24), SIMDE_FLOAT32_C(  -281.33),
+        SIMDE_FLOAT32_C(   735.61), SIMDE_FLOAT32_C(   944.13), SIMDE_FLOAT32_C(   533.30), SIMDE_FLOAT32_C(  -652.56),
+        SIMDE_FLOAT32_C(  -886.00), SIMDE_FLOAT32_C(   -74.18), SIMDE_FLOAT32_C(   -51.61), SIMDE_FLOAT32_C(   986.53),
+        SIMDE_FLOAT32_C(   323.43), SIMDE_FLOAT32_C(   140.01), SIMDE_FLOAT32_C(  -134.72), SIMDE_FLOAT32_C(  -462.04) },
+      UINT16_C( 9817),
+      { SIMDE_FLOAT32_C(  -926.19), SIMDE_FLOAT32_C(   223.28), SIMDE_FLOAT32_C(  -765.18), SIMDE_FLOAT32_C(  -478.97),
+        SIMDE_FLOAT32_C(   627.93), SIMDE_FLOAT32_C(  -447.08), SIMDE_FLOAT32_C(  -580.83), SIMDE_FLOAT32_C(  -134.10),
+        SIMDE_FLOAT32_C(  -424.06), SIMDE_FLOAT32_C(  -301.53), SIMDE_FLOAT32_C(    -9.68), SIMDE_FLOAT32_C(   676.71),
+        SIMDE_FLOAT32_C(  -500.22), SIMDE_FLOAT32_C(    65.83), SIMDE_FLOAT32_C(   826.62), SIMDE_FLOAT32_C(  -106.34) },
+      {  INT32_C(  2104482084),  INT32_C(  1761891493), -INT32_C(   361458977), -INT32_C(  1368615538), -INT32_C(  2049603177), -INT32_C(   510948973), -INT32_C(   682173156), -INT32_C(  1040339043),
+         INT32_C(   775842952), -INT32_C(  1600699711),  INT32_C(  1669991380),  INT32_C(   940701345),  INT32_C(   331212415), -INT32_C(  1946924689), -INT32_C(  1016903130), -INT32_C(  2121965319) },
+       INT32_C(         205),
+      { SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(   927.04), SIMDE_FLOAT32_C(   499.24), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   944.13), SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(  -652.56),
+        SIMDE_FLOAT32_C(  -886.00), SIMDE_FLOAT32_C(   -74.18),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   986.53),
+        SIMDE_FLOAT32_C(   323.43), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -134.72), SIMDE_FLOAT32_C(  -462.04) } },
+    { { SIMDE_FLOAT32_C(    -7.13), SIMDE_FLOAT32_C(   325.86), SIMDE_FLOAT32_C(   612.34), SIMDE_FLOAT32_C(  -271.52),
+        SIMDE_FLOAT32_C(   269.99), SIMDE_FLOAT32_C(   145.64), SIMDE_FLOAT32_C(    75.91), SIMDE_FLOAT32_C(   383.99),
+        SIMDE_FLOAT32_C(  -928.54), SIMDE_FLOAT32_C(  -975.70), SIMDE_FLOAT32_C(   370.52), SIMDE_FLOAT32_C(   394.89),
+        SIMDE_FLOAT32_C(   164.31), SIMDE_FLOAT32_C(  -764.19), SIMDE_FLOAT32_C(   932.84), SIMDE_FLOAT32_C(   238.12) },
+      UINT16_C(17926),
+      { SIMDE_FLOAT32_C(   459.08), SIMDE_FLOAT32_C(  -832.34), SIMDE_FLOAT32_C(   759.15), SIMDE_FLOAT32_C(    87.01),
+        SIMDE_FLOAT32_C(  -279.41), SIMDE_FLOAT32_C(  -821.69), SIMDE_FLOAT32_C(   952.91), SIMDE_FLOAT32_C(   296.52),
+        SIMDE_FLOAT32_C(  -123.22), SIMDE_FLOAT32_C(   -56.77), SIMDE_FLOAT32_C(   -26.77), SIMDE_FLOAT32_C(   376.57),
+        SIMDE_FLOAT32_C(  -990.93), SIMDE_FLOAT32_C(  -200.15), SIMDE_FLOAT32_C(  -729.77), SIMDE_FLOAT32_C(     1.94) },
+      { -INT32_C(  1202529746),  INT32_C(  1320153917), -INT32_C(   382456277),  INT32_C(   892511297), -INT32_C(  1837148113), -INT32_C(  1594656741), -INT32_C(  1453014790),  INT32_C(  2096130638),
+        -INT32_C(  2110504380),  INT32_C(  1624302389),  INT32_C(  1397294354), -INT32_C(   662078551), -INT32_C(   278198061),  INT32_C(  2072993409),  INT32_C(  1814360862), -INT32_C(  1561848739) },
+       INT32_C(          86),
+      { SIMDE_FLOAT32_C(    -7.13), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(  -271.52),
+        SIMDE_FLOAT32_C(   269.99), SIMDE_FLOAT32_C(   145.64), SIMDE_FLOAT32_C(    75.91), SIMDE_FLOAT32_C(   383.99),
+        SIMDE_FLOAT32_C(  -928.54), SIMDE_FLOAT32_C(  -975.70),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   394.89),
+        SIMDE_FLOAT32_C(   164.31), SIMDE_FLOAT32_C(  -764.19), SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(   238.12) } },
+    { { SIMDE_FLOAT32_C(  -874.29), SIMDE_FLOAT32_C(   882.57), SIMDE_FLOAT32_C(   730.42), SIMDE_FLOAT32_C(   395.70),
+        SIMDE_FLOAT32_C(    28.20), SIMDE_FLOAT32_C(  -193.67), SIMDE_FLOAT32_C(  -220.31), SIMDE_FLOAT32_C(    99.66),
+        SIMDE_FLOAT32_C(  -169.37), SIMDE_FLOAT32_C(  -849.78), SIMDE_FLOAT32_C(  -505.45), SIMDE_FLOAT32_C(   994.95),
+        SIMDE_FLOAT32_C(  -613.98), SIMDE_FLOAT32_C(  -572.60), SIMDE_FLOAT32_C(   233.07), SIMDE_FLOAT32_C(   845.11) },
+      UINT16_C(62464),
+      { SIMDE_FLOAT32_C(  -404.94), SIMDE_FLOAT32_C(    -7.79), SIMDE_FLOAT32_C(   -67.88), SIMDE_FLOAT32_C(   315.64),
+        SIMDE_FLOAT32_C(   170.53), SIMDE_FLOAT32_C(  -114.97), SIMDE_FLOAT32_C(  -387.83), SIMDE_FLOAT32_C(  -952.69),
+        SIMDE_FLOAT32_C(   828.26), SIMDE_FLOAT32_C(   585.39), SIMDE_FLOAT32_C(   423.88), SIMDE_FLOAT32_C(   837.33),
+        SIMDE_FLOAT32_C(  -614.76), SIMDE_FLOAT32_C(   694.11), SIMDE_FLOAT32_C(  -160.73), SIMDE_FLOAT32_C(  -489.05) },
+      {  INT32_C(   905515756), -INT32_C(   290348443), -INT32_C(   419986309),  INT32_C(    54818931),  INT32_C(   402023155), -INT32_C(  1238608690),  INT32_C(   450003702), -INT32_C(    99692018),
+         INT32_C(  1244596452),  INT32_C(   624484522), -INT32_C(   670355611), -INT32_C(  1696903257),  INT32_C(  2142425777),  INT32_C(   473292326),  INT32_C(  1849034848), -INT32_C(  1083685670) },
+       INT32_C(          76),
+      { SIMDE_FLOAT32_C(  -874.29), SIMDE_FLOAT32_C(   882.57), SIMDE_FLOAT32_C(   730.42), SIMDE_FLOAT32_C(   395.70),
+        SIMDE_FLOAT32_C(    28.20), SIMDE_FLOAT32_C(  -193.67), SIMDE_FLOAT32_C(  -220.31), SIMDE_FLOAT32_C(    99.66),
+        SIMDE_FLOAT32_C(  -169.37), SIMDE_FLOAT32_C(  -849.78), SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(   994.95),
+        SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(   694.11), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00) } },
+    { { SIMDE_FLOAT32_C(   576.67), SIMDE_FLOAT32_C(  -430.32), SIMDE_FLOAT32_C(   906.65), SIMDE_FLOAT32_C(  -395.12),
+        SIMDE_FLOAT32_C(   376.01), SIMDE_FLOAT32_C(  -313.66), SIMDE_FLOAT32_C(   704.54), SIMDE_FLOAT32_C(  -793.36),
+        SIMDE_FLOAT32_C(  -163.44), SIMDE_FLOAT32_C(  -800.91), SIMDE_FLOAT32_C(  -798.41), SIMDE_FLOAT32_C(   222.58),
+        SIMDE_FLOAT32_C(  -373.52), SIMDE_FLOAT32_C(   434.65), SIMDE_FLOAT32_C(    67.68), SIMDE_FLOAT32_C(   221.54) },
+      UINT16_C(16760),
+      { SIMDE_FLOAT32_C(  -573.13), SIMDE_FLOAT32_C(   999.80), SIMDE_FLOAT32_C(  -462.82), SIMDE_FLOAT32_C(   597.40),
+        SIMDE_FLOAT32_C(  -115.17), SIMDE_FLOAT32_C(   149.35), SIMDE_FLOAT32_C(   644.71), SIMDE_FLOAT32_C(  -286.90),
+        SIMDE_FLOAT32_C(  -265.26), SIMDE_FLOAT32_C(    68.58), SIMDE_FLOAT32_C(  -449.57), SIMDE_FLOAT32_C(   119.98),
+        SIMDE_FLOAT32_C(  -237.31), SIMDE_FLOAT32_C(   389.69), SIMDE_FLOAT32_C(   630.93), SIMDE_FLOAT32_C(  -660.64) },
+      {  INT32_C(   678550812), -INT32_C(  1854465866),  INT32_C(  1700997555), -INT32_C(   565999192), -INT32_C(   605641819),  INT32_C(  2048966674), -INT32_C(  2012058497), -INT32_C(  2134209693),
+         INT32_C(   514341736),  INT32_C(   112205651), -INT32_C(   244640952),  INT32_C(  1120906909),  INT32_C(  1679734098), -INT32_C(   169984395),  INT32_C(   243134890), -INT32_C(   460437636) },
+       INT32_C(         130),
+      { SIMDE_FLOAT32_C(   576.67), SIMDE_FLOAT32_C(  -430.32), SIMDE_FLOAT32_C(   906.65), SIMDE_FLOAT32_C(     1.57),
+        SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -793.36),
+        SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(  -800.91), SIMDE_FLOAT32_C(  -798.41), SIMDE_FLOAT32_C(   222.58),
+        SIMDE_FLOAT32_C(  -373.52), SIMDE_FLOAT32_C(   434.65), SIMDE_FLOAT32_C(    67.68), SIMDE_FLOAT32_C(   221.54) } },
+    { { SIMDE_FLOAT32_C(   959.37), SIMDE_FLOAT32_C(   537.58), SIMDE_FLOAT32_C(   -55.76), SIMDE_FLOAT32_C(   335.39),
+        SIMDE_FLOAT32_C(  -776.08), SIMDE_FLOAT32_C(  -351.23), SIMDE_FLOAT32_C(   542.03), SIMDE_FLOAT32_C(    60.48),
+        SIMDE_FLOAT32_C(  -152.14), SIMDE_FLOAT32_C(   743.62), SIMDE_FLOAT32_C(  -716.94), SIMDE_FLOAT32_C(   474.34),
+        SIMDE_FLOAT32_C(   178.27), SIMDE_FLOAT32_C(   350.74), SIMDE_FLOAT32_C(  -304.11), SIMDE_FLOAT32_C(   605.14) },
+      UINT16_C(45909),
+      { SIMDE_FLOAT32_C(   350.54), SIMDE_FLOAT32_C(   233.07), SIMDE_FLOAT32_C(   202.54), SIMDE_FLOAT32_C(  -764.62),
+        SIMDE_FLOAT32_C(  -617.58), SIMDE_FLOAT32_C(  -152.76), SIMDE_FLOAT32_C(   -51.53), SIMDE_FLOAT32_C(   117.16),
+        SIMDE_FLOAT32_C(   915.82), SIMDE_FLOAT32_C(   498.90), SIMDE_FLOAT32_C(  -762.86), SIMDE_FLOAT32_C(  -321.49),
+        SIMDE_FLOAT32_C(  -111.41), SIMDE_FLOAT32_C(   868.08), SIMDE_FLOAT32_C(    17.87), SIMDE_FLOAT32_C(  -152.03) },
+      {  INT32_C(  1220976348),  INT32_C(  1593205647), -INT32_C(  1005369178), -INT32_C(  1962768212), -INT32_C(    75715459),  INT32_C(  1212348602), -INT32_C(   545339940),  INT32_C(  2006111387),
+         INT32_C(    29317490),  INT32_C(  1650439868), -INT32_C(  1423543554),  INT32_C(  2016815354), -INT32_C(  1888242987), -INT32_C(  2032618070),  INT32_C(   359028346), -INT32_C(  1668417494) },
+       INT32_C(          81),
+      {     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(   537.58), SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(   335.39),
+        SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(  -351.23), SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(    60.48),
+        SIMDE_FLOAT32_C(  -152.14),      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(  -716.94), SIMDE_FLOAT32_C(   474.34),
+        SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -304.11), SIMDE_FLOAT32_C(    90.00) } },
+  };
+
+  simde__m512 a, b, r;
+  simde__m512i c;
+
+  a = simde_mm512_loadu_ps(test_vec[0].a);
+  b = simde_mm512_loadu_ps(test_vec[0].b);
+  c = simde_mm512_loadu_epi32(test_vec[0].c);
+  r = simde_mm512_mask_fixupimm_ps(a, test_vec[0].k, b, c, INT32_C(         105));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[0].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[1].a);
+  b = simde_mm512_loadu_ps(test_vec[1].b);
+  c = simde_mm512_loadu_epi32(test_vec[1].c);
+  r = simde_mm512_mask_fixupimm_ps(a, test_vec[1].k, b, c, INT32_C(          37));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[1].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[2].a);
+  b = simde_mm512_loadu_ps(test_vec[2].b);
+  c = simde_mm512_loadu_epi32(test_vec[2].c);
+  r = simde_mm512_mask_fixupimm_ps(a, test_vec[2].k, b, c, INT32_C(          81));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[2].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[3].a);
+  b = simde_mm512_loadu_ps(test_vec[3].b);
+  c = simde_mm512_loadu_epi32(test_vec[3].c);
+  r = simde_mm512_mask_fixupimm_ps(a, test_vec[3].k, b, c, INT32_C(         205));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[3].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[4].a);
+  b = simde_mm512_loadu_ps(test_vec[4].b);
+  c = simde_mm512_loadu_epi32(test_vec[4].c);
+  r = simde_mm512_mask_fixupimm_ps(a, test_vec[4].k, b, c, INT32_C(          86));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[4].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[5].a);
+  b = simde_mm512_loadu_ps(test_vec[5].b);
+  c = simde_mm512_loadu_epi32(test_vec[5].c);
+  r = simde_mm512_mask_fixupimm_ps(a, test_vec[5].k, b, c, INT32_C(          76));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[5].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[6].a);
+  b = simde_mm512_loadu_ps(test_vec[6].b);
+  c = simde_mm512_loadu_epi32(test_vec[6].c);
+  r = simde_mm512_mask_fixupimm_ps(a, test_vec[6].k, b, c, INT32_C(         130));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[6].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[7].a);
+  b = simde_mm512_loadu_ps(test_vec[7].b);
+  c = simde_mm512_loadu_epi32(test_vec[7].c);
+  r = simde_mm512_mask_fixupimm_ps(a, test_vec[7].k, b, c, INT32_C(          81));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float32 values[8 * 2 * sizeof(simde__m512)];
+  simde_test_x86_random_f32x16_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__m512 a = simde_test_x86_random_extract_f32x16(i, 2, 0, values);
+    simde__mmask16 k = simde_test_x86_random_mmask16();
+    simde__m512 b = simde_test_x86_random_extract_f32x16(i, 2, 1, values);
+    simde__m512i c = simde_test_x86_random_i32x16();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    simde__m512 r;
+    SIMDE_CONSTIFY_256_(simde_mm512_mask_fixupimm_ps, r, simde_mm512_setzero_ps(), imm8, a, k, b, c);
+
+    simde_test_x86_write_f32x16(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_mmask16(2, k, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x16(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x16(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x16(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  fprintf(stderr, "-------------------------\n------------------------\n----------------------\n");
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm512_maskz_fixupimm_ps (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde__mmask16 k;
+    const simde_float32 a[16];
+    const simde_float32 b[16];
+    const int32_t c[16];
+    const int imm8;
+    const simde_float32 r[16];
+  } test_vec[] = {
+    { UINT16_C( 4530),
+      {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -915.59),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -611.87),
+        SIMDE_FLOAT32_C(   972.93), SIMDE_FLOAT32_C(  -368.90), SIMDE_FLOAT32_C(   180.66), SIMDE_FLOAT32_C(   295.65),
+        SIMDE_FLOAT32_C(  -338.99), SIMDE_FLOAT32_C(  -384.12), SIMDE_FLOAT32_C(  -256.69), SIMDE_FLOAT32_C(  -116.90),
+        SIMDE_FLOAT32_C(   336.00), SIMDE_FLOAT32_C(   767.24), SIMDE_FLOAT32_C(   339.49), SIMDE_FLOAT32_C(  -776.36) },
+      { SIMDE_FLOAT32_C(   426.32),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   200.37),
+        SIMDE_FLOAT32_C(   186.37), SIMDE_FLOAT32_C(   203.64), SIMDE_FLOAT32_C(  -405.80), SIMDE_FLOAT32_C(   404.64),
+        SIMDE_FLOAT32_C(   860.07), SIMDE_FLOAT32_C(   721.39), SIMDE_FLOAT32_C(  -837.45), SIMDE_FLOAT32_C(    -5.34),
+        SIMDE_FLOAT32_C(   413.01), SIMDE_FLOAT32_C(  -154.92), SIMDE_FLOAT32_C(  -941.34), SIMDE_FLOAT32_C(  -275.03) },
+      { -INT32_C(   156968499),  INT32_C(   704587896), -INT32_C(  2049974577),  INT32_C(   866252229), -INT32_C(   574602056),  INT32_C(  1633063746),  INT32_C(  2001845234),  INT32_C(  1971848104),
+         INT32_C(  1416310236),  INT32_C(   612264533),  INT32_C(   246041929), -INT32_C(    79541438), -INT32_C(   774372721), -INT32_C(  2009976938), -INT32_C(  1828748310),  INT32_C(  1661438087) },
+       INT32_C(         181),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     1.57),      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(    -0.00),
+             SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00) } },
+    { UINT16_C(14045),
+      { SIMDE_FLOAT32_C(   -70.51), SIMDE_FLOAT32_C(  -358.94), SIMDE_FLOAT32_C(   113.10), SIMDE_FLOAT32_C(   -97.59),
+        SIMDE_FLOAT32_C(   272.16), SIMDE_FLOAT32_C(  -706.25), SIMDE_FLOAT32_C(  -801.94), SIMDE_FLOAT32_C(   933.18),
+        SIMDE_FLOAT32_C(   -90.36), SIMDE_FLOAT32_C(   -58.63), SIMDE_FLOAT32_C(  -183.72), SIMDE_FLOAT32_C(  -754.36),
+        SIMDE_FLOAT32_C(  -291.39), SIMDE_FLOAT32_C(  -844.23), SIMDE_FLOAT32_C(  -530.72), SIMDE_FLOAT32_C(  -865.07) },
+      { SIMDE_FLOAT32_C(   -64.89), SIMDE_FLOAT32_C(  -143.98), SIMDE_FLOAT32_C(   335.30), SIMDE_FLOAT32_C(  -878.52),
+        SIMDE_FLOAT32_C(  -940.34), SIMDE_FLOAT32_C(   929.50), SIMDE_FLOAT32_C(   526.12), SIMDE_FLOAT32_C(   919.74),
+        SIMDE_FLOAT32_C(   650.89), SIMDE_FLOAT32_C(   688.67), SIMDE_FLOAT32_C(   -85.61), SIMDE_FLOAT32_C(    63.90),
+        SIMDE_FLOAT32_C(  -466.25), SIMDE_FLOAT32_C(   -26.95), SIMDE_FLOAT32_C(   788.87), SIMDE_FLOAT32_C(   463.23) },
+      { -INT32_C(   662493650),  INT32_C(  1998833205), -INT32_C(  1720077631), -INT32_C(  1245180029), -INT32_C(  1757826409),  INT32_C(  1277149252), -INT32_C(   608185309),  INT32_C(   202480862),
+        -INT32_C(   119171645),  INT32_C(   477038683),  INT32_C(  1052108987), -INT32_C(  1879802120),  INT32_C(  1965436208),  INT32_C(   281101805), -INT32_C(   135495655), -INT32_C(   553321188) },
+       INT32_C(         146),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(    -1.00),      SIMDE_MATH_INFINITYF,
+        SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(   933.18),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   688.67), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(     0.00),
+             SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(  -844.23), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00) } },
+    { UINT16_C(18161),
+      { SIMDE_FLOAT32_C(   614.11), SIMDE_FLOAT32_C(   -98.04), SIMDE_FLOAT32_C(  -634.35), SIMDE_FLOAT32_C(  -113.73),
+        SIMDE_FLOAT32_C(   195.71), SIMDE_FLOAT32_C(  -436.29), SIMDE_FLOAT32_C(  -180.56), SIMDE_FLOAT32_C(  -894.65),
+        SIMDE_FLOAT32_C(   505.08), SIMDE_FLOAT32_C(   635.72), SIMDE_FLOAT32_C(  -649.01), SIMDE_FLOAT32_C(  -786.31),
+        SIMDE_FLOAT32_C(   791.49), SIMDE_FLOAT32_C(  -179.73), SIMDE_FLOAT32_C(  -651.38), SIMDE_FLOAT32_C(  -273.39) },
+      { SIMDE_FLOAT32_C(   676.29), SIMDE_FLOAT32_C(   683.92), SIMDE_FLOAT32_C(  -151.91), SIMDE_FLOAT32_C(   735.95),
+        SIMDE_FLOAT32_C(   613.41), SIMDE_FLOAT32_C(  -625.79), SIMDE_FLOAT32_C(   655.69), SIMDE_FLOAT32_C(   264.30),
+        SIMDE_FLOAT32_C(  -937.12), SIMDE_FLOAT32_C(  -429.92), SIMDE_FLOAT32_C(  -671.80), SIMDE_FLOAT32_C(  -403.37),
+        SIMDE_FLOAT32_C(   543.13), SIMDE_FLOAT32_C(  -882.94), SIMDE_FLOAT32_C(  -940.14), SIMDE_FLOAT32_C(   157.24) },
+      { -INT32_C(  1087394807), -INT32_C(   549640213), -INT32_C(   586388042), -INT32_C(  1557988894), -INT32_C(   182240247),  INT32_C(   938688563), -INT32_C(   148863713),  INT32_C(  2084377203),
+        -INT32_C(  1455723330),  INT32_C(  1250457747), -INT32_C(   936930074), -INT32_C(  1754510963), -INT32_C(  1181970555), -INT32_C(   269451313),  INT32_C(  2028343557), -INT32_C(   504093917) },
+       INT32_C(         144),
+      { SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(    -0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00) } },
+    { UINT16_C( 5032),
+      { SIMDE_FLOAT32_C(    19.02), SIMDE_FLOAT32_C(  -574.49), SIMDE_FLOAT32_C(  -956.50), SIMDE_FLOAT32_C(  -785.26),
+        SIMDE_FLOAT32_C(   -10.78), SIMDE_FLOAT32_C(  -137.05), SIMDE_FLOAT32_C(  -679.91), SIMDE_FLOAT32_C(  -505.71),
+        SIMDE_FLOAT32_C(  -501.33), SIMDE_FLOAT32_C(  -328.92), SIMDE_FLOAT32_C(  -292.02), SIMDE_FLOAT32_C(  -709.84),
+        SIMDE_FLOAT32_C(   491.34), SIMDE_FLOAT32_C(    56.60), SIMDE_FLOAT32_C(    16.77), SIMDE_FLOAT32_C(   167.63) },
+      { SIMDE_FLOAT32_C(  -259.48), SIMDE_FLOAT32_C(   864.86), SIMDE_FLOAT32_C(   -96.41), SIMDE_FLOAT32_C(  -646.07),
+        SIMDE_FLOAT32_C(  -760.93), SIMDE_FLOAT32_C(  -440.72), SIMDE_FLOAT32_C(   618.23), SIMDE_FLOAT32_C(  -698.05),
+        SIMDE_FLOAT32_C(   129.36), SIMDE_FLOAT32_C(   946.42), SIMDE_FLOAT32_C(  -101.42), SIMDE_FLOAT32_C(  -327.51),
+        SIMDE_FLOAT32_C(  -936.52), SIMDE_FLOAT32_C(   -41.56), SIMDE_FLOAT32_C(   829.73), SIMDE_FLOAT32_C(    82.51) },
+      { -INT32_C(  1800892819), -INT32_C(  1008847529),  INT32_C(  1498571724),  INT32_C(   232268316), -INT32_C(   148972271),  INT32_C(  1243234645), -INT32_C(  1384469982),  INT32_C(  1002513102),
+         INT32_C(   147876273),  INT32_C(  1808510622),  INT32_C(   784604433),  INT32_C(  1346083903), -INT32_C(   817407622), -INT32_C(  1139187046), -INT32_C(   630549748),  INT32_C(  1729506230) },
+       INT32_C(         148),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.57),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.50),
+        SIMDE_FLOAT32_C(  -501.33),      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00) } },
+    { UINT16_C(14996),
+      { SIMDE_FLOAT32_C(   383.95), SIMDE_FLOAT32_C(   873.23), SIMDE_FLOAT32_C(   297.25), SIMDE_FLOAT32_C(  -626.83),
+        SIMDE_FLOAT32_C(  -263.82), SIMDE_FLOAT32_C(   617.33), SIMDE_FLOAT32_C(  -132.54), SIMDE_FLOAT32_C(   234.85),
+        SIMDE_FLOAT32_C(  -711.59), SIMDE_FLOAT32_C(   575.45), SIMDE_FLOAT32_C(   525.01), SIMDE_FLOAT32_C(   779.75),
+        SIMDE_FLOAT32_C(  -367.96), SIMDE_FLOAT32_C(  -458.22), SIMDE_FLOAT32_C(   -52.61), SIMDE_FLOAT32_C(   372.56) },
+      { SIMDE_FLOAT32_C(  -593.37), SIMDE_FLOAT32_C(   850.97), SIMDE_FLOAT32_C(   726.49), SIMDE_FLOAT32_C(  -354.30),
+        SIMDE_FLOAT32_C(  -589.75), SIMDE_FLOAT32_C(   344.72), SIMDE_FLOAT32_C(   -52.35), SIMDE_FLOAT32_C(   539.61),
+        SIMDE_FLOAT32_C(   291.14), SIMDE_FLOAT32_C(   846.23), SIMDE_FLOAT32_C(  -787.90), SIMDE_FLOAT32_C(   354.62),
+        SIMDE_FLOAT32_C(  -195.33), SIMDE_FLOAT32_C(  -958.17), SIMDE_FLOAT32_C(  -562.87), SIMDE_FLOAT32_C(  -811.37) },
+      {  INT32_C(  1633133981),  INT32_C(   251566035),  INT32_C(   795310311),  INT32_C(  1636892999),  INT32_C(   687119806), -INT32_C(  1907119496), -INT32_C(  2139822319), -INT32_C(  1212544999),
+        -INT32_C(  2129128787), -INT32_C(  1869670743), -INT32_C(   692062322), -INT32_C(  1237888776),  INT32_C(  1725836270), -INT32_C(   403426858),  INT32_C(   845703192),  INT32_C(   501817968) },
+       INT32_C(          52),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.50),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(    -1.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.50),
+            -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00) } },
+    { UINT16_C(11800),
+      { SIMDE_FLOAT32_C(   915.06), SIMDE_FLOAT32_C(   734.38), SIMDE_FLOAT32_C(  -438.20), SIMDE_FLOAT32_C(  -348.76),
+        SIMDE_FLOAT32_C(   351.71), SIMDE_FLOAT32_C(   429.26), SIMDE_FLOAT32_C(   886.09), SIMDE_FLOAT32_C(   640.12),
+        SIMDE_FLOAT32_C(     4.71), SIMDE_FLOAT32_C(   411.10), SIMDE_FLOAT32_C(   419.87), SIMDE_FLOAT32_C(   636.75),
+        SIMDE_FLOAT32_C(   952.88), SIMDE_FLOAT32_C(  -632.74), SIMDE_FLOAT32_C(     9.31), SIMDE_FLOAT32_C(  -640.49) },
+      { SIMDE_FLOAT32_C(  -781.77), SIMDE_FLOAT32_C(  -264.20), SIMDE_FLOAT32_C(     5.21), SIMDE_FLOAT32_C(  -371.51),
+        SIMDE_FLOAT32_C(  -919.48), SIMDE_FLOAT32_C(   952.86), SIMDE_FLOAT32_C(  -831.90), SIMDE_FLOAT32_C(   371.66),
+        SIMDE_FLOAT32_C(   799.09), SIMDE_FLOAT32_C(  -619.80), SIMDE_FLOAT32_C(  -273.72), SIMDE_FLOAT32_C(  -396.24),
+        SIMDE_FLOAT32_C(  -577.97), SIMDE_FLOAT32_C(   163.41), SIMDE_FLOAT32_C(  -207.61), SIMDE_FLOAT32_C(  -662.91) },
+      {  INT32_C(   757442158), -INT32_C(  1283580548), -INT32_C(  1293980460), -INT32_C(   958089774),  INT32_C(    70188188),  INT32_C(   388472366),  INT32_C(  1511611323), -INT32_C(  1484246727),
+         INT32_C(  1423224279), -INT32_C(  1643687222), -INT32_C(  1873680706),  INT32_C(   945173915),  INT32_C(  1614578737), -INT32_C(   562601182), -INT32_C(   130510657), -INT32_C(  1717583679) },
+       INT32_C(         109),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),     -SIMDE_MATH_INFINITYF,
+            -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(   419.87), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00) } },
+    { UINT16_C(62662),
+      { SIMDE_FLOAT32_C(  -102.21), SIMDE_FLOAT32_C(   354.19), SIMDE_FLOAT32_C(   -11.66), SIMDE_FLOAT32_C(  -750.50),
+        SIMDE_FLOAT32_C(  -216.55), SIMDE_FLOAT32_C(  -125.57), SIMDE_FLOAT32_C(   889.62), SIMDE_FLOAT32_C(   788.16),
+        SIMDE_FLOAT32_C(  -714.47), SIMDE_FLOAT32_C(   309.50), SIMDE_FLOAT32_C(   424.91), SIMDE_FLOAT32_C(  -761.59),
+        SIMDE_FLOAT32_C(   676.76), SIMDE_FLOAT32_C(  -565.77), SIMDE_FLOAT32_C(  -402.08), SIMDE_FLOAT32_C(   894.99) },
+      { SIMDE_FLOAT32_C(   170.03), SIMDE_FLOAT32_C(   603.13), SIMDE_FLOAT32_C(  -476.52), SIMDE_FLOAT32_C(   250.55),
+        SIMDE_FLOAT32_C(   555.99), SIMDE_FLOAT32_C(  -308.42), SIMDE_FLOAT32_C(  -377.79), SIMDE_FLOAT32_C(   355.08),
+        SIMDE_FLOAT32_C(    71.78), SIMDE_FLOAT32_C(   348.49), SIMDE_FLOAT32_C(   958.85), SIMDE_FLOAT32_C(   493.81),
+        SIMDE_FLOAT32_C(  -488.10), SIMDE_FLOAT32_C(  -248.76), SIMDE_FLOAT32_C(   830.90), SIMDE_FLOAT32_C(   409.69) },
+      {  INT32_C(   668697814),  INT32_C(  1801221653), -INT32_C(   336556626),  INT32_C(  1699615469),  INT32_C(   687148528), -INT32_C(  1528252667),  INT32_C(  1025004880),  INT32_C(  1664212621),
+         INT32_C(  2005535842),  INT32_C(   837019267),  INT32_C(  1629279091), -INT32_C(   691639323),  INT32_C(  2130623352), -INT32_C(  1037899918), -INT32_C(   906020292),  INT32_C(  2066493720) },
+       INT32_C(          61),
+      { SIMDE_FLOAT32_C(     0.00),      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.57),      SIMDE_MATH_INFINITYF,
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(    -0.00) } },
+    { UINT16_C(54684),
+      { SIMDE_FLOAT32_C(  -894.58), SIMDE_FLOAT32_C(  -180.76), SIMDE_FLOAT32_C(   659.19), SIMDE_FLOAT32_C(  -111.12),
+        SIMDE_FLOAT32_C(   693.67), SIMDE_FLOAT32_C(   548.82), SIMDE_FLOAT32_C(  -322.96), SIMDE_FLOAT32_C(   979.20),
+        SIMDE_FLOAT32_C(  -141.69), SIMDE_FLOAT32_C(  -898.05), SIMDE_FLOAT32_C(  -782.40), SIMDE_FLOAT32_C(  -464.93),
+        SIMDE_FLOAT32_C(  -463.82), SIMDE_FLOAT32_C(  -184.48), SIMDE_FLOAT32_C(  -569.93), SIMDE_FLOAT32_C(   706.20) },
+      { SIMDE_FLOAT32_C(  -581.35), SIMDE_FLOAT32_C(   -46.46), SIMDE_FLOAT32_C(   -43.25), SIMDE_FLOAT32_C(   974.64),
+        SIMDE_FLOAT32_C(   645.12), SIMDE_FLOAT32_C(   578.96), SIMDE_FLOAT32_C(   329.73), SIMDE_FLOAT32_C(  -283.11),
+        SIMDE_FLOAT32_C(   -72.55), SIMDE_FLOAT32_C(   288.57), SIMDE_FLOAT32_C(  -789.30), SIMDE_FLOAT32_C(   439.35),
+        SIMDE_FLOAT32_C(  -960.19), SIMDE_FLOAT32_C(  -958.40), SIMDE_FLOAT32_C(  -150.96), SIMDE_FLOAT32_C(  -854.77) },
+      {  INT32_C(   245895410),  INT32_C(   930713201),  INT32_C(  1660088932), -INT32_C(  1840683664),  INT32_C(   667780647),  INT32_C(  2086200655),  INT32_C(  1395823968),  INT32_C(  1210634070),
+         INT32_C(  1347867103), -INT32_C(  1014509473),  INT32_C(   841316802),  INT32_C(   113536990),  INT32_C(  1143837173), -INT32_C(   675248777),  INT32_C(  1881862938), -INT32_C(  1581755454) },
+       INT32_C(          36),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    -1.00),
+                   SIMDE_MATH_NANF, SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(  -141.69), SIMDE_FLOAT32_C(     0.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(     0.00),
+            -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -569.93), SIMDE_FLOAT32_C(  -854.77) } },
+  };
+
+  simde__m512 a, b, r;
+  simde__m512i c;
+
+  a = simde_mm512_loadu_ps(test_vec[0].a);
+  b = simde_mm512_loadu_ps(test_vec[0].b);
+  c = simde_mm512_loadu_epi32(test_vec[0].c);
+  r = simde_mm512_maskz_fixupimm_ps(test_vec[0].k, a, b, c, INT32_C(         181));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[0].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[1].a);
+  b = simde_mm512_loadu_ps(test_vec[1].b);
+  c = simde_mm512_loadu_epi32(test_vec[1].c);
+  r = simde_mm512_maskz_fixupimm_ps(test_vec[1].k, a, b, c, INT32_C(         146));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[1].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[2].a);
+  b = simde_mm512_loadu_ps(test_vec[2].b);
+  c = simde_mm512_loadu_epi32(test_vec[2].c);
+  r = simde_mm512_maskz_fixupimm_ps(test_vec[2].k, a, b, c, INT32_C(         144));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[2].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[3].a);
+  b = simde_mm512_loadu_ps(test_vec[3].b);
+  c = simde_mm512_loadu_epi32(test_vec[3].c);
+  r = simde_mm512_maskz_fixupimm_ps(test_vec[3].k, a, b, c, INT32_C(         148));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[3].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[4].a);
+  b = simde_mm512_loadu_ps(test_vec[4].b);
+  c = simde_mm512_loadu_epi32(test_vec[4].c);
+  r = simde_mm512_maskz_fixupimm_ps(test_vec[4].k, a, b, c, INT32_C(          52));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[4].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[5].a);
+  b = simde_mm512_loadu_ps(test_vec[5].b);
+  c = simde_mm512_loadu_epi32(test_vec[5].c);
+  r = simde_mm512_maskz_fixupimm_ps(test_vec[5].k, a, b, c, INT32_C(         109));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[5].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[6].a);
+  b = simde_mm512_loadu_ps(test_vec[6].b);
+  c = simde_mm512_loadu_epi32(test_vec[6].c);
+  r = simde_mm512_maskz_fixupimm_ps(test_vec[6].k, a, b, c, INT32_C(          61));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[6].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[7].a);
+  b = simde_mm512_loadu_ps(test_vec[7].b);
+  c = simde_mm512_loadu_epi32(test_vec[7].c);
+  r = simde_mm512_maskz_fixupimm_ps(test_vec[7].k, a, b, c, INT32_C(          36));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float32 values[8 * 2 * sizeof(simde__m512)];
+  simde_test_x86_random_f32x16_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__mmask16 k = simde_test_x86_random_mmask16();
+    simde__m512 a = simde_test_x86_random_extract_f32x16(i, 2, 0, values);
+    simde__m512 b = simde_test_x86_random_extract_f32x16(i, 2, 1, values);
+    simde__m512i c = simde_test_x86_random_i32x16();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    simde__m512 r;
+    SIMDE_CONSTIFY_256_(simde_mm512_maskz_fixupimm_ps, r, simde_mm512_setzero_ps(), imm8, k, a, b, c);
+
+    simde_test_x86_write_mmask16(2, k, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_f32x16(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x16(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x16(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x16(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  fprintf(stderr, "-------------------------\n------------------------\n----------------------\n");
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm_fixupimm_ss (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde_float32 a[4];
+    const simde_float32 b[4];
+    const int32_t c[4];
+    const int imm8;
+    const simde_float32 r[4];
+  } test_vec[] = {
+    { {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -551.70),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   860.02) },
+      { SIMDE_FLOAT32_C(  -735.62),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   790.88) },
+      { -INT32_C(  1265195033),  INT32_C(   140789386), -INT32_C(  1899312875), -INT32_C(  1770193656) },
+       INT32_C(         221),
+      {     -SIMDE_MATH_INFINITYF,            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   790.88) } },
+    { { SIMDE_FLOAT32_C(  -566.66), SIMDE_FLOAT32_C(  -571.40), SIMDE_FLOAT32_C(  -782.02), SIMDE_FLOAT32_C(   251.94) },
+      { SIMDE_FLOAT32_C(   742.03), SIMDE_FLOAT32_C(  -460.96), SIMDE_FLOAT32_C(  -135.23), SIMDE_FLOAT32_C(  -190.10) },
+      { -INT32_C(  1353407648),  INT32_C(  1058776384), -INT32_C(  1024844325),  INT32_C(  1316389060) },
+       INT32_C(         198),
+      { SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(  -460.96), SIMDE_FLOAT32_C(  -135.23), SIMDE_FLOAT32_C(  -190.10) } },
+    { { SIMDE_FLOAT32_C(   660.22), SIMDE_FLOAT32_C(  -229.57), SIMDE_FLOAT32_C(    69.62), SIMDE_FLOAT32_C(   482.86) },
+      { SIMDE_FLOAT32_C(  -269.44), SIMDE_FLOAT32_C(   498.43), SIMDE_FLOAT32_C(   544.01), SIMDE_FLOAT32_C(  -439.37) },
+      { -INT32_C(  1385619292), -INT32_C(    79436514), -INT32_C(   752182669),  INT32_C(  2122481213) },
+       INT32_C(          36),
+      { SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(   498.43), SIMDE_FLOAT32_C(   544.01), SIMDE_FLOAT32_C(  -439.37) } },
+    { { SIMDE_FLOAT32_C(  -597.94), SIMDE_FLOAT32_C(  -379.85), SIMDE_FLOAT32_C(   -27.17), SIMDE_FLOAT32_C(    48.01) },
+      { SIMDE_FLOAT32_C(  -137.68), SIMDE_FLOAT32_C(  -230.12), SIMDE_FLOAT32_C(   577.75), SIMDE_FLOAT32_C(  -764.05) },
+      {  INT32_C(  2143398075), -INT32_C(   271763672), -INT32_C(  1211489262),  INT32_C(  1650734148) },
+       INT32_C(          25),
+      { SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(  -230.12), SIMDE_FLOAT32_C(   577.75), SIMDE_FLOAT32_C(  -764.05) } },
+    { { SIMDE_FLOAT32_C(   218.17), SIMDE_FLOAT32_C(   867.81), SIMDE_FLOAT32_C(  -904.03), SIMDE_FLOAT32_C(   482.55) },
+      { SIMDE_FLOAT32_C(   374.21), SIMDE_FLOAT32_C(  -537.12), SIMDE_FLOAT32_C(   273.43), SIMDE_FLOAT32_C(   807.55) },
+      {  INT32_C(  2120255553),  INT32_C(   737993479),  INT32_C(  1009433217), -INT32_C(  1967395998) },
+       INT32_C(          34),
+      { SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(  -537.12), SIMDE_FLOAT32_C(   273.43), SIMDE_FLOAT32_C(   807.55) } },
+    { { SIMDE_FLOAT32_C(  -108.52), SIMDE_FLOAT32_C(   491.41), SIMDE_FLOAT32_C(    59.49), SIMDE_FLOAT32_C(  -366.49) },
+      { SIMDE_FLOAT32_C(  -969.54), SIMDE_FLOAT32_C(   924.26), SIMDE_FLOAT32_C(   443.40), SIMDE_FLOAT32_C(   690.68) },
+      { -INT32_C(   236174164), -INT32_C(  1856810888),  INT32_C(   941535735),  INT32_C(  1102479162) },
+       INT32_C(          98),
+      { SIMDE_FLOAT32_C(  -969.54), SIMDE_FLOAT32_C(   924.26), SIMDE_FLOAT32_C(   443.40), SIMDE_FLOAT32_C(   690.68) } },
+    { { SIMDE_FLOAT32_C(  -305.31), SIMDE_FLOAT32_C(  -486.97), SIMDE_FLOAT32_C(   173.54), SIMDE_FLOAT32_C(   425.25) },
+      { SIMDE_FLOAT32_C(  -988.54), SIMDE_FLOAT32_C(  -282.45), SIMDE_FLOAT32_C(   985.88), SIMDE_FLOAT32_C(  -586.48) },
+      { -INT32_C(   820013459), -INT32_C(  1554392447),  INT32_C(   265868130), -INT32_C(  1895775209) },
+       INT32_C(          20),
+      { SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(  -282.45), SIMDE_FLOAT32_C(   985.88), SIMDE_FLOAT32_C(  -586.48) } },
+    { { SIMDE_FLOAT32_C(   337.70), SIMDE_FLOAT32_C(   -41.29), SIMDE_FLOAT32_C(   461.53), SIMDE_FLOAT32_C(  -799.98) },
+      { SIMDE_FLOAT32_C(   728.59), SIMDE_FLOAT32_C(    39.27), SIMDE_FLOAT32_C(  -564.03), SIMDE_FLOAT32_C(   -53.24) },
+      {  INT32_C(  1061371653),  INT32_C(   545323710),  INT32_C(   436464813),  INT32_C(    65610370) },
+       INT32_C(         252),
+      {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    39.27), SIMDE_FLOAT32_C(  -564.03), SIMDE_FLOAT32_C(   -53.24) } },
+  };
+
+  simde__m128 a, b, r;
+  simde__m128i c;
+
+  a = simde_mm_loadu_ps(test_vec[0].a);
+  b = simde_mm_loadu_ps(test_vec[0].b);
+  c = simde_x_mm_loadu_epi32(test_vec[0].c);
+  r = simde_mm_fixupimm_ss(a, b, c, INT32_C(         221));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[0].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[1].a);
+  b = simde_mm_loadu_ps(test_vec[1].b);
+  c = simde_x_mm_loadu_epi32(test_vec[1].c);
+  r = simde_mm_fixupimm_ss(a, b, c, INT32_C(         198));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[1].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[2].a);
+  b = simde_mm_loadu_ps(test_vec[2].b);
+  c = simde_x_mm_loadu_epi32(test_vec[2].c);
+  r = simde_mm_fixupimm_ss(a, b, c, INT32_C(          36));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[2].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[3].a);
+  b = simde_mm_loadu_ps(test_vec[3].b);
+  c = simde_x_mm_loadu_epi32(test_vec[3].c);
+  r = simde_mm_fixupimm_ss(a, b, c, INT32_C(          25));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[3].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[4].a);
+  b = simde_mm_loadu_ps(test_vec[4].b);
+  c = simde_x_mm_loadu_epi32(test_vec[4].c);
+  r = simde_mm_fixupimm_ss(a, b, c, INT32_C(          34));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[4].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[5].a);
+  b = simde_mm_loadu_ps(test_vec[5].b);
+  c = simde_x_mm_loadu_epi32(test_vec[5].c);
+  r = simde_mm_fixupimm_ss(a, b, c, INT32_C(          98));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[5].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[6].a);
+  b = simde_mm_loadu_ps(test_vec[6].b);
+  c = simde_x_mm_loadu_epi32(test_vec[6].c);
+  r = simde_mm_fixupimm_ss(a, b, c, INT32_C(          20));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[6].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[7].a);
+  b = simde_mm_loadu_ps(test_vec[7].b);
+  c = simde_x_mm_loadu_epi32(test_vec[7].c);
+  r = simde_mm_fixupimm_ss(a, b, c, INT32_C(         252));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float32 values[8 * 2 * sizeof(simde__m128)];
+  simde_test_x86_random_f32x4_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__m128 a = simde_test_x86_random_extract_f32x4(i, 2, 0, values);
+    simde__m128 b = simde_test_x86_random_extract_f32x4(i, 2, 1, values);
+    simde__m128i c = simde_test_x86_random_i32x4();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    simde__m128 r;
+    SIMDE_CONSTIFY_256_(simde_mm_fixupimm_ss, r, simde_mm_setzero_ps(), imm8, a, b, c);
+
+    simde_test_x86_write_f32x4(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_f32x4(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x4(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x4(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm_mask_fixupimm_ss (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde_float32 a[4];
+    const simde__mmask8 k;
+    const simde_float32 b[4];
+    const int32_t c[4];
+    const int imm8;
+    const simde_float32 r[4];
+  } test_vec[] = {
+    { {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    17.73),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   583.28) },
+      UINT8_C(236),
+      { SIMDE_FLOAT32_C(    68.85),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   338.17) },
+      {  INT32_C(   205575547), -INT32_C(  1485220724),  INT32_C(   241697071), -INT32_C(  1133261982) },
+       INT32_C(         123),
+      {            SIMDE_MATH_NANF,            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   338.17) } },
+    { { SIMDE_FLOAT32_C(   817.25), SIMDE_FLOAT32_C(   -66.40), SIMDE_FLOAT32_C(   105.72), SIMDE_FLOAT32_C(   631.13) },
+      UINT8_C( 17),
+      { SIMDE_FLOAT32_C(   185.74), SIMDE_FLOAT32_C(   511.50), SIMDE_FLOAT32_C(  -859.94), SIMDE_FLOAT32_C(   913.76) },
+      {  INT32_C(   349175174), -INT32_C(  1608832262),  INT32_C(  1981548449), -INT32_C(  1677514681) },
+       INT32_C(         162),
+      { SIMDE_FLOAT32_C(   185.74), SIMDE_FLOAT32_C(   511.50), SIMDE_FLOAT32_C(  -859.94), SIMDE_FLOAT32_C(   913.76) } },
+    { { SIMDE_FLOAT32_C(  -266.07), SIMDE_FLOAT32_C(  -678.72), SIMDE_FLOAT32_C(   797.47), SIMDE_FLOAT32_C(  -873.06) },
+      UINT8_C( 18),
+      { SIMDE_FLOAT32_C(  -943.82), SIMDE_FLOAT32_C(   178.63), SIMDE_FLOAT32_C(  -914.24), SIMDE_FLOAT32_C(   532.25) },
+      {  INT32_C(  1289553625), -INT32_C(   711632446), -INT32_C(   363092243), -INT32_C(  1595576203) },
+       INT32_C(         139),
+      { SIMDE_FLOAT32_C(  -266.07), SIMDE_FLOAT32_C(   178.63), SIMDE_FLOAT32_C(  -914.24), SIMDE_FLOAT32_C(   532.25) } },
+    { { SIMDE_FLOAT32_C(  -158.88), SIMDE_FLOAT32_C(  -140.71), SIMDE_FLOAT32_C(   552.23), SIMDE_FLOAT32_C(   322.89) },
+      UINT8_C(161),
+      { SIMDE_FLOAT32_C(   792.00), SIMDE_FLOAT32_C(  -875.53), SIMDE_FLOAT32_C(   222.85), SIMDE_FLOAT32_C(  -731.62) },
+      { -INT32_C(  1161110857),  INT32_C(  1097100406),  INT32_C(   354055951), -INT32_C(  1378326700) },
+       INT32_C(         252),
+      { SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(  -875.53), SIMDE_FLOAT32_C(   222.85), SIMDE_FLOAT32_C(  -731.62) } },
+    { { SIMDE_FLOAT32_C(   142.21), SIMDE_FLOAT32_C(   394.02), SIMDE_FLOAT32_C(   851.66), SIMDE_FLOAT32_C(  -788.94) },
+      UINT8_C(  8),
+      { SIMDE_FLOAT32_C(   656.53), SIMDE_FLOAT32_C(   647.14), SIMDE_FLOAT32_C(   549.23), SIMDE_FLOAT32_C(   473.77) },
+      {  INT32_C(  1786255237), -INT32_C(   118553673),  INT32_C(  1890619798), -INT32_C(   941200805) },
+       INT32_C(         207),
+      { SIMDE_FLOAT32_C(   142.21), SIMDE_FLOAT32_C(   647.14), SIMDE_FLOAT32_C(   549.23), SIMDE_FLOAT32_C(   473.77) } },
+    { { SIMDE_FLOAT32_C(  -419.26), SIMDE_FLOAT32_C(  -345.05), SIMDE_FLOAT32_C(   104.91), SIMDE_FLOAT32_C(   766.48) },
+      UINT8_C( 65),
+      { SIMDE_FLOAT32_C(  -833.55), SIMDE_FLOAT32_C(   244.97), SIMDE_FLOAT32_C(   680.24), SIMDE_FLOAT32_C(   -99.63) },
+      { -INT32_C(   995583252), -INT32_C(   495868856),  INT32_C(  1583839558), -INT32_C(   183119374) },
+       INT32_C(         193),
+      {     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(   244.97), SIMDE_FLOAT32_C(   680.24), SIMDE_FLOAT32_C(   -99.63) } },
+    { { SIMDE_FLOAT32_C(   566.25), SIMDE_FLOAT32_C(   477.71), SIMDE_FLOAT32_C(    27.31), SIMDE_FLOAT32_C(   622.43) },
+      UINT8_C(190),
+      { SIMDE_FLOAT32_C(  -343.66), SIMDE_FLOAT32_C(   113.07), SIMDE_FLOAT32_C(   154.68), SIMDE_FLOAT32_C(   497.46) },
+      { -INT32_C(   517427717),  INT32_C(  1242101620), -INT32_C(   667530691), -INT32_C(  1759446286) },
+       INT32_C(         107),
+      { SIMDE_FLOAT32_C(   566.25), SIMDE_FLOAT32_C(   113.07), SIMDE_FLOAT32_C(   154.68), SIMDE_FLOAT32_C(   497.46) } },
+    { { SIMDE_FLOAT32_C(   972.36), SIMDE_FLOAT32_C(  -293.10), SIMDE_FLOAT32_C(  -179.65), SIMDE_FLOAT32_C(   764.37) },
+      UINT8_C(106),
+      { SIMDE_FLOAT32_C(  -168.62), SIMDE_FLOAT32_C(  -956.80), SIMDE_FLOAT32_C(  -967.26), SIMDE_FLOAT32_C(   973.59) },
+      {  INT32_C(  1362876219),  INT32_C(  1482685644), -INT32_C(    78439090),  INT32_C(  1030698309) },
+       INT32_C(          61),
+      { SIMDE_FLOAT32_C(   972.36), SIMDE_FLOAT32_C(  -956.80), SIMDE_FLOAT32_C(  -967.26), SIMDE_FLOAT32_C(   973.59) } },
+  };
+
+  simde__m128 a, b, r;
+  simde__m128i c;
+
+  a = simde_mm_loadu_ps(test_vec[0].a);
+  b = simde_mm_loadu_ps(test_vec[0].b);
+  c = simde_x_mm_loadu_epi32(test_vec[0].c);
+  r = simde_mm_mask_fixupimm_ss(a, test_vec[0].k, b, c, INT32_C(         123));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[0].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[1].a);
+  b = simde_mm_loadu_ps(test_vec[1].b);
+  c = simde_x_mm_loadu_epi32(test_vec[1].c);
+  r = simde_mm_mask_fixupimm_ss(a, test_vec[1].k, b, c, INT32_C(         162));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[1].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[2].a);
+  b = simde_mm_loadu_ps(test_vec[2].b);
+  c = simde_x_mm_loadu_epi32(test_vec[2].c);
+  r = simde_mm_mask_fixupimm_ss(a, test_vec[2].k, b, c, INT32_C(         139));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[2].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[3].a);
+  b = simde_mm_loadu_ps(test_vec[3].b);
+  c = simde_x_mm_loadu_epi32(test_vec[3].c);
+  r = simde_mm_mask_fixupimm_ss(a, test_vec[3].k, b, c, INT32_C(         252));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[3].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[4].a);
+  b = simde_mm_loadu_ps(test_vec[4].b);
+  c = simde_x_mm_loadu_epi32(test_vec[4].c);
+  r = simde_mm_mask_fixupimm_ss(a, test_vec[4].k, b, c, INT32_C(         207));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[4].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[5].a);
+  b = simde_mm_loadu_ps(test_vec[5].b);
+  c = simde_x_mm_loadu_epi32(test_vec[5].c);
+  r = simde_mm_mask_fixupimm_ss(a, test_vec[5].k, b, c, INT32_C(         193));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[5].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[6].a);
+  b = simde_mm_loadu_ps(test_vec[6].b);
+  c = simde_x_mm_loadu_epi32(test_vec[6].c);
+  r = simde_mm_mask_fixupimm_ss(a, test_vec[6].k, b, c, INT32_C(         107));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[6].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[7].a);
+  b = simde_mm_loadu_ps(test_vec[7].b);
+  c = simde_x_mm_loadu_epi32(test_vec[7].c);
+  r = simde_mm_mask_fixupimm_ss(a, test_vec[7].k, b, c, INT32_C(          61));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float32 values[8 * 2 * sizeof(simde__m128)];
+  simde_test_x86_random_f32x4_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__m128 a = simde_test_x86_random_extract_f32x4(i, 2, 0, values);
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m128 b = simde_test_x86_random_extract_f32x4(i, 2, 1, values);
+    simde__m128i c = simde_test_x86_random_i32x4();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    simde__m128 r;
+    SIMDE_CONSTIFY_256_(simde_mm_mask_fixupimm_ss, r, simde_mm_setzero_ps(), imm8, a, k, b, c);
+
+    simde_test_x86_write_f32x4(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x4(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x4(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x4(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm_maskz_fixupimm_ss (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde__mmask8 k;
+    const simde_float32 a[4];
+    const simde_float32 b[4];
+    const int32_t c[4];
+    const int imm8;
+    const simde_float32 r[4];
+  } test_vec[] = {
+    { UINT8_C(234),
+      {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -233.09),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   338.03) },
+      { SIMDE_FLOAT32_C(   938.21),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -268.29) },
+      { -INT32_C(    33940159),  INT32_C(  1492514891), -INT32_C(  1015021536),  INT32_C(   172015337) },
+       INT32_C(          98),
+      { SIMDE_FLOAT32_C(     0.00),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -268.29) } },
+    { UINT8_C(100),
+      { SIMDE_FLOAT32_C(   984.95), SIMDE_FLOAT32_C(   613.19), SIMDE_FLOAT32_C(   216.07), SIMDE_FLOAT32_C(   990.37) },
+      { SIMDE_FLOAT32_C(   512.12), SIMDE_FLOAT32_C(   530.89), SIMDE_FLOAT32_C(  -760.11), SIMDE_FLOAT32_C(  -884.63) },
+      { -INT32_C(  2020721377),  INT32_C(  2020846749),  INT32_C(   783899921),  INT32_C(  1333442135) },
+       INT32_C(         172),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   530.89), SIMDE_FLOAT32_C(  -760.11), SIMDE_FLOAT32_C(  -884.63) } },
+    { UINT8_C( 82),
+      { SIMDE_FLOAT32_C(   252.22), SIMDE_FLOAT32_C(  -949.26), SIMDE_FLOAT32_C(   957.94), SIMDE_FLOAT32_C(  -357.53) },
+      { SIMDE_FLOAT32_C(  -170.23), SIMDE_FLOAT32_C(   968.08), SIMDE_FLOAT32_C(   431.81), SIMDE_FLOAT32_C(  -235.42) },
+      {  INT32_C(  1913754930),  INT32_C(  1411806111),  INT32_C(   410291163), -INT32_C(   961152231) },
+       INT32_C(         110),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   968.08), SIMDE_FLOAT32_C(   431.81), SIMDE_FLOAT32_C(  -235.42) } },
+    { UINT8_C(230),
+      { SIMDE_FLOAT32_C(  -380.08), SIMDE_FLOAT32_C(   711.98), SIMDE_FLOAT32_C(   903.51), SIMDE_FLOAT32_C(  -241.52) },
+      { SIMDE_FLOAT32_C(  -291.25), SIMDE_FLOAT32_C(   790.88), SIMDE_FLOAT32_C(   342.11), SIMDE_FLOAT32_C(   113.51) },
+      {  INT32_C(  2140939013), -INT32_C(   497923982), -INT32_C(  1978358540),  INT32_C(   690587573) },
+       INT32_C(         173),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   790.88), SIMDE_FLOAT32_C(   342.11), SIMDE_FLOAT32_C(   113.51) } },
+    { UINT8_C(242),
+      { SIMDE_FLOAT32_C(  -442.21), SIMDE_FLOAT32_C(   668.58), SIMDE_FLOAT32_C(  -548.45), SIMDE_FLOAT32_C(  -504.00) },
+      { SIMDE_FLOAT32_C(   707.30), SIMDE_FLOAT32_C(  -856.65), SIMDE_FLOAT32_C(   227.71), SIMDE_FLOAT32_C(   692.25) },
+      { -INT32_C(   772976100), -INT32_C(   268543208),  INT32_C(  1240785958), -INT32_C(   910396288) },
+       INT32_C(         198),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -856.65), SIMDE_FLOAT32_C(   227.71), SIMDE_FLOAT32_C(   692.25) } },
+    { UINT8_C(178),
+      { SIMDE_FLOAT32_C(   756.54), SIMDE_FLOAT32_C(  -556.23), SIMDE_FLOAT32_C(   682.63), SIMDE_FLOAT32_C(   268.66) },
+      { SIMDE_FLOAT32_C(   974.66), SIMDE_FLOAT32_C(   922.52), SIMDE_FLOAT32_C(   384.03), SIMDE_FLOAT32_C(   226.89) },
+      {  INT32_C(  1899569223),  INT32_C(  1307567945),  INT32_C(  1902764319),  INT32_C(   696859342) },
+       INT32_C(          56),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   922.52), SIMDE_FLOAT32_C(   384.03), SIMDE_FLOAT32_C(   226.89) } },
+    { UINT8_C(109),
+      { SIMDE_FLOAT32_C(   973.26), SIMDE_FLOAT32_C(   341.97), SIMDE_FLOAT32_C(   869.36), SIMDE_FLOAT32_C(  -196.97) },
+      { SIMDE_FLOAT32_C(   310.05), SIMDE_FLOAT32_C(   301.17), SIMDE_FLOAT32_C(   567.61), SIMDE_FLOAT32_C(   929.98) },
+      {  INT32_C(  1440849049),  INT32_C(   603170661),  INT32_C(   829072657), -INT32_C(   965026849) },
+       INT32_C(         202),
+      {      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(   301.17), SIMDE_FLOAT32_C(   567.61), SIMDE_FLOAT32_C(   929.98) } },
+    { UINT8_C( 48),
+      { SIMDE_FLOAT32_C(    13.15), SIMDE_FLOAT32_C(   471.12), SIMDE_FLOAT32_C(  -311.54), SIMDE_FLOAT32_C(   721.89) },
+      { SIMDE_FLOAT32_C(   262.00), SIMDE_FLOAT32_C(  -969.44), SIMDE_FLOAT32_C(  -164.59), SIMDE_FLOAT32_C(   819.79) },
+      { -INT32_C(   529893033), -INT32_C(   229006686),  INT32_C(  1535887038),  INT32_C(  1321263271) },
+       INT32_C(         211),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -969.44), SIMDE_FLOAT32_C(  -164.59), SIMDE_FLOAT32_C(   819.79) } },
+  };
+
+  simde__m128 a, b, r;
+  simde__m128i c;
+
+  a = simde_mm_loadu_ps(test_vec[0].a);
+  b = simde_mm_loadu_ps(test_vec[0].b);
+  c = simde_x_mm_loadu_epi32(test_vec[0].c);
+  r = simde_mm_maskz_fixupimm_ss(test_vec[0].k, a, b, c, INT32_C(          98));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[0].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[1].a);
+  b = simde_mm_loadu_ps(test_vec[1].b);
+  c = simde_x_mm_loadu_epi32(test_vec[1].c);
+  r = simde_mm_maskz_fixupimm_ss(test_vec[1].k, a, b, c, INT32_C(         172));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[1].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[2].a);
+  b = simde_mm_loadu_ps(test_vec[2].b);
+  c = simde_x_mm_loadu_epi32(test_vec[2].c);
+  r = simde_mm_maskz_fixupimm_ss(test_vec[2].k, a, b, c, INT32_C(         110));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[2].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[3].a);
+  b = simde_mm_loadu_ps(test_vec[3].b);
+  c = simde_x_mm_loadu_epi32(test_vec[3].c);
+  r = simde_mm_maskz_fixupimm_ss(test_vec[3].k, a, b, c, INT32_C(         173));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[3].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[4].a);
+  b = simde_mm_loadu_ps(test_vec[4].b);
+  c = simde_x_mm_loadu_epi32(test_vec[4].c);
+  r = simde_mm_maskz_fixupimm_ss(test_vec[4].k, a, b, c, INT32_C(         198));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[4].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[5].a);
+  b = simde_mm_loadu_ps(test_vec[5].b);
+  c = simde_x_mm_loadu_epi32(test_vec[5].c);
+  r = simde_mm_maskz_fixupimm_ss(test_vec[5].k, a, b, c, INT32_C(          56));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[5].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[6].a);
+  b = simde_mm_loadu_ps(test_vec[6].b);
+  c = simde_x_mm_loadu_epi32(test_vec[6].c);
+  r = simde_mm_maskz_fixupimm_ss(test_vec[6].k, a, b, c, INT32_C(         202));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[6].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[7].a);
+  b = simde_mm_loadu_ps(test_vec[7].b);
+  c = simde_x_mm_loadu_epi32(test_vec[7].c);
+  r = simde_mm_maskz_fixupimm_ss(test_vec[7].k, a, b, c, INT32_C(         211));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float32 values[8 * 2 * sizeof(simde__m128)];
+  simde_test_x86_random_f32x4_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m128 a = simde_test_x86_random_extract_f32x4(i, 2, 0, values);
+    simde__m128 b = simde_test_x86_random_extract_f32x4(i, 2, 1, values);
+    simde__m128i c = simde_test_x86_random_i32x4();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    simde__m128 r;
+    SIMDE_CONSTIFY_256_(simde_mm_maskz_fixupimm_ss, r, simde_mm_setzero_ps(), imm8, k, a, b, c);
+
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_f32x4(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x4(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x4(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x4(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
 SIMDE_TEST_FUNC_LIST_BEGIN
   SIMDE_TEST_FUNC_LIST_ENTRY(mm_fixupimm_ps)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm_mask_fixupimm_ps)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm_maskz_fixupimm_ps)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_fixupimm_ps)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_mask_fixupimm_ps)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm256_maskz_fixupimm_ps)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm512_fixupimm_ps)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm512_mask_fixupimm_ps)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm512_maskz_fixupimm_ps)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_fixupimm_ss)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_mask_fixupimm_ss)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_maskz_fixupimm_ss)
 SIMDE_TEST_FUNC_LIST_END
 
 #include <test/x86/avx512/test-avx512-footer.h>

--- a/test/x86/avx512/fixupimm_round.c
+++ b/test/x86/avx512/fixupimm_round.c
@@ -1,0 +1,2104 @@
+#define SIMDE_TEST_X86_AVX512_INSN fixupimm_round
+
+#include <test/x86/avx512/test-avx512.h>
+#include <simde/x86/avx512/fixupimm_round.h>
+#include <simde/x86/avx512/setzero.h>
+
+static int
+test_simde_mm512_fixupimm_round_ps (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde_float32 a[16];
+    const simde_float32 b[16];
+    const int32_t c[16];
+    const int imm8;
+    const int sae;
+    const simde_float32 r[16];
+  } test_vec[] = {
+    { {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -725.22),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -972.31),
+        SIMDE_FLOAT32_C(   236.80), SIMDE_FLOAT32_C(   603.87), SIMDE_FLOAT32_C(    26.44), SIMDE_FLOAT32_C(  -468.11),
+        SIMDE_FLOAT32_C(   -84.87), SIMDE_FLOAT32_C(  -396.42), SIMDE_FLOAT32_C(  -972.94), SIMDE_FLOAT32_C(   575.74),
+        SIMDE_FLOAT32_C(    47.76), SIMDE_FLOAT32_C(  -513.89), SIMDE_FLOAT32_C(   538.82), SIMDE_FLOAT32_C(  -530.17) },
+      { SIMDE_FLOAT32_C(  -748.26),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   -96.43),
+        SIMDE_FLOAT32_C(  -920.70), SIMDE_FLOAT32_C(  -285.54), SIMDE_FLOAT32_C(   865.76), SIMDE_FLOAT32_C(   937.33),
+        SIMDE_FLOAT32_C(   905.64), SIMDE_FLOAT32_C(   346.68), SIMDE_FLOAT32_C(  -771.84), SIMDE_FLOAT32_C(   672.63),
+        SIMDE_FLOAT32_C(   636.24), SIMDE_FLOAT32_C(  -763.35), SIMDE_FLOAT32_C(  -549.46), SIMDE_FLOAT32_C(  -522.48) },
+      {  INT32_C(   968187140), -INT32_C(   766540851),  INT32_C(  1919636378),  INT32_C(   378562414),  INT32_C(   496715296), -INT32_C(    91824163),  INT32_C(  1192870380), -INT32_C(   476994081),
+        -INT32_C(   820230398),  INT32_C(  1688300490),  INT32_C(   769002687), -INT32_C(  1807456397), -INT32_C(  1968054355), -INT32_C(  1417398337), -INT32_C(   655188231),  INT32_C(  1169916995) },
+       INT32_C(         203),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(    -1.00), SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(     1.00),     -SIMDE_MATH_INFINITYF,
+        SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(     1.00),     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00),
+        SIMDE_FLOAT32_C(    90.00),      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(    -1.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(     0.00),      SIMDE_MATH_INFINITYF } },
+    { { SIMDE_FLOAT32_C(  -488.57), SIMDE_FLOAT32_C(  -629.31), SIMDE_FLOAT32_C(  -494.79), SIMDE_FLOAT32_C(   748.23),
+        SIMDE_FLOAT32_C(   974.56), SIMDE_FLOAT32_C(   531.65), SIMDE_FLOAT32_C(  -719.88), SIMDE_FLOAT32_C(  -110.32),
+        SIMDE_FLOAT32_C(  -864.77), SIMDE_FLOAT32_C(  -692.82), SIMDE_FLOAT32_C(  -534.58), SIMDE_FLOAT32_C(   182.99),
+        SIMDE_FLOAT32_C(  -206.71), SIMDE_FLOAT32_C(  -995.76), SIMDE_FLOAT32_C(   652.82), SIMDE_FLOAT32_C(    45.04) },
+      { SIMDE_FLOAT32_C(   665.90), SIMDE_FLOAT32_C(   643.76), SIMDE_FLOAT32_C(   948.60), SIMDE_FLOAT32_C(   745.20),
+        SIMDE_FLOAT32_C(  -641.78), SIMDE_FLOAT32_C(   814.36), SIMDE_FLOAT32_C(   682.53), SIMDE_FLOAT32_C(  -736.14),
+        SIMDE_FLOAT32_C(   161.04), SIMDE_FLOAT32_C(   910.69), SIMDE_FLOAT32_C(   936.49), SIMDE_FLOAT32_C(  -202.72),
+        SIMDE_FLOAT32_C(  -852.66), SIMDE_FLOAT32_C(  -612.97), SIMDE_FLOAT32_C(   274.80), SIMDE_FLOAT32_C(  -341.23) },
+      { -INT32_C(  1056769355),  INT32_C(   926232784),  INT32_C(  1407568244), -INT32_C(  1307414662), -INT32_C(  1834238220),  INT32_C(   886408112),  INT32_C(   385817150), -INT32_C(   480602834),
+         INT32_C(  1604607119),  INT32_C(     9951628),  INT32_C(   492076194), -INT32_C(   540055829), -INT32_C(   713983452),  INT32_C(   990463741), -INT32_C(  1907226272),  INT32_C(   762424478) },
+       INT32_C(           8),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(    90.00),            SIMDE_MATH_NANF,      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.50),
+                   SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   682.53),            SIMDE_MATH_NANF,
+             SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(  -692.82), SIMDE_FLOAT32_C(   936.49), SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00),
+             SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.57) } },
+    { { SIMDE_FLOAT32_C(  -242.28), SIMDE_FLOAT32_C(   780.00), SIMDE_FLOAT32_C(  -593.00), SIMDE_FLOAT32_C(  -267.73),
+        SIMDE_FLOAT32_C(   311.65), SIMDE_FLOAT32_C(  -312.88), SIMDE_FLOAT32_C(   621.96), SIMDE_FLOAT32_C(   446.88),
+        SIMDE_FLOAT32_C(    -5.69), SIMDE_FLOAT32_C(  -912.62), SIMDE_FLOAT32_C(  -370.13), SIMDE_FLOAT32_C(   787.60),
+        SIMDE_FLOAT32_C(  -908.37), SIMDE_FLOAT32_C(  -717.31), SIMDE_FLOAT32_C(  -167.37), SIMDE_FLOAT32_C(   757.53) },
+      { SIMDE_FLOAT32_C(   926.45), SIMDE_FLOAT32_C(  -218.77), SIMDE_FLOAT32_C(   502.73), SIMDE_FLOAT32_C(  -715.33),
+        SIMDE_FLOAT32_C(  -404.41), SIMDE_FLOAT32_C(   185.27), SIMDE_FLOAT32_C(  -451.47), SIMDE_FLOAT32_C(   756.63),
+        SIMDE_FLOAT32_C(    95.96), SIMDE_FLOAT32_C(  -514.97), SIMDE_FLOAT32_C(  -446.09), SIMDE_FLOAT32_C(   243.29),
+        SIMDE_FLOAT32_C(  -127.94), SIMDE_FLOAT32_C(   828.70), SIMDE_FLOAT32_C(   902.06), SIMDE_FLOAT32_C(   629.78) },
+      { -INT32_C(  1617783517),  INT32_C(  1351331817), -INT32_C(   126588290),  INT32_C(   586500572),  INT32_C(  1552101459),  INT32_C(   788140418), -INT32_C(  1724438653), -INT32_C(   678900557),
+         INT32_C(  1266031201),  INT32_C(  1201340873),  INT32_C(  1212092268), -INT32_C(  1402325927), -INT32_C(   418845339), -INT32_C(  2112486657), -INT32_C(   602190551),  INT32_C(  2058593049) },
+       INT32_C(         190),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(    -1.00), SIMDE_FLOAT32_C(   780.00), SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00),            SIMDE_MATH_NANF,
+        SIMDE_FLOAT32_C(    90.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    -1.00), SIMDE_FLOAT32_C(     1.57),
+            -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.00),
+        SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(    -0.00) } },
+    { { SIMDE_FLOAT32_C(   608.70), SIMDE_FLOAT32_C(  -690.94), SIMDE_FLOAT32_C(  -637.94), SIMDE_FLOAT32_C(   -79.65),
+        SIMDE_FLOAT32_C(    -3.82), SIMDE_FLOAT32_C(   984.02), SIMDE_FLOAT32_C(  -632.76), SIMDE_FLOAT32_C(   990.49),
+        SIMDE_FLOAT32_C(  -928.60), SIMDE_FLOAT32_C(    -2.89), SIMDE_FLOAT32_C(   778.08), SIMDE_FLOAT32_C(  -836.97),
+        SIMDE_FLOAT32_C(   279.80), SIMDE_FLOAT32_C(  -389.29), SIMDE_FLOAT32_C(   920.56), SIMDE_FLOAT32_C(   206.25) },
+      { SIMDE_FLOAT32_C(   391.95), SIMDE_FLOAT32_C(   423.29), SIMDE_FLOAT32_C(   490.93), SIMDE_FLOAT32_C(   987.54),
+        SIMDE_FLOAT32_C(  -391.44), SIMDE_FLOAT32_C(  -960.54), SIMDE_FLOAT32_C(   744.17), SIMDE_FLOAT32_C(   704.51),
+        SIMDE_FLOAT32_C(  -475.51), SIMDE_FLOAT32_C(  -701.92), SIMDE_FLOAT32_C(   -52.19), SIMDE_FLOAT32_C(   396.55),
+        SIMDE_FLOAT32_C(  -873.22), SIMDE_FLOAT32_C(  -150.13), SIMDE_FLOAT32_C(    26.33), SIMDE_FLOAT32_C(   735.48) },
+      {  INT32_C(  1888997216),  INT32_C(  1137303310),  INT32_C(   933786954),  INT32_C(  2134282109), -INT32_C(   223823707),  INT32_C(  1997243603),  INT32_C(  1647674936), -INT32_C(  1399997365),
+        -INT32_C(  1709431413),  INT32_C(  1323164932), -INT32_C(   679049894), -INT32_C(  1168720876),  INT32_C(  1219296885), -INT32_C(  1161840510), -INT32_C(  1994591170),  INT32_C(  1010150065) },
+       INT32_C(         207),
+       INT32_C(           4),
+      { SIMDE_FLOAT32_C(    -0.00),     -SIMDE_MATH_INFINITYF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    -0.00),
+                   SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    -0.00),      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     1.00),
+        SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(     0.50),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(     0.00),            SIMDE_MATH_NANF } },
+    { { SIMDE_FLOAT32_C(   158.93), SIMDE_FLOAT32_C(   388.39), SIMDE_FLOAT32_C(  -344.17), SIMDE_FLOAT32_C(  -844.89),
+        SIMDE_FLOAT32_C(   372.41), SIMDE_FLOAT32_C(    23.07), SIMDE_FLOAT32_C(  -854.40), SIMDE_FLOAT32_C(   443.80),
+        SIMDE_FLOAT32_C(  -979.82), SIMDE_FLOAT32_C(   923.68), SIMDE_FLOAT32_C(   606.83), SIMDE_FLOAT32_C(   299.98),
+        SIMDE_FLOAT32_C(  -465.60), SIMDE_FLOAT32_C(   527.39), SIMDE_FLOAT32_C(  -493.77), SIMDE_FLOAT32_C(   926.34) },
+      { SIMDE_FLOAT32_C(   -49.32), SIMDE_FLOAT32_C(   997.16), SIMDE_FLOAT32_C(   913.89), SIMDE_FLOAT32_C(   559.23),
+        SIMDE_FLOAT32_C(  -963.38), SIMDE_FLOAT32_C(   658.06), SIMDE_FLOAT32_C(   263.74), SIMDE_FLOAT32_C(  -438.89),
+        SIMDE_FLOAT32_C(   956.14), SIMDE_FLOAT32_C(  -788.45), SIMDE_FLOAT32_C(   957.66), SIMDE_FLOAT32_C(  -917.08),
+        SIMDE_FLOAT32_C(    61.42), SIMDE_FLOAT32_C(   -16.01), SIMDE_FLOAT32_C(   818.40), SIMDE_FLOAT32_C(  -779.65) },
+      {  INT32_C(   948970163),  INT32_C(  1682794408), -INT32_C(  1143404611),  INT32_C(  1799234227), -INT32_C(   693503775), -INT32_C(  1081658603), -INT32_C(  1165048984),  INT32_C(  1307599258),
+         INT32_C(   730235267), -INT32_C(  1500458008), -INT32_C(  1922995750),  INT32_C(  1845075851), -INT32_C(  1388076392),  INT32_C(  1047317205),  INT32_C(   670628493), -INT32_C(   545920933) },
+       INT32_C(         105),
+       INT32_C(           4),
+      { SIMDE_FLOAT32_C(     0.00),      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.50),      SIMDE_MATH_INFINITYF,
+            -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(     1.57),
+                   SIMDE_MATH_NANF,     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.57),
+        SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00) } },
+    { { SIMDE_FLOAT32_C(  -627.62), SIMDE_FLOAT32_C(  -525.77), SIMDE_FLOAT32_C(  -624.54), SIMDE_FLOAT32_C(   744.79),
+        SIMDE_FLOAT32_C(   497.30), SIMDE_FLOAT32_C(  -478.94), SIMDE_FLOAT32_C(   188.59), SIMDE_FLOAT32_C(   517.48),
+        SIMDE_FLOAT32_C(  -555.26), SIMDE_FLOAT32_C(  -204.58), SIMDE_FLOAT32_C(  -182.54), SIMDE_FLOAT32_C(   -20.86),
+        SIMDE_FLOAT32_C(  -677.19), SIMDE_FLOAT32_C(   323.69), SIMDE_FLOAT32_C(   -94.52), SIMDE_FLOAT32_C(   273.49) },
+      { SIMDE_FLOAT32_C(   320.84), SIMDE_FLOAT32_C(  -180.63), SIMDE_FLOAT32_C(  -167.28), SIMDE_FLOAT32_C(   357.46),
+        SIMDE_FLOAT32_C(  -522.58), SIMDE_FLOAT32_C(  -903.54), SIMDE_FLOAT32_C(   918.56), SIMDE_FLOAT32_C(  -566.44),
+        SIMDE_FLOAT32_C(  -691.99), SIMDE_FLOAT32_C(   876.22), SIMDE_FLOAT32_C(  -483.53), SIMDE_FLOAT32_C(   369.44),
+        SIMDE_FLOAT32_C(  -139.79), SIMDE_FLOAT32_C(  -665.13), SIMDE_FLOAT32_C(   589.78), SIMDE_FLOAT32_C(   232.59) },
+      {  INT32_C(    78182554), -INT32_C(   108055207), -INT32_C(   778961874),  INT32_C(   161889855), -INT32_C(  1533549398), -INT32_C(   973095204),  INT32_C(   774823475), -INT32_C(  2080603927),
+        -INT32_C(   762862472),  INT32_C(   147527642),  INT32_C(  1406753811),  INT32_C(  1146912922),  INT32_C(  1105785700), -INT32_C(   452532302), -INT32_C(  1357630266),  INT32_C(   758255797) },
+       INT32_C(         181),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(  -627.62), SIMDE_FLOAT32_C(    -1.00), SIMDE_FLOAT32_C(  -167.28), SIMDE_FLOAT32_C(   744.79),
+            -SIMDE_MATH_INFINITYF,      SIMDE_MATH_INFINITYF,            SIMDE_MATH_NANF,            SIMDE_MATH_NANF,
+                   SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -204.58),            SIMDE_MATH_NANF,     -SIMDE_MATH_INFINITYF,
+        SIMDE_FLOAT32_C(  -139.79),      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     1.00),            SIMDE_MATH_NANF } },
+    { { SIMDE_FLOAT32_C(  -190.89), SIMDE_FLOAT32_C(   965.24), SIMDE_FLOAT32_C(   -22.62), SIMDE_FLOAT32_C(  -693.59),
+        SIMDE_FLOAT32_C(  -513.70), SIMDE_FLOAT32_C(  -834.03), SIMDE_FLOAT32_C(   823.89), SIMDE_FLOAT32_C(   -68.96),
+        SIMDE_FLOAT32_C(   -38.61), SIMDE_FLOAT32_C(  -358.65), SIMDE_FLOAT32_C(   910.18), SIMDE_FLOAT32_C(   284.20),
+        SIMDE_FLOAT32_C(   965.03), SIMDE_FLOAT32_C(  -184.34), SIMDE_FLOAT32_C(  -442.32), SIMDE_FLOAT32_C(   285.88) },
+      { SIMDE_FLOAT32_C(   635.02), SIMDE_FLOAT32_C(   390.40), SIMDE_FLOAT32_C(  -356.66), SIMDE_FLOAT32_C(  -887.55),
+        SIMDE_FLOAT32_C(   486.87), SIMDE_FLOAT32_C(  -438.10), SIMDE_FLOAT32_C(  -453.99), SIMDE_FLOAT32_C(   794.88),
+        SIMDE_FLOAT32_C(  -561.88), SIMDE_FLOAT32_C(    62.48), SIMDE_FLOAT32_C(   164.32), SIMDE_FLOAT32_C(   298.34),
+        SIMDE_FLOAT32_C(   397.35), SIMDE_FLOAT32_C(  -245.90), SIMDE_FLOAT32_C(  -469.07), SIMDE_FLOAT32_C(  -793.54) },
+      {  INT32_C(   652515274), -INT32_C(   239061135), -INT32_C(  2024471404), -INT32_C(   734423316), -INT32_C(   778428516),  INT32_C(  1132874035),  INT32_C(   905491323),  INT32_C(  2097579955),
+        -INT32_C(  1868240097), -INT32_C(  1233034206),  INT32_C(  1430181481),  INT32_C(   153712493), -INT32_C(   908409962), -INT32_C(  2012389364), -INT32_C(   943913708), -INT32_C(  1404779379) },
+       INT32_C(         175),
+       INT32_C(           8),
+      {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(    -0.00),     -SIMDE_MATH_INFINITYF,
+        SIMDE_FLOAT32_C(     1.57),            SIMDE_MATH_NANF,      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(    -0.00),
+        SIMDE_FLOAT32_C(   -38.61), SIMDE_FLOAT32_C(     0.50),      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(   284.20),
+        SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(    90.00) } },
+    { { SIMDE_FLOAT32_C(  -280.66), SIMDE_FLOAT32_C(   508.31), SIMDE_FLOAT32_C(  -487.13), SIMDE_FLOAT32_C(   205.65),
+        SIMDE_FLOAT32_C(   674.28), SIMDE_FLOAT32_C(  -663.24), SIMDE_FLOAT32_C(  -863.31), SIMDE_FLOAT32_C(  -364.33),
+        SIMDE_FLOAT32_C(   -21.89), SIMDE_FLOAT32_C(  -953.13), SIMDE_FLOAT32_C(   919.87), SIMDE_FLOAT32_C(   -56.86),
+        SIMDE_FLOAT32_C(  -137.47), SIMDE_FLOAT32_C(  -522.45), SIMDE_FLOAT32_C(  -770.98), SIMDE_FLOAT32_C(  -502.45) },
+      { SIMDE_FLOAT32_C(   867.95), SIMDE_FLOAT32_C(  -127.64), SIMDE_FLOAT32_C(  -390.00), SIMDE_FLOAT32_C(   354.82),
+        SIMDE_FLOAT32_C(   434.26), SIMDE_FLOAT32_C(   156.00), SIMDE_FLOAT32_C(   149.70), SIMDE_FLOAT32_C(   872.38),
+        SIMDE_FLOAT32_C(  -781.52), SIMDE_FLOAT32_C(  -685.98), SIMDE_FLOAT32_C(   170.72), SIMDE_FLOAT32_C(   615.83),
+        SIMDE_FLOAT32_C(    68.12), SIMDE_FLOAT32_C(   701.65), SIMDE_FLOAT32_C(   822.29), SIMDE_FLOAT32_C(   787.46) },
+      { -INT32_C(  1816753987),  INT32_C(  1023413190), -INT32_C(   120321483),  INT32_C(  1157996004), -INT32_C(  1336308310),  INT32_C(   238886986),  INT32_C(  1304291684), -INT32_C(   493187291),
+        -INT32_C(   579514345), -INT32_C(  1877313957),  INT32_C(  1686761088),  INT32_C(   917081740),  INT32_C(  1709572635), -INT32_C(  2022431966),  INT32_C(   835989772), -INT32_C(   686592320) },
+       INT32_C(         190),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(    -1.00), SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(     0.00),     -SIMDE_MATH_INFINITYF,
+        SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(  -663.24),     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00),
+        SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(  -953.13),      SIMDE_MATH_INFINITYF,            SIMDE_MATH_NANF,
+             SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(     1.57) } },
+  };
+
+  simde__m512 a, b, r;
+  simde__m512i c;
+
+  a = simde_mm512_loadu_ps(test_vec[0].a);
+  b = simde_mm512_loadu_ps(test_vec[0].b);
+  c = simde_mm512_loadu_epi32(test_vec[0].c);
+  r = simde_mm512_fixupimm_round_ps(a, b, c, INT32_C(         203), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[0].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[1].a);
+  b = simde_mm512_loadu_ps(test_vec[1].b);
+  c = simde_mm512_loadu_epi32(test_vec[1].c);
+  r = simde_mm512_fixupimm_round_ps(a, b, c, INT32_C(           8), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[1].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[2].a);
+  b = simde_mm512_loadu_ps(test_vec[2].b);
+  c = simde_mm512_loadu_epi32(test_vec[2].c);
+  r = simde_mm512_fixupimm_round_ps(a, b, c, INT32_C(         190), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[2].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[3].a);
+  b = simde_mm512_loadu_ps(test_vec[3].b);
+  c = simde_mm512_loadu_epi32(test_vec[3].c);
+  r = simde_mm512_fixupimm_round_ps(a, b, c, INT32_C(         207), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[3].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[4].a);
+  b = simde_mm512_loadu_ps(test_vec[4].b);
+  c = simde_mm512_loadu_epi32(test_vec[4].c);
+  r = simde_mm512_fixupimm_round_ps(a, b, c, INT32_C(         105), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[4].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[5].a);
+  b = simde_mm512_loadu_ps(test_vec[5].b);
+  c = simde_mm512_loadu_epi32(test_vec[5].c);
+  r = simde_mm512_fixupimm_round_ps(a, b, c, INT32_C(         181), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[5].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[6].a);
+  b = simde_mm512_loadu_ps(test_vec[6].b);
+  c = simde_mm512_loadu_epi32(test_vec[6].c);
+  r = simde_mm512_fixupimm_round_ps(a, b, c, INT32_C(         175), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[6].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[7].a);
+  b = simde_mm512_loadu_ps(test_vec[7].b);
+  c = simde_mm512_loadu_epi32(test_vec[7].c);
+  r = simde_mm512_fixupimm_round_ps(a, b, c, INT32_C(         190), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float32 values[8 * 2 * sizeof(simde__m512)];
+  simde_test_x86_random_f32x16_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__m512 a = simde_test_x86_random_extract_f32x16(i, 2, 0, values);
+    simde__m512 b = simde_test_x86_random_extract_f32x16(i, 2, 1, values);
+    simde__m512i c = simde_test_x86_random_i32x16();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    int32_t sae = simde_test_codegen_rand() & 1 ? SIMDE_MM_FROUND_NO_EXC : SIMDE_MM_FROUND_CUR_DIRECTION;
+    simde__m512 r;
+    SIMDE_CONSTIFY_256_NEW(simde_mm512_fixupimm_round_ps, r, simde_mm512_setzero_ps(), imm8, sae, a, b, c);
+
+    simde_test_x86_write_f32x16(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_f32x16(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x16(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, sae, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x16(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm512_mask_fixupimm_round_ps (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde_float32 a[16];
+    const simde__mmask16 k;
+    const simde_float32 b[16];
+    const int32_t c[16];
+    const int imm8;
+    const int sae;
+    const simde_float32 r[16];
+  } test_vec[] = {
+    { {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   717.49),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   949.63),
+        SIMDE_FLOAT32_C(  -127.43), SIMDE_FLOAT32_C(    98.90), SIMDE_FLOAT32_C(   851.71), SIMDE_FLOAT32_C(  -425.50),
+        SIMDE_FLOAT32_C(  -862.77), SIMDE_FLOAT32_C(   555.31), SIMDE_FLOAT32_C(  -957.24), SIMDE_FLOAT32_C(   524.65),
+        SIMDE_FLOAT32_C(   510.73), SIMDE_FLOAT32_C(   470.26), SIMDE_FLOAT32_C(   216.49), SIMDE_FLOAT32_C(  -220.53) },
+      UINT16_C(34923),
+      { SIMDE_FLOAT32_C(  -799.00),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -641.87),
+        SIMDE_FLOAT32_C(  -158.49), SIMDE_FLOAT32_C(  -348.69), SIMDE_FLOAT32_C(  -156.78), SIMDE_FLOAT32_C(  -715.61),
+        SIMDE_FLOAT32_C(  -479.20), SIMDE_FLOAT32_C(   469.73), SIMDE_FLOAT32_C(  -462.15), SIMDE_FLOAT32_C(  -822.56),
+        SIMDE_FLOAT32_C(   345.36), SIMDE_FLOAT32_C(  -722.77), SIMDE_FLOAT32_C(   958.22), SIMDE_FLOAT32_C(   408.69) },
+      { -INT32_C(   418002665),  INT32_C(  1912938350),  INT32_C(     1859954), -INT32_C(  2029836534),  INT32_C(  1594346097), -INT32_C(  1388315549),  INT32_C(  1770789115), -INT32_C(  1175259230),
+         INT32_C(   782239680), -INT32_C(  1734236634),  INT32_C(   295222535),  INT32_C(  1452841957), -INT32_C(   910844059), -INT32_C(  1753811812), -INT32_C(  1358953972), -INT32_C(  1184304391) },
+       INT32_C(         249),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    -0.00),
+        SIMDE_FLOAT32_C(  -127.43), SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(    -1.00), SIMDE_FLOAT32_C(  -425.50),
+        SIMDE_FLOAT32_C(  -862.77), SIMDE_FLOAT32_C(   555.31), SIMDE_FLOAT32_C(  -957.24),     -SIMDE_MATH_INFINITYF,
+        SIMDE_FLOAT32_C(   510.73), SIMDE_FLOAT32_C(   470.26), SIMDE_FLOAT32_C(   216.49), SIMDE_FLOAT32_C(     0.50) } },
+    { { SIMDE_FLOAT32_C(   994.71), SIMDE_FLOAT32_C(  -679.53), SIMDE_FLOAT32_C(   358.32), SIMDE_FLOAT32_C(  -132.71),
+        SIMDE_FLOAT32_C(   419.37), SIMDE_FLOAT32_C(   210.03), SIMDE_FLOAT32_C(   441.78), SIMDE_FLOAT32_C(   556.60),
+        SIMDE_FLOAT32_C(  -234.66), SIMDE_FLOAT32_C(   484.55), SIMDE_FLOAT32_C(    81.25), SIMDE_FLOAT32_C(  -723.93),
+        SIMDE_FLOAT32_C(   -45.19), SIMDE_FLOAT32_C(  -702.26), SIMDE_FLOAT32_C(    55.54), SIMDE_FLOAT32_C(   155.81) },
+      UINT16_C(46984),
+      { SIMDE_FLOAT32_C(  -343.03), SIMDE_FLOAT32_C(   206.89), SIMDE_FLOAT32_C(   513.93), SIMDE_FLOAT32_C(   498.47),
+        SIMDE_FLOAT32_C(   858.20), SIMDE_FLOAT32_C(  -642.85), SIMDE_FLOAT32_C(   782.87), SIMDE_FLOAT32_C(  -621.01),
+        SIMDE_FLOAT32_C(   826.88), SIMDE_FLOAT32_C(  -679.28), SIMDE_FLOAT32_C(  -443.56), SIMDE_FLOAT32_C(   172.25),
+        SIMDE_FLOAT32_C(  -402.06), SIMDE_FLOAT32_C(  -485.34), SIMDE_FLOAT32_C(  -419.07), SIMDE_FLOAT32_C(  -407.35) },
+      { -INT32_C(   951105866), -INT32_C(  2124420309),  INT32_C(   423034704),  INT32_C(   848243355), -INT32_C(   449670858),  INT32_C(  1129194890),  INT32_C(  1043027742), -INT32_C(  1124748538),
+         INT32_C(   612582905), -INT32_C(  2136612304),  INT32_C(  2090523617),  INT32_C(  1018046725),  INT32_C(  1159848379),  INT32_C(   612986630), -INT32_C(   865946426),  INT32_C(  1636325479) },
+       INT32_C(         157),
+       INT32_C(           4),
+      { SIMDE_FLOAT32_C(   994.71), SIMDE_FLOAT32_C(  -679.53), SIMDE_FLOAT32_C(   358.32),            SIMDE_MATH_NANF,
+        SIMDE_FLOAT32_C(   419.37), SIMDE_FLOAT32_C(   210.03), SIMDE_FLOAT32_C(   441.78), SIMDE_FLOAT32_C(    90.00),
+                   SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   484.55), SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(  -723.93),
+             SIMDE_MATH_INFINITYF,     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(    55.54), SIMDE_FLOAT32_C(  -407.35) } },
+    { { SIMDE_FLOAT32_C(  -164.88), SIMDE_FLOAT32_C(   939.25), SIMDE_FLOAT32_C(   459.94), SIMDE_FLOAT32_C(  -745.51),
+        SIMDE_FLOAT32_C(   149.28), SIMDE_FLOAT32_C(   -98.28), SIMDE_FLOAT32_C(   811.09), SIMDE_FLOAT32_C(   914.62),
+        SIMDE_FLOAT32_C(  -613.73), SIMDE_FLOAT32_C(  -107.65), SIMDE_FLOAT32_C(  -809.31), SIMDE_FLOAT32_C(   341.07),
+        SIMDE_FLOAT32_C(   190.09), SIMDE_FLOAT32_C(   246.23), SIMDE_FLOAT32_C(  -503.12), SIMDE_FLOAT32_C(   847.05) },
+      UINT16_C(19755),
+      { SIMDE_FLOAT32_C(  -546.89), SIMDE_FLOAT32_C(  -989.19), SIMDE_FLOAT32_C(   345.53), SIMDE_FLOAT32_C(  -688.69),
+        SIMDE_FLOAT32_C(  -632.04), SIMDE_FLOAT32_C(   128.39), SIMDE_FLOAT32_C(  -309.70), SIMDE_FLOAT32_C(  -805.15),
+        SIMDE_FLOAT32_C(   449.11), SIMDE_FLOAT32_C(   246.74), SIMDE_FLOAT32_C(   367.09), SIMDE_FLOAT32_C(  -952.95),
+        SIMDE_FLOAT32_C(   761.40), SIMDE_FLOAT32_C(   948.02), SIMDE_FLOAT32_C(  -360.30), SIMDE_FLOAT32_C(  -403.48) },
+      {  INT32_C(  1290208975),  INT32_C(  1224347916),  INT32_C(   292150220),  INT32_C(   110811617),  INT32_C(  1818775199),  INT32_C(   401916086),  INT32_C(   714866781), -INT32_C(  1116157970),
+        -INT32_C(   636919858),  INT32_C(  1008862320), -INT32_C(  1051816993),  INT32_C(    80210020), -INT32_C(   311414985),  INT32_C(  1292133616),  INT32_C(  1383637092),  INT32_C(   907079784) },
+       INT32_C(          79),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   459.94),     -SIMDE_MATH_INFINITYF,
+        SIMDE_FLOAT32_C(   149.28), SIMDE_FLOAT32_C(   128.39), SIMDE_FLOAT32_C(   811.09), SIMDE_FLOAT32_C(   914.62),
+        SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(  -107.65), SIMDE_FLOAT32_C(    90.00),     -SIMDE_MATH_INFINITYF,
+        SIMDE_FLOAT32_C(   190.09), SIMDE_FLOAT32_C(   246.23),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   847.05) } },
+    { { SIMDE_FLOAT32_C(   887.27), SIMDE_FLOAT32_C(  -900.36), SIMDE_FLOAT32_C(  -148.99), SIMDE_FLOAT32_C(    36.55),
+        SIMDE_FLOAT32_C(     1.36), SIMDE_FLOAT32_C(  -337.89), SIMDE_FLOAT32_C(   -48.83), SIMDE_FLOAT32_C(   387.63),
+        SIMDE_FLOAT32_C(   554.45), SIMDE_FLOAT32_C(   141.86), SIMDE_FLOAT32_C(  -271.30), SIMDE_FLOAT32_C(  -255.46),
+        SIMDE_FLOAT32_C(  -611.92), SIMDE_FLOAT32_C(   225.58), SIMDE_FLOAT32_C(  -408.41), SIMDE_FLOAT32_C(  -158.80) },
+      UINT16_C(64562),
+      { SIMDE_FLOAT32_C(   236.40), SIMDE_FLOAT32_C(   937.12), SIMDE_FLOAT32_C(   152.51), SIMDE_FLOAT32_C(   604.36),
+        SIMDE_FLOAT32_C(    65.51), SIMDE_FLOAT32_C(   842.81), SIMDE_FLOAT32_C(   799.21), SIMDE_FLOAT32_C(  -485.38),
+        SIMDE_FLOAT32_C(    89.55), SIMDE_FLOAT32_C(   166.30), SIMDE_FLOAT32_C(  -438.33), SIMDE_FLOAT32_C(  -149.05),
+        SIMDE_FLOAT32_C(   114.32), SIMDE_FLOAT32_C(   201.37), SIMDE_FLOAT32_C(   447.47), SIMDE_FLOAT32_C(     1.59) },
+      { -INT32_C(  1102397955),  INT32_C(   646263586),  INT32_C(  1469494378), -INT32_C(   228853084), -INT32_C(  1318388897), -INT32_C(  1715381661),  INT32_C(  1772739497), -INT32_C(   177808392),
+        -INT32_C(  1145851751),  INT32_C(  1306605795), -INT32_C(  1851492371), -INT32_C(   796655759),  INT32_C(  1585638907), -INT32_C(   235388089),  INT32_C(   391815454),  INT32_C(   369934461) },
+       INT32_C(         113),
+       INT32_C(           4),
+      { SIMDE_FLOAT32_C(   887.27),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -148.99), SIMDE_FLOAT32_C(    36.55),
+        SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(    -1.00), SIMDE_FLOAT32_C(   -48.83), SIMDE_FLOAT32_C(   387.63),
+        SIMDE_FLOAT32_C(   554.45), SIMDE_FLOAT32_C(   141.86), SIMDE_FLOAT32_C(  -438.33), SIMDE_FLOAT32_C(  -255.46),
+             SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(   447.47), SIMDE_FLOAT32_C(     1.59) } },
+    { { SIMDE_FLOAT32_C(   301.01), SIMDE_FLOAT32_C(  -701.52), SIMDE_FLOAT32_C(  -961.85), SIMDE_FLOAT32_C(  -697.62),
+        SIMDE_FLOAT32_C(   -39.41), SIMDE_FLOAT32_C(   -10.69), SIMDE_FLOAT32_C(   690.01), SIMDE_FLOAT32_C(  -484.96),
+        SIMDE_FLOAT32_C(  -868.83), SIMDE_FLOAT32_C(  -581.29), SIMDE_FLOAT32_C(   259.58), SIMDE_FLOAT32_C(  -480.75),
+        SIMDE_FLOAT32_C(   644.30), SIMDE_FLOAT32_C(   851.17), SIMDE_FLOAT32_C(   360.45), SIMDE_FLOAT32_C(  -119.31) },
+      UINT16_C(41650),
+      { SIMDE_FLOAT32_C(   788.29), SIMDE_FLOAT32_C(  -487.04), SIMDE_FLOAT32_C(  -514.95), SIMDE_FLOAT32_C(  -146.20),
+        SIMDE_FLOAT32_C(  -644.24), SIMDE_FLOAT32_C(  -715.74), SIMDE_FLOAT32_C(   368.41), SIMDE_FLOAT32_C(   445.31),
+        SIMDE_FLOAT32_C(   450.56), SIMDE_FLOAT32_C(   930.08), SIMDE_FLOAT32_C(  -703.74), SIMDE_FLOAT32_C(  -435.12),
+        SIMDE_FLOAT32_C(   131.45), SIMDE_FLOAT32_C(   743.73), SIMDE_FLOAT32_C(   566.47), SIMDE_FLOAT32_C(  -567.54) },
+      {  INT32_C(  2001086949),  INT32_C(  1811564186), -INT32_C(  1611798463),  INT32_C(   546779183),  INT32_C(  1719351631), -INT32_C(   864928842),  INT32_C(    27079340),  INT32_C(   279138091),
+         INT32_C(   310897016),  INT32_C(  1887273519), -INT32_C(  1726977430), -INT32_C(   356866149), -INT32_C(  1773128224),  INT32_C(   493011568),  INT32_C(   538902517), -INT32_C(   969883314) },
+       INT32_C(         170),
+       INT32_C(           4),
+      { SIMDE_FLOAT32_C(   301.01), SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(  -961.85), SIMDE_FLOAT32_C(  -697.62),
+            -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(   690.01), SIMDE_FLOAT32_C(   445.31),
+        SIMDE_FLOAT32_C(  -868.83), SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(   259.58), SIMDE_FLOAT32_C(  -480.75),
+        SIMDE_FLOAT32_C(   644.30), SIMDE_FLOAT32_C(   743.73), SIMDE_FLOAT32_C(   360.45),     -SIMDE_MATH_INFINITYF } },
+    { { SIMDE_FLOAT32_C(  -957.79), SIMDE_FLOAT32_C(   604.62), SIMDE_FLOAT32_C(  -265.16), SIMDE_FLOAT32_C(     2.81),
+        SIMDE_FLOAT32_C(  -406.07), SIMDE_FLOAT32_C(  -575.15), SIMDE_FLOAT32_C(   517.85), SIMDE_FLOAT32_C(  -274.90),
+        SIMDE_FLOAT32_C(  -156.44), SIMDE_FLOAT32_C(  -222.57), SIMDE_FLOAT32_C(   244.36), SIMDE_FLOAT32_C(  -512.14),
+        SIMDE_FLOAT32_C(  -371.40), SIMDE_FLOAT32_C(  -395.19), SIMDE_FLOAT32_C(   368.55), SIMDE_FLOAT32_C(  -583.11) },
+      UINT16_C(19030),
+      { SIMDE_FLOAT32_C(   117.76), SIMDE_FLOAT32_C(   853.60), SIMDE_FLOAT32_C(   270.69), SIMDE_FLOAT32_C(   473.53),
+        SIMDE_FLOAT32_C(  -862.14), SIMDE_FLOAT32_C(  -360.90), SIMDE_FLOAT32_C(   -81.16), SIMDE_FLOAT32_C(   588.42),
+        SIMDE_FLOAT32_C(  -430.82), SIMDE_FLOAT32_C(   215.10), SIMDE_FLOAT32_C(  -846.71), SIMDE_FLOAT32_C(   700.63),
+        SIMDE_FLOAT32_C(   -41.16), SIMDE_FLOAT32_C(   719.77), SIMDE_FLOAT32_C(  -866.91), SIMDE_FLOAT32_C(     1.05) },
+      {  INT32_C(  1029357988),  INT32_C(  1190593116),  INT32_C(  2039885026), -INT32_C(  1160030051),  INT32_C(  1842928461), -INT32_C(   258041559),  INT32_C(   499734083),  INT32_C(   879239056),
+         INT32_C(  1014088416), -INT32_C(  1484625468),  INT32_C(   840964245), -INT32_C(  1091765391),  INT32_C(     2933974), -INT32_C(  1578055075), -INT32_C(  1329678048), -INT32_C(  1176230184) },
+       INT32_C(         233),
+       INT32_C(           4),
+      { SIMDE_FLOAT32_C(  -957.79),     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(     2.81),
+        SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(  -575.15), SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(  -274.90),
+        SIMDE_FLOAT32_C(  -156.44), SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(   244.36), SIMDE_FLOAT32_C(     0.50),
+        SIMDE_FLOAT32_C(  -371.40), SIMDE_FLOAT32_C(  -395.19), SIMDE_FLOAT32_C(   368.55), SIMDE_FLOAT32_C(  -583.11) } },
+    { { SIMDE_FLOAT32_C(   324.39), SIMDE_FLOAT32_C(  -132.07), SIMDE_FLOAT32_C(  -996.14), SIMDE_FLOAT32_C(   918.32),
+        SIMDE_FLOAT32_C(   292.78), SIMDE_FLOAT32_C(   521.70), SIMDE_FLOAT32_C(  -356.58), SIMDE_FLOAT32_C(  -863.65),
+        SIMDE_FLOAT32_C(  -700.87), SIMDE_FLOAT32_C(   887.78), SIMDE_FLOAT32_C(  -375.80), SIMDE_FLOAT32_C(   -72.27),
+        SIMDE_FLOAT32_C(  -507.42), SIMDE_FLOAT32_C(   992.75), SIMDE_FLOAT32_C(   344.62), SIMDE_FLOAT32_C(   610.35) },
+      UINT16_C(21624),
+      { SIMDE_FLOAT32_C(   846.36), SIMDE_FLOAT32_C(  -384.69), SIMDE_FLOAT32_C(    83.88), SIMDE_FLOAT32_C(   984.22),
+        SIMDE_FLOAT32_C(   254.41), SIMDE_FLOAT32_C(  -997.28), SIMDE_FLOAT32_C(   572.63), SIMDE_FLOAT32_C(   823.58),
+        SIMDE_FLOAT32_C(   217.83), SIMDE_FLOAT32_C(   725.93), SIMDE_FLOAT32_C(   524.21), SIMDE_FLOAT32_C(  -823.34),
+        SIMDE_FLOAT32_C(   445.70), SIMDE_FLOAT32_C(   657.31), SIMDE_FLOAT32_C(   177.71), SIMDE_FLOAT32_C(  -229.92) },
+      { -INT32_C(  2039181228), -INT32_C(  1066176511),  INT32_C(  1189885766),  INT32_C(   909555349), -INT32_C(  2030768170), -INT32_C(  2123752504), -INT32_C(  1317617916), -INT32_C(   771297666),
+        -INT32_C(  2141685121),  INT32_C(   826330090), -INT32_C(  1737020413), -INT32_C(  1194414366),  INT32_C(  1698611869), -INT32_C(   504977187), -INT32_C(   426549912), -INT32_C(   893871797) },
+       INT32_C(          19),
+       INT32_C(           4),
+      { SIMDE_FLOAT32_C(   324.39), SIMDE_FLOAT32_C(  -132.07), SIMDE_FLOAT32_C(  -996.14),            SIMDE_MATH_NANF,
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -997.28), SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(  -863.65),
+        SIMDE_FLOAT32_C(  -700.87), SIMDE_FLOAT32_C(   887.78), SIMDE_FLOAT32_C(    -1.00), SIMDE_FLOAT32_C(   -72.27),
+             SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(   992.75), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(   610.35) } },
+    { { SIMDE_FLOAT32_C(  -474.76), SIMDE_FLOAT32_C(   181.57), SIMDE_FLOAT32_C(  -311.60), SIMDE_FLOAT32_C(   818.03),
+        SIMDE_FLOAT32_C(  -296.73), SIMDE_FLOAT32_C(   331.82), SIMDE_FLOAT32_C(   954.37), SIMDE_FLOAT32_C(     2.40),
+        SIMDE_FLOAT32_C(   219.59), SIMDE_FLOAT32_C(  -421.42), SIMDE_FLOAT32_C(   930.13), SIMDE_FLOAT32_C(   712.18),
+        SIMDE_FLOAT32_C(  -428.67), SIMDE_FLOAT32_C(   274.75), SIMDE_FLOAT32_C(   322.53), SIMDE_FLOAT32_C(  -582.31) },
+      UINT16_C(12171),
+      { SIMDE_FLOAT32_C(   890.06), SIMDE_FLOAT32_C(  -593.59), SIMDE_FLOAT32_C(  -598.10), SIMDE_FLOAT32_C(   144.47),
+        SIMDE_FLOAT32_C(  -590.87), SIMDE_FLOAT32_C(   974.54), SIMDE_FLOAT32_C(   -31.95), SIMDE_FLOAT32_C(   626.95),
+        SIMDE_FLOAT32_C(   700.46), SIMDE_FLOAT32_C(  -507.74), SIMDE_FLOAT32_C(   803.61), SIMDE_FLOAT32_C(   146.16),
+        SIMDE_FLOAT32_C(  -850.43), SIMDE_FLOAT32_C(   -18.68), SIMDE_FLOAT32_C(   916.24), SIMDE_FLOAT32_C(  -325.19) },
+      {  INT32_C(  2007415007),  INT32_C(  1397052570),  INT32_C(  1469122546), -INT32_C(   969000219), -INT32_C(  2007393374), -INT32_C(  1321143578),  INT32_C(    83644422),  INT32_C(   187926316),
+        -INT32_C(   628958913),  INT32_C(   539871022), -INT32_C(  1267220785), -INT32_C(  1703234056),  INT32_C(   925029456), -INT32_C(   857185594), -INT32_C(   539958093), -INT32_C(  1410661525) },
+       INT32_C(         221),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(    -0.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -311.60), SIMDE_FLOAT32_C(    90.00),
+        SIMDE_FLOAT32_C(  -296.73), SIMDE_FLOAT32_C(   331.82), SIMDE_FLOAT32_C(   954.37), SIMDE_FLOAT32_C(     2.40),
+        SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(  -421.42), SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(    -1.00),
+        SIMDE_FLOAT32_C(  -428.67), SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(   322.53), SIMDE_FLOAT32_C(  -582.31) } },
+  };
+
+  simde__m512 a, b, r;
+  simde__m512i c;
+
+  a = simde_mm512_loadu_ps(test_vec[0].a);
+  b = simde_mm512_loadu_ps(test_vec[0].b);
+  c = simde_mm512_loadu_epi32(test_vec[0].c);
+  r = simde_mm512_mask_fixupimm_round_ps(a, test_vec[0].k, b, c, INT32_C(         249), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[0].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[1].a);
+  b = simde_mm512_loadu_ps(test_vec[1].b);
+  c = simde_mm512_loadu_epi32(test_vec[1].c);
+  r = simde_mm512_mask_fixupimm_round_ps(a, test_vec[1].k, b, c, INT32_C(         157), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[1].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[2].a);
+  b = simde_mm512_loadu_ps(test_vec[2].b);
+  c = simde_mm512_loadu_epi32(test_vec[2].c);
+  r = simde_mm512_mask_fixupimm_round_ps(a, test_vec[2].k, b, c, INT32_C(          79), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[2].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[3].a);
+  b = simde_mm512_loadu_ps(test_vec[3].b);
+  c = simde_mm512_loadu_epi32(test_vec[3].c);
+  r = simde_mm512_mask_fixupimm_round_ps(a, test_vec[3].k, b, c, INT32_C(         113), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[3].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[4].a);
+  b = simde_mm512_loadu_ps(test_vec[4].b);
+  c = simde_mm512_loadu_epi32(test_vec[4].c);
+  r = simde_mm512_mask_fixupimm_round_ps(a, test_vec[4].k, b, c, INT32_C(         170), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[4].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[5].a);
+  b = simde_mm512_loadu_ps(test_vec[5].b);
+  c = simde_mm512_loadu_epi32(test_vec[5].c);
+  r = simde_mm512_mask_fixupimm_round_ps(a, test_vec[5].k, b, c, INT32_C(         233), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[5].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[6].a);
+  b = simde_mm512_loadu_ps(test_vec[6].b);
+  c = simde_mm512_loadu_epi32(test_vec[6].c);
+  r = simde_mm512_mask_fixupimm_round_ps(a, test_vec[6].k, b, c, INT32_C(          19), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[6].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[7].a);
+  b = simde_mm512_loadu_ps(test_vec[7].b);
+  c = simde_mm512_loadu_epi32(test_vec[7].c);
+  r = simde_mm512_mask_fixupimm_round_ps(a, test_vec[7].k, b, c, INT32_C(         221), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float32 values[8 * 2 * sizeof(simde__m512)];
+  simde_test_x86_random_f32x16_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__m512 a = simde_test_x86_random_extract_f32x16(i, 2, 0, values);
+    simde__mmask16 k = simde_test_x86_random_mmask16();
+    simde__m512 b = simde_test_x86_random_extract_f32x16(i, 2, 1, values);
+    simde__m512i c = simde_test_x86_random_i32x16();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    int32_t sae = simde_test_codegen_rand() & 1 ? SIMDE_MM_FROUND_NO_EXC : SIMDE_MM_FROUND_CUR_DIRECTION;
+    simde__m512 r;
+    SIMDE_CONSTIFY_256_NEW(simde_mm512_mask_fixupimm_round_ps, r, simde_mm512_setzero_ps(), imm8, sae, a, k, b, c);
+
+    simde_test_x86_write_f32x16(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_mmask16(2, k, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x16(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x16(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, sae, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x16(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  fprintf(stderr, "-------------------------\n------------------------\n----------------------\n");
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm512_maskz_fixupimm_round_ps (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde__mmask16 k;
+    const simde_float32 a[16];
+    const simde_float32 b[16];
+    const int32_t c[16];
+    const int imm8;
+    const int sae;
+    const simde_float32 r[16];
+  } test_vec[] = {
+    { UINT16_C(58968),
+      {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   750.06),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   588.42),
+        SIMDE_FLOAT32_C(  -180.88), SIMDE_FLOAT32_C(   317.29), SIMDE_FLOAT32_C(   395.27), SIMDE_FLOAT32_C(    57.07),
+        SIMDE_FLOAT32_C(  -754.03), SIMDE_FLOAT32_C(   703.53), SIMDE_FLOAT32_C(   331.42), SIMDE_FLOAT32_C(   588.99),
+        SIMDE_FLOAT32_C(  -937.18), SIMDE_FLOAT32_C(  -230.83), SIMDE_FLOAT32_C(  -868.54), SIMDE_FLOAT32_C(  -129.11) },
+      { SIMDE_FLOAT32_C(  -220.13),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   552.45),
+        SIMDE_FLOAT32_C(  -129.00), SIMDE_FLOAT32_C(   695.59), SIMDE_FLOAT32_C(  -879.64), SIMDE_FLOAT32_C(  -883.58),
+        SIMDE_FLOAT32_C(   333.46), SIMDE_FLOAT32_C(   282.67), SIMDE_FLOAT32_C(  -744.96), SIMDE_FLOAT32_C(  -433.69),
+        SIMDE_FLOAT32_C(  -220.29), SIMDE_FLOAT32_C(   928.69), SIMDE_FLOAT32_C(  -477.71), SIMDE_FLOAT32_C(   703.28) },
+      { -INT32_C(  1049963273),  INT32_C(   871681320),  INT32_C(   677254200),  INT32_C(  1238148996), -INT32_C(   700097088),  INT32_C(  1626042968), -INT32_C(  1095245291), -INT32_C(   542830616),
+         INT32_C(   211816420),  INT32_C(   356488413),  INT32_C(   759013033),  INT32_C(    91687493), -INT32_C(  1076118425),  INT32_C(  1142933038), -INT32_C(  1862084951), -INT32_C(   898521114) },
+       INT32_C(         183),
+       INT32_C(           4),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),     -SIMDE_MATH_INFINITYF,
+            -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   282.67), SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00),     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(  -477.71), SIMDE_FLOAT32_C(    90.00) } },
+    { UINT16_C(43286),
+      { SIMDE_FLOAT32_C(   678.75), SIMDE_FLOAT32_C(   692.46), SIMDE_FLOAT32_C(   291.70), SIMDE_FLOAT32_C(  -502.13),
+        SIMDE_FLOAT32_C(     9.75), SIMDE_FLOAT32_C(  -313.03), SIMDE_FLOAT32_C(   554.94), SIMDE_FLOAT32_C(   255.73),
+        SIMDE_FLOAT32_C(  -609.50), SIMDE_FLOAT32_C(  -113.64), SIMDE_FLOAT32_C(  -155.28), SIMDE_FLOAT32_C(  -546.67),
+        SIMDE_FLOAT32_C(   655.53), SIMDE_FLOAT32_C(   -23.82), SIMDE_FLOAT32_C(   324.21), SIMDE_FLOAT32_C(  -564.60) },
+      { SIMDE_FLOAT32_C(   808.60), SIMDE_FLOAT32_C(   791.22), SIMDE_FLOAT32_C(   987.85), SIMDE_FLOAT32_C(  -320.40),
+        SIMDE_FLOAT32_C(   486.81), SIMDE_FLOAT32_C(  -891.80), SIMDE_FLOAT32_C(  -203.98), SIMDE_FLOAT32_C(  -179.73),
+        SIMDE_FLOAT32_C(   390.88), SIMDE_FLOAT32_C(    51.06), SIMDE_FLOAT32_C(   386.58), SIMDE_FLOAT32_C(  -829.41),
+        SIMDE_FLOAT32_C(   -20.26), SIMDE_FLOAT32_C(   908.86), SIMDE_FLOAT32_C(   873.87), SIMDE_FLOAT32_C(  -341.51) },
+      {  INT32_C(  2095559759), -INT32_C(    17567239),  INT32_C(   400142424),  INT32_C(   574071006), -INT32_C(   635105975), -INT32_C(  1119105805),  INT32_C(   395599235),  INT32_C(  1388423683),
+         INT32_C(  1473161310), -INT32_C(   246037863),  INT32_C(  1342713458),  INT32_C(   393428942),  INT32_C(  1089640525), -INT32_C(   385991324), -INT32_C(  1644195174), -INT32_C(  1695563716) },
+       INT32_C(         104),
+       INT32_C(           4),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(   987.85), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+             SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(    -0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.00) } },
+    { UINT16_C(62022),
+      { SIMDE_FLOAT32_C(   601.33), SIMDE_FLOAT32_C(   165.57), SIMDE_FLOAT32_C(   156.36), SIMDE_FLOAT32_C(  -388.92),
+        SIMDE_FLOAT32_C(   852.54), SIMDE_FLOAT32_C(  -288.70), SIMDE_FLOAT32_C(   866.81), SIMDE_FLOAT32_C(  -756.95),
+        SIMDE_FLOAT32_C(   597.66), SIMDE_FLOAT32_C(  -288.47), SIMDE_FLOAT32_C(  -303.62), SIMDE_FLOAT32_C(   253.19),
+        SIMDE_FLOAT32_C(   687.70), SIMDE_FLOAT32_C(  -979.41), SIMDE_FLOAT32_C(   688.59), SIMDE_FLOAT32_C(   496.30) },
+      { SIMDE_FLOAT32_C(   811.81), SIMDE_FLOAT32_C(   676.44), SIMDE_FLOAT32_C(  -824.10), SIMDE_FLOAT32_C(   298.62),
+        SIMDE_FLOAT32_C(   784.65), SIMDE_FLOAT32_C(   -28.08), SIMDE_FLOAT32_C(  -881.11), SIMDE_FLOAT32_C(   175.52),
+        SIMDE_FLOAT32_C(  -977.02), SIMDE_FLOAT32_C(   505.47), SIMDE_FLOAT32_C(   346.11), SIMDE_FLOAT32_C(     2.72),
+        SIMDE_FLOAT32_C(   414.33), SIMDE_FLOAT32_C(   219.98), SIMDE_FLOAT32_C(   661.21), SIMDE_FLOAT32_C(    15.66) },
+      {  INT32_C(  1123775730),  INT32_C(  1521826371), -INT32_C(   934523513), -INT32_C(  1698264398), -INT32_C(  1030137820),  INT32_C(   783374996), -INT32_C(  1004572734), -INT32_C(   508140049),
+         INT32_C(   472166873),  INT32_C(  1937234412), -INT32_C(   650394841),  INT32_C(  1920139597), -INT32_C(   315356071),  INT32_C(   689694054),  INT32_C(  1156397653),  INT32_C(  2032575391) },
+       INT32_C(          85),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(     0.00),      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00),            SIMDE_MATH_NANF,     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(    -0.00) } },
+    { UINT16_C(46092),
+      { SIMDE_FLOAT32_C(  -614.45), SIMDE_FLOAT32_C(  -182.43), SIMDE_FLOAT32_C(   626.74), SIMDE_FLOAT32_C(  -761.91),
+        SIMDE_FLOAT32_C(   528.87), SIMDE_FLOAT32_C(   493.54), SIMDE_FLOAT32_C(  -518.86), SIMDE_FLOAT32_C(   126.53),
+        SIMDE_FLOAT32_C(  -794.93), SIMDE_FLOAT32_C(   177.52), SIMDE_FLOAT32_C(  -620.27), SIMDE_FLOAT32_C(   892.78),
+        SIMDE_FLOAT32_C(   198.11), SIMDE_FLOAT32_C(  -931.68), SIMDE_FLOAT32_C(   389.08), SIMDE_FLOAT32_C(     9.92) },
+      { SIMDE_FLOAT32_C(   744.76), SIMDE_FLOAT32_C(   564.98), SIMDE_FLOAT32_C(  -691.46), SIMDE_FLOAT32_C(   529.41),
+        SIMDE_FLOAT32_C(  -463.10), SIMDE_FLOAT32_C(  -572.57), SIMDE_FLOAT32_C(  -295.07), SIMDE_FLOAT32_C(  -440.12),
+        SIMDE_FLOAT32_C(   932.90), SIMDE_FLOAT32_C(  -948.96), SIMDE_FLOAT32_C(   562.60), SIMDE_FLOAT32_C(   347.23),
+        SIMDE_FLOAT32_C(   271.02), SIMDE_FLOAT32_C(   223.82), SIMDE_FLOAT32_C(  -637.11), SIMDE_FLOAT32_C(   656.56) },
+      {  INT32_C(   602984522), -INT32_C(  1885933283),  INT32_C(   952345419),  INT32_C(   844409097),  INT32_C(  1109364478), -INT32_C(  1486306514),  INT32_C(  1497149976),  INT32_C(   537741782),
+         INT32_C(   910490905),  INT32_C(   986110703), -INT32_C(  2022536835),  INT32_C(   817481266), -INT32_C(  2089559723), -INT32_C(  1272259684),  INT32_C(  1678599822), -INT32_C(   930866513) },
+       INT32_C(          24),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),            SIMDE_MATH_NANF,
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(    90.00) } },
+    { UINT16_C(16837),
+      { SIMDE_FLOAT32_C(  -958.61), SIMDE_FLOAT32_C(   989.63), SIMDE_FLOAT32_C(   894.66), SIMDE_FLOAT32_C(   570.26),
+        SIMDE_FLOAT32_C(   483.18), SIMDE_FLOAT32_C(  -624.20), SIMDE_FLOAT32_C(  -303.20), SIMDE_FLOAT32_C(   688.25),
+        SIMDE_FLOAT32_C(   553.32), SIMDE_FLOAT32_C(    76.52), SIMDE_FLOAT32_C(   581.03), SIMDE_FLOAT32_C(  -248.57),
+        SIMDE_FLOAT32_C(   144.84), SIMDE_FLOAT32_C(   -29.90), SIMDE_FLOAT32_C(   761.35), SIMDE_FLOAT32_C(  -110.40) },
+      { SIMDE_FLOAT32_C(  -464.91), SIMDE_FLOAT32_C(  -930.11), SIMDE_FLOAT32_C(  -580.99), SIMDE_FLOAT32_C(    71.99),
+        SIMDE_FLOAT32_C(  -502.68), SIMDE_FLOAT32_C(   123.94), SIMDE_FLOAT32_C(   631.87), SIMDE_FLOAT32_C(  -569.77),
+        SIMDE_FLOAT32_C(   174.97), SIMDE_FLOAT32_C(   194.47), SIMDE_FLOAT32_C(   777.46), SIMDE_FLOAT32_C(  -554.01),
+        SIMDE_FLOAT32_C(  -581.71), SIMDE_FLOAT32_C(  -859.65), SIMDE_FLOAT32_C(  -897.45), SIMDE_FLOAT32_C(  -540.32) },
+      { -INT32_C(  1481421280), -INT32_C(  1319011711),  INT32_C(  1378106063), -INT32_C(  1971584810), -INT32_C(   224927090),  INT32_C(  1517728146), -INT32_C(   799457335),  INT32_C(    34676450),
+        -INT32_C(   290798227),  INT32_C(   245304127),  INT32_C(   459326533),  INT32_C(  1386601668),  INT32_C(  1346649278), -INT32_C(  1213482259), -INT32_C(   611908359), -INT32_C(  1864459997) },
+       INT32_C(          94),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(    -0.00), SIMDE_FLOAT32_C(     0.00),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.57),            SIMDE_MATH_NANF,
+        SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(     0.00) } },
+    { UINT16_C(43805),
+      { SIMDE_FLOAT32_C(  -870.01), SIMDE_FLOAT32_C(   997.21), SIMDE_FLOAT32_C(  -970.06), SIMDE_FLOAT32_C(   613.16),
+        SIMDE_FLOAT32_C(  -626.99), SIMDE_FLOAT32_C(  -273.26), SIMDE_FLOAT32_C(   301.41), SIMDE_FLOAT32_C(   926.33),
+        SIMDE_FLOAT32_C(   803.26), SIMDE_FLOAT32_C(  -117.56), SIMDE_FLOAT32_C(  -322.25), SIMDE_FLOAT32_C(   -51.89),
+        SIMDE_FLOAT32_C(   852.54), SIMDE_FLOAT32_C(  -560.90), SIMDE_FLOAT32_C(   837.71), SIMDE_FLOAT32_C(  -612.37) },
+      { SIMDE_FLOAT32_C(  -491.01), SIMDE_FLOAT32_C(  -743.29), SIMDE_FLOAT32_C(   459.62), SIMDE_FLOAT32_C(     6.31),
+        SIMDE_FLOAT32_C(   380.65), SIMDE_FLOAT32_C(    91.49), SIMDE_FLOAT32_C(   436.54), SIMDE_FLOAT32_C(  -444.38),
+        SIMDE_FLOAT32_C(  -714.04), SIMDE_FLOAT32_C(   214.00), SIMDE_FLOAT32_C(     1.62), SIMDE_FLOAT32_C(  -295.76),
+        SIMDE_FLOAT32_C(   354.35), SIMDE_FLOAT32_C(   104.17), SIMDE_FLOAT32_C(   163.92), SIMDE_FLOAT32_C(   484.34) },
+      { -INT32_C(   217325096), -INT32_C(   140974171), -INT32_C(   163851099),  INT32_C(  2023880385), -INT32_C(   889149969),  INT32_C(  1487509960), -INT32_C(  1797901833), -INT32_C(  1673530172),
+         INT32_C(  2072988373), -INT32_C(   697161935), -INT32_C(  1127436549), -INT32_C(  1825215068), -INT32_C(   614583021), -INT32_C(   986445874), -INT32_C(    61273544), -INT32_C(   728196866) },
+       INT32_C(         226),
+       INT32_C(           4),
+      {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(    -0.00),
+        SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(     1.57), SIMDE_FLOAT32_C(     0.00),            SIMDE_MATH_NANF,
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(    90.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     1.57) } },
+    { UINT16_C(59841),
+      { SIMDE_FLOAT32_C(   101.38), SIMDE_FLOAT32_C(   193.86), SIMDE_FLOAT32_C(    97.50), SIMDE_FLOAT32_C(   474.39),
+        SIMDE_FLOAT32_C(   920.60), SIMDE_FLOAT32_C(  -601.08), SIMDE_FLOAT32_C(   400.72), SIMDE_FLOAT32_C(   723.86),
+        SIMDE_FLOAT32_C(   281.36), SIMDE_FLOAT32_C(  -921.53), SIMDE_FLOAT32_C(  -328.03), SIMDE_FLOAT32_C(   133.90),
+        SIMDE_FLOAT32_C(  -482.43), SIMDE_FLOAT32_C(  -490.32), SIMDE_FLOAT32_C(   521.53), SIMDE_FLOAT32_C(    26.56) },
+      { SIMDE_FLOAT32_C(  -233.61), SIMDE_FLOAT32_C(   -18.85), SIMDE_FLOAT32_C(  -967.12), SIMDE_FLOAT32_C(  -852.96),
+        SIMDE_FLOAT32_C(  -927.36), SIMDE_FLOAT32_C(   469.42), SIMDE_FLOAT32_C(  -297.34), SIMDE_FLOAT32_C(  -641.41),
+        SIMDE_FLOAT32_C(  -316.58), SIMDE_FLOAT32_C(   704.28), SIMDE_FLOAT32_C(    62.83), SIMDE_FLOAT32_C(  -962.23),
+        SIMDE_FLOAT32_C(  -191.55), SIMDE_FLOAT32_C(  -773.25), SIMDE_FLOAT32_C(   522.11), SIMDE_FLOAT32_C(   909.83) },
+      {  INT32_C(   112619337), -INT32_C(  1489296621),  INT32_C(   302346294),  INT32_C(    54922558),  INT32_C(  1113346117),  INT32_C(   601551951), -INT32_C(   378404138), -INT32_C(  1697500336),
+        -INT32_C(  1230993245), -INT32_C(   497165396), -INT32_C(  1980472501), -INT32_C(  1249101200), -INT32_C(   621287285), -INT32_C(  1291988260),  INT32_C(   614166484),  INT32_C(  1170107810) },
+       INT32_C(         246),
+       INT32_C(           8),
+      {     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(    -1.00), SIMDE_FLOAT32_C(     1.00),
+            -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),      SIMDE_MATH_INFINITYF,
+        SIMDE_FLOAT32_C(     0.00),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF,     -SIMDE_MATH_INFINITYF } },
+    { UINT16_C(33881),
+      { SIMDE_FLOAT32_C(   420.61), SIMDE_FLOAT32_C(  -380.39), SIMDE_FLOAT32_C(   384.22), SIMDE_FLOAT32_C(   341.22),
+        SIMDE_FLOAT32_C(    18.53), SIMDE_FLOAT32_C(  -215.06), SIMDE_FLOAT32_C(    65.08), SIMDE_FLOAT32_C(  -700.11),
+        SIMDE_FLOAT32_C(  -136.59), SIMDE_FLOAT32_C(   737.05), SIMDE_FLOAT32_C(   433.80), SIMDE_FLOAT32_C(   380.99),
+        SIMDE_FLOAT32_C(  -753.27), SIMDE_FLOAT32_C(   -44.67), SIMDE_FLOAT32_C(  -592.45), SIMDE_FLOAT32_C(    13.12) },
+      { SIMDE_FLOAT32_C(   936.48), SIMDE_FLOAT32_C(  -559.57), SIMDE_FLOAT32_C(   160.16), SIMDE_FLOAT32_C(  -990.88),
+        SIMDE_FLOAT32_C(   909.85), SIMDE_FLOAT32_C(   862.82), SIMDE_FLOAT32_C(  -632.29), SIMDE_FLOAT32_C(  -406.74),
+        SIMDE_FLOAT32_C(   567.10), SIMDE_FLOAT32_C(   430.54), SIMDE_FLOAT32_C(  -368.97), SIMDE_FLOAT32_C(  -624.45),
+        SIMDE_FLOAT32_C(   657.29), SIMDE_FLOAT32_C(  -846.86), SIMDE_FLOAT32_C(  -714.62), SIMDE_FLOAT32_C(    77.91) },
+      {  INT32_C(   226081924), -INT32_C(   493243604),  INT32_C(   416907582),  INT32_C(   253078365), -INT32_C(  1532328833),  INT32_C(  1818368039), -INT32_C(  1335312114),  INT32_C(  2134164218),
+        -INT32_C(  1416843906), -INT32_C(  1618139551),  INT32_C(    95970983), -INT32_C(  1860907758),  INT32_C(  2033565522), -INT32_C(   437937961),  INT32_C(  1402293849), -INT32_C(  1898788592) },
+       INT32_C(         119),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(   420.61), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00),
+        SIMDE_FLOAT32_C(     1.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(    65.08), SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00),      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(     0.00),
+        SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00) } },
+  };
+
+  simde__m512 a, b, r;
+  simde__m512i c;
+
+  a = simde_mm512_loadu_ps(test_vec[0].a);
+  b = simde_mm512_loadu_ps(test_vec[0].b);
+  c = simde_mm512_loadu_epi32(test_vec[0].c);
+  r = simde_mm512_maskz_fixupimm_round_ps(test_vec[0].k, a, b, c, INT32_C(         183), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[0].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[1].a);
+  b = simde_mm512_loadu_ps(test_vec[1].b);
+  c = simde_mm512_loadu_epi32(test_vec[1].c);
+  r = simde_mm512_maskz_fixupimm_round_ps(test_vec[1].k, a, b, c, INT32_C(         104), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[1].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[2].a);
+  b = simde_mm512_loadu_ps(test_vec[2].b);
+  c = simde_mm512_loadu_epi32(test_vec[2].c);
+  r = simde_mm512_maskz_fixupimm_round_ps(test_vec[2].k, a, b, c, INT32_C(          85), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[2].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[3].a);
+  b = simde_mm512_loadu_ps(test_vec[3].b);
+  c = simde_mm512_loadu_epi32(test_vec[3].c);
+  r = simde_mm512_maskz_fixupimm_round_ps(test_vec[3].k, a, b, c, INT32_C(          24), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[3].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[4].a);
+  b = simde_mm512_loadu_ps(test_vec[4].b);
+  c = simde_mm512_loadu_epi32(test_vec[4].c);
+  r = simde_mm512_maskz_fixupimm_round_ps(test_vec[4].k, a, b, c, INT32_C(          94), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[4].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[5].a);
+  b = simde_mm512_loadu_ps(test_vec[5].b);
+  c = simde_mm512_loadu_epi32(test_vec[5].c);
+  r = simde_mm512_maskz_fixupimm_round_ps(test_vec[5].k, a, b, c, INT32_C(         226), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[5].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[6].a);
+  b = simde_mm512_loadu_ps(test_vec[6].b);
+  c = simde_mm512_loadu_epi32(test_vec[6].c);
+  r = simde_mm512_maskz_fixupimm_round_ps(test_vec[6].k, a, b, c, INT32_C(         246), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[6].r), 1);
+
+  a = simde_mm512_loadu_ps(test_vec[7].a);
+  b = simde_mm512_loadu_ps(test_vec[7].b);
+  c = simde_mm512_loadu_epi32(test_vec[7].c);
+  r = simde_mm512_maskz_fixupimm_round_ps(test_vec[7].k, a, b, c, INT32_C(         119), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x16(r, simde_mm512_loadu_ps(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float32 values[8 * 2 * sizeof(simde__m512)];
+  simde_test_x86_random_f32x16_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__mmask16 k = simde_test_x86_random_mmask16();
+    simde__m512 a = simde_test_x86_random_extract_f32x16(i, 2, 0, values);
+    simde__m512 b = simde_test_x86_random_extract_f32x16(i, 2, 1, values);
+    simde__m512i c = simde_test_x86_random_i32x16();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    int32_t sae = simde_test_codegen_rand() & 1 ? SIMDE_MM_FROUND_NO_EXC : SIMDE_MM_FROUND_CUR_DIRECTION;
+    simde__m512 r;
+    SIMDE_CONSTIFY_256_NEW(simde_mm512_maskz_fixupimm_round_ps, r, simde_mm512_setzero_ps(), imm8, sae, k, a, b, c);
+
+    simde_test_x86_write_mmask16(2, k, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_f32x16(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x16(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x16(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, sae, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x16(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  fprintf(stderr, "-------------------------\n------------------------\n----------------------\n");
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm512_fixupimm_round_pd (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde_float64 a[8];
+    const simde_float64 b[8];
+    const int64_t c[8];
+    const int imm8;
+    const int sae;
+    const simde_float64 r[8];
+  } test_vec[] = {
+    { { SIMDE_FLOAT64_C(   396.57), SIMDE_FLOAT64_C(  -372.12), SIMDE_FLOAT64_C(   818.53), SIMDE_FLOAT64_C(  -141.92),
+        SIMDE_FLOAT64_C(  -448.49), SIMDE_FLOAT64_C(  -343.61), SIMDE_FLOAT64_C(  -844.43), SIMDE_FLOAT64_C(   759.12) },
+      { SIMDE_FLOAT64_C(   378.41), SIMDE_FLOAT64_C(   141.84), SIMDE_FLOAT64_C(   796.31), SIMDE_FLOAT64_C(   268.49),
+        SIMDE_FLOAT64_C(   953.07), SIMDE_FLOAT64_C(  -566.68), SIMDE_FLOAT64_C(  -304.40), SIMDE_FLOAT64_C(   978.22) },
+      { -INT64_C( 7968095395795426675), -INT64_C( 4010061006190228465), -INT64_C(  208651453885577713),  INT64_C( 7541819480488314648),
+        -INT64_C( 8425353659227383538), -INT64_C( 1479507400353286675), -INT64_C( 8044917156261085247), -INT64_C(  828328191158977987) },
+       INT32_C(           8),
+       INT32_C(           4),
+      {       -SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(     1.57), SIMDE_FLOAT64_C(     0.50), SIMDE_FLOAT64_C(-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.00),
+        SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.00), SIMDE_FLOAT64_C(     1.57), SIMDE_FLOAT64_C(   978.22) } },
+    { { SIMDE_FLOAT64_C(  -600.14), SIMDE_FLOAT64_C(  -153.93), SIMDE_FLOAT64_C(  -818.29), SIMDE_FLOAT64_C(  -456.16),
+        SIMDE_FLOAT64_C(  -588.07), SIMDE_FLOAT64_C(  -308.93), SIMDE_FLOAT64_C(  -116.14), SIMDE_FLOAT64_C(   572.90) },
+      { SIMDE_FLOAT64_C(   416.75), SIMDE_FLOAT64_C(  -952.21), SIMDE_FLOAT64_C(  -852.48), SIMDE_FLOAT64_C(   216.83),
+        SIMDE_FLOAT64_C(  -412.85), SIMDE_FLOAT64_C(  -207.84), SIMDE_FLOAT64_C(  -753.11), SIMDE_FLOAT64_C(  -738.96) },
+      { -INT64_C( 1691261391516388442),  INT64_C( 8970737190664436719),  INT64_C( 2460468119575708550),  INT64_C(  402773509627777820),
+         INT64_C( 5315422228964568099), -INT64_C( 5758154306311178840),  INT64_C(  327018846016278960), -INT64_C( 1493759357831882783) },
+       INT32_C(           5),
+       INT32_C(           8),
+      { SIMDE_FLOAT64_C(     1.00),       -SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(    -0.00),
+        SIMDE_FLOAT64_C(    90.00), SIMDE_FLOAT64_C(     1.00), SIMDE_FLOAT64_C(    -0.00), SIMDE_FLOAT64_C(   572.90) } },
+    { { SIMDE_FLOAT64_C(   550.22), SIMDE_FLOAT64_C(  -934.99), SIMDE_FLOAT64_C(   328.61), SIMDE_FLOAT64_C(   252.74),
+        SIMDE_FLOAT64_C(   537.53), SIMDE_FLOAT64_C(   935.83), SIMDE_FLOAT64_C(  -404.91), SIMDE_FLOAT64_C(   355.80) },
+      { SIMDE_FLOAT64_C(   642.03), SIMDE_FLOAT64_C(  -576.67), SIMDE_FLOAT64_C(   701.53), SIMDE_FLOAT64_C(    -8.93),
+        SIMDE_FLOAT64_C(   149.39), SIMDE_FLOAT64_C(   265.79), SIMDE_FLOAT64_C(  -133.20), SIMDE_FLOAT64_C(  -653.83) },
+      { -INT64_C( 8555797571368129115), -INT64_C( 9008906835447566600), -INT64_C( 9172937362542184297),  INT64_C( 2927737244389304138),
+        -INT64_C( 4660970769111313322),  INT64_C( 7245900155468242710), -INT64_C( 3826434057922457261),  INT64_C( 2799122205149586989) },
+       INT32_C(         142),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(    -0.00),             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(     1.00), SIMDE_FLOAT64_C(-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.00),
+        SIMDE_FLOAT64_C(    90.00), SIMDE_FLOAT64_C(   935.83),        SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(   355.80) } },
+    { { SIMDE_FLOAT64_C(   566.18), SIMDE_FLOAT64_C(   725.12), SIMDE_FLOAT64_C(   650.97), SIMDE_FLOAT64_C(   665.97),
+        SIMDE_FLOAT64_C(  -495.48), SIMDE_FLOAT64_C(  -887.62), SIMDE_FLOAT64_C(   498.15), SIMDE_FLOAT64_C(   123.96) },
+      { SIMDE_FLOAT64_C(  -288.41), SIMDE_FLOAT64_C(   127.73), SIMDE_FLOAT64_C(   -87.94), SIMDE_FLOAT64_C(  -298.66),
+        SIMDE_FLOAT64_C(  -907.76), SIMDE_FLOAT64_C(   804.63), SIMDE_FLOAT64_C(  -323.27), SIMDE_FLOAT64_C(   747.49) },
+      {  INT64_C(   82478246986559214),  INT64_C( 8484469678701235165), -INT64_C( 3243018622757422856), -INT64_C( 7327044696793439543),
+        -INT64_C( 8623526139732711990), -INT64_C( 4679907658644135329), -INT64_C( 2060277968073285672), -INT64_C( 8911393606580986098) },
+       INT32_C(           3),
+       INT32_C(           8),
+      {        SIMDE_MATH_INFINITY,        SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.00), SIMDE_FLOAT64_C(     1.00),
+        SIMDE_FLOAT64_C(  -907.76), SIMDE_FLOAT64_C(    -1.00),       -SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(     0.50) } },
+    { { SIMDE_FLOAT64_C(   280.76), SIMDE_FLOAT64_C(   378.34), SIMDE_FLOAT64_C(  -130.75), SIMDE_FLOAT64_C(  -610.40),
+        SIMDE_FLOAT64_C(   956.51), SIMDE_FLOAT64_C(  -705.21), SIMDE_FLOAT64_C(   627.65), SIMDE_FLOAT64_C(  -889.42) },
+      { SIMDE_FLOAT64_C(  -256.92), SIMDE_FLOAT64_C(  -279.98), SIMDE_FLOAT64_C(   491.50), SIMDE_FLOAT64_C(   880.08),
+        SIMDE_FLOAT64_C(  -828.76), SIMDE_FLOAT64_C(  -788.33), SIMDE_FLOAT64_C(   203.96), SIMDE_FLOAT64_C(   105.27) },
+      {  INT64_C( 7198779726217541774),  INT64_C( 7719754988379335816), -INT64_C( 8999800471842006966),  INT64_C( 6793279613163186907),
+         INT64_C( 9003667574278045835), -INT64_C( 5148624352265676321),  INT64_C( 2804393790953685569), -INT64_C( 8714667603328407072) },
+       INT32_C(           7),
+       INT32_C(           8),
+      { SIMDE_FLOAT64_C(     1.57), SIMDE_FLOAT64_C(     0.50),        SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(     1.57),
+        SIMDE_FLOAT64_C(   956.51), SIMDE_FLOAT64_C(  -788.33),        SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(     0.50) } },
+    { { SIMDE_FLOAT64_C(  -460.14), SIMDE_FLOAT64_C(   186.05), SIMDE_FLOAT64_C(   171.62), SIMDE_FLOAT64_C(   254.80),
+        SIMDE_FLOAT64_C(  -383.32), SIMDE_FLOAT64_C(   838.05), SIMDE_FLOAT64_C(   805.13), SIMDE_FLOAT64_C(   716.93) },
+      { SIMDE_FLOAT64_C(   621.16), SIMDE_FLOAT64_C(   569.20), SIMDE_FLOAT64_C(   356.05), SIMDE_FLOAT64_C(   -89.44),
+        SIMDE_FLOAT64_C(  -496.48), SIMDE_FLOAT64_C(   828.84), SIMDE_FLOAT64_C(   333.90), SIMDE_FLOAT64_C(  -281.32) },
+      {  INT64_C( 6206640949288439484), -INT64_C( 3737327154453697926), -INT64_C( 5281594141347672113), -INT64_C( 6193230221650289524),
+        -INT64_C( 5860042712802080697),  INT64_C( 3470838669206817180), -INT64_C( 1673244096296297740), -INT64_C( 7339416782524245618) },
+       INT32_C(         239),
+       INT32_C(           4),
+      {             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(   569.20), SIMDE_FLOAT64_C(     0.00),             SIMDE_MATH_NAN,
+              -SIMDE_MATH_INFINITY,        SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(   333.90), SIMDE_FLOAT64_C(     0.50) } },
+    { { SIMDE_FLOAT64_C(   872.13), SIMDE_FLOAT64_C(   877.47), SIMDE_FLOAT64_C(    49.75), SIMDE_FLOAT64_C(  -669.06),
+        SIMDE_FLOAT64_C(  -421.54), SIMDE_FLOAT64_C(   -55.79), SIMDE_FLOAT64_C(   658.78), SIMDE_FLOAT64_C(   647.08) },
+      { SIMDE_FLOAT64_C(  -337.83), SIMDE_FLOAT64_C(    41.72), SIMDE_FLOAT64_C(  -745.03), SIMDE_FLOAT64_C(   458.45),
+        SIMDE_FLOAT64_C(    96.43), SIMDE_FLOAT64_C(  -759.84), SIMDE_FLOAT64_C(   138.15), SIMDE_FLOAT64_C(   539.84) },
+      { -INT64_C( 1319148123310412986), -INT64_C( 2777314434654385258), -INT64_C( 1738803029764736816),  INT64_C( 1233160340092374208),
+         INT64_C( 1904496545415304123),  INT64_C( 1910118099934661229),  INT64_C( 5320261381801312531), -INT64_C( 1187511915115502679) },
+       INT32_C(          47),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.00), SIMDE_FLOAT64_C(     0.00),       -SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(     0.50),
+        SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(    -1.00), SIMDE_FLOAT64_C(179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.00), SIMDE_FLOAT64_C(    -0.00) } },
+    { { SIMDE_FLOAT64_C(  -573.47), SIMDE_FLOAT64_C(   763.99), SIMDE_FLOAT64_C(   935.88), SIMDE_FLOAT64_C(  -109.60),
+        SIMDE_FLOAT64_C(   -21.59), SIMDE_FLOAT64_C(  -162.53), SIMDE_FLOAT64_C(   823.86), SIMDE_FLOAT64_C(   385.61) },
+      { SIMDE_FLOAT64_C(  -389.31), SIMDE_FLOAT64_C(   104.39), SIMDE_FLOAT64_C(  -964.64), SIMDE_FLOAT64_C(   586.47),
+        SIMDE_FLOAT64_C(   310.45), SIMDE_FLOAT64_C(   871.87), SIMDE_FLOAT64_C(   423.59), SIMDE_FLOAT64_C(  -910.88) },
+      { -INT64_C( 7080355148247956891), -INT64_C(  353673183669408757),  INT64_C( 8453986334756084302), -INT64_C( 1613592119628925915),
+         INT64_C( 4611456445470387680), -INT64_C( 7209041115402416932), -INT64_C( 3085334421648303631), -INT64_C( 7921371383508544604) },
+       INT32_C(          79),
+       INT32_C(           8),
+      { SIMDE_FLOAT64_C(    -1.00), SIMDE_FLOAT64_C(   763.99),             SIMDE_MATH_NAN,             SIMDE_MATH_NAN,
+               SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.00), SIMDE_FLOAT64_C(     0.50), SIMDE_FLOAT64_C(     0.00) } },
+  };
+
+  simde__m512d a, b, r;
+  simde__m512i c;
+
+  a = simde_mm512_loadu_pd(test_vec[0].a);
+  b = simde_mm512_loadu_pd(test_vec[0].b);
+  c = simde_mm512_loadu_epi64(test_vec[0].c);
+  r = simde_mm512_fixupimm_round_pd(a, b, c, INT32_C(           8), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[0].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[1].a);
+  b = simde_mm512_loadu_pd(test_vec[1].b);
+  c = simde_mm512_loadu_epi64(test_vec[1].c);
+  r = simde_mm512_fixupimm_round_pd(a, b, c, INT32_C(           5), INT32_C(           8));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[1].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[2].a);
+  b = simde_mm512_loadu_pd(test_vec[2].b);
+  c = simde_mm512_loadu_epi64(test_vec[2].c);
+  r = simde_mm512_fixupimm_round_pd(a, b, c, INT32_C(         142), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[2].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[3].a);
+  b = simde_mm512_loadu_pd(test_vec[3].b);
+  c = simde_mm512_loadu_epi64(test_vec[3].c);
+  r = simde_mm512_fixupimm_round_pd(a, b, c, INT32_C(           3), INT32_C(           8));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[3].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[4].a);
+  b = simde_mm512_loadu_pd(test_vec[4].b);
+  c = simde_mm512_loadu_epi64(test_vec[4].c);
+  r = simde_mm512_fixupimm_round_pd(a, b, c, INT32_C(           7), INT32_C(           8));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[4].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[5].a);
+  b = simde_mm512_loadu_pd(test_vec[5].b);
+  c = simde_mm512_loadu_epi64(test_vec[5].c);
+  r = simde_mm512_fixupimm_round_pd(a, b, c, INT32_C(         239), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[5].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[6].a);
+  b = simde_mm512_loadu_pd(test_vec[6].b);
+  c = simde_mm512_loadu_epi64(test_vec[6].c);
+  r = simde_mm512_fixupimm_round_pd(a, b, c, INT32_C(          47), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[6].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[7].a);
+  b = simde_mm512_loadu_pd(test_vec[7].b);
+  c = simde_mm512_loadu_epi64(test_vec[7].c);
+  r = simde_mm512_fixupimm_round_pd(a, b, c, INT32_C(          79), INT32_C(           8));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float64 values[8 * 2 * sizeof(simde__m512d)];
+  simde_test_x86_random_f64x8_full(8, 2, values, -1000.0, 1000.0, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__m512d a = simde_test_x86_random_f64x8(SIMDE_FLOAT64_C(-1000.0), SIMDE_FLOAT64_C(1000.0));
+    simde__m512d b = simde_test_x86_random_f64x8(SIMDE_FLOAT64_C(-1000.0), SIMDE_FLOAT64_C(1000.0));
+    simde__m512i c = simde_test_x86_random_i64x8();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    int32_t sae = simde_test_codegen_rand() & 1 ? SIMDE_MM_FROUND_NO_EXC : SIMDE_MM_FROUND_CUR_DIRECTION;
+    simde__m512d r;
+    SIMDE_CONSTIFY_256_NEW(simde_mm512_fixupimm_round_pd, r, simde_mm512_setzero_pd(), imm8, sae, a, b, c);
+
+    simde_test_x86_write_f64x8(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_f64x8(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i64x8(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, sae, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f64x8(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm512_mask_fixupimm_round_pd (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde_float64 a[8];
+    const simde__mmask8 k;
+    const simde_float64 b[8];
+    const int64_t c[8];
+    const int imm8;
+    const int sae;
+    const simde_float64 r[8];
+  } test_vec[] = {
+    { {             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(   449.69),             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(  -958.94),
+        SIMDE_FLOAT64_C(   574.51), SIMDE_FLOAT64_C(  -911.71), SIMDE_FLOAT64_C(  -811.80), SIMDE_FLOAT64_C(  -558.40) },
+      UINT8_C(103),
+      { SIMDE_FLOAT64_C(  -435.21),             SIMDE_MATH_NAN,             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(  -269.79),
+        SIMDE_FLOAT64_C(  -150.39), SIMDE_FLOAT64_C(    47.71), SIMDE_FLOAT64_C(  -591.58), SIMDE_FLOAT64_C(   727.90) },
+      { -INT64_C( 3091491664709224112), -INT64_C( 2065458207807749348),  INT64_C(  326670077314333435),  INT64_C( 8427241112902148172),
+        -INT64_C( 3740408062606909556),  INT64_C( 5350606551697935274),  INT64_C( 3377471996440367654),  INT64_C( 1686788877068204240) },
+       INT32_C(         140),
+       INT32_C(           8),
+      { SIMDE_FLOAT64_C(     1.00), SIMDE_FLOAT64_C(    90.00), SIMDE_FLOAT64_C(     0.50), SIMDE_FLOAT64_C(  -958.94),
+        SIMDE_FLOAT64_C(   574.51),        SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(     1.00), SIMDE_FLOAT64_C(  -558.40) } },
+    { { SIMDE_FLOAT64_C(  -765.11), SIMDE_FLOAT64_C(  -296.20), SIMDE_FLOAT64_C(  -198.19), SIMDE_FLOAT64_C(   134.85),
+        SIMDE_FLOAT64_C(   -73.18), SIMDE_FLOAT64_C(   943.22), SIMDE_FLOAT64_C(   171.18), SIMDE_FLOAT64_C(   166.58) },
+      UINT8_C(112),
+      { SIMDE_FLOAT64_C(  -290.59), SIMDE_FLOAT64_C(   507.66), SIMDE_FLOAT64_C(   118.45), SIMDE_FLOAT64_C(   650.48),
+        SIMDE_FLOAT64_C(  -952.25), SIMDE_FLOAT64_C(   151.79), SIMDE_FLOAT64_C(  -245.18), SIMDE_FLOAT64_C(   973.91) },
+      {  INT64_C( 7352419024409184007), -INT64_C( 1716545415744508075),  INT64_C( 6427037927806729674),  INT64_C(   21723020579028356),
+         INT64_C( 7457932473349769459), -INT64_C( 7131571148983879659), -INT64_C( 2821414643683956594),  INT64_C(  578714837185849359) },
+       INT32_C(          10),
+       INT32_C(           8),
+      { SIMDE_FLOAT64_C(  -765.11), SIMDE_FLOAT64_C(  -296.20), SIMDE_FLOAT64_C(  -198.19), SIMDE_FLOAT64_C(   134.85),
+        SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(   151.79), SIMDE_FLOAT64_C(-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.00), SIMDE_FLOAT64_C(   166.58) } },
+    { { SIMDE_FLOAT64_C(  -398.52), SIMDE_FLOAT64_C(   165.13), SIMDE_FLOAT64_C(  -985.03), SIMDE_FLOAT64_C(  -824.01),
+        SIMDE_FLOAT64_C(   253.42), SIMDE_FLOAT64_C(  -796.83), SIMDE_FLOAT64_C(  -382.41), SIMDE_FLOAT64_C(   818.21) },
+      UINT8_C(159),
+      { SIMDE_FLOAT64_C(  -665.26), SIMDE_FLOAT64_C(  -395.57), SIMDE_FLOAT64_C(  -451.58), SIMDE_FLOAT64_C(   184.35),
+        SIMDE_FLOAT64_C(   652.15), SIMDE_FLOAT64_C(   -43.16), SIMDE_FLOAT64_C(   -87.75), SIMDE_FLOAT64_C(   887.04) },
+      {  INT64_C(  394817028681621636),  INT64_C( 7042577070977517896), -INT64_C( 2534860471647220710),  INT64_C( 9089826430547778917),
+        -INT64_C( 1121147094247670420), -INT64_C( 4984332913989755413), -INT64_C( 2264364501207212573),  INT64_C( 5526634587299927097) },
+       INT32_C(         137),
+       INT32_C(           8),
+      { SIMDE_FLOAT64_C(    -1.00), SIMDE_FLOAT64_C(     1.00), SIMDE_FLOAT64_C(  -985.03), SIMDE_FLOAT64_C(     0.00),
+               SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(  -796.83), SIMDE_FLOAT64_C(  -382.41),             SIMDE_MATH_NAN } },
+    { { SIMDE_FLOAT64_C(   660.64), SIMDE_FLOAT64_C(   714.07), SIMDE_FLOAT64_C(    21.89), SIMDE_FLOAT64_C(  -412.54),
+        SIMDE_FLOAT64_C(   657.29), SIMDE_FLOAT64_C(  -806.94), SIMDE_FLOAT64_C(   754.03), SIMDE_FLOAT64_C(  -633.30) },
+      UINT8_C( 38),
+      { SIMDE_FLOAT64_C(   700.72), SIMDE_FLOAT64_C(  -127.51), SIMDE_FLOAT64_C(  -982.82), SIMDE_FLOAT64_C(   748.46),
+        SIMDE_FLOAT64_C(  -975.72), SIMDE_FLOAT64_C(  -228.00), SIMDE_FLOAT64_C(   722.38), SIMDE_FLOAT64_C(  -374.24) },
+      {  INT64_C( 3356065018864264737), -INT64_C( 4556297925171579171), -INT64_C( 2046054589159637593),  INT64_C( 8439174320566838080),
+        -INT64_C( 6744275938660212258),  INT64_C( 2443147247396434938),  INT64_C( 3449697872154459083), -INT64_C( 5569189314603590676) },
+       INT32_C(         228),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(   660.64), SIMDE_FLOAT64_C(    -0.00), SIMDE_FLOAT64_C(179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.00), SIMDE_FLOAT64_C(  -412.54),
+        SIMDE_FLOAT64_C(   657.29), SIMDE_FLOAT64_C(    -0.00), SIMDE_FLOAT64_C(   754.03), SIMDE_FLOAT64_C(  -633.30) } },
+    { { SIMDE_FLOAT64_C(   937.13), SIMDE_FLOAT64_C(   737.34), SIMDE_FLOAT64_C(  -198.25), SIMDE_FLOAT64_C(   190.56),
+        SIMDE_FLOAT64_C(   940.51), SIMDE_FLOAT64_C(   419.34), SIMDE_FLOAT64_C(     8.77), SIMDE_FLOAT64_C(  -724.74) },
+      UINT8_C( 81),
+      { SIMDE_FLOAT64_C(  -976.23), SIMDE_FLOAT64_C(   557.19), SIMDE_FLOAT64_C(   459.61), SIMDE_FLOAT64_C(   675.92),
+        SIMDE_FLOAT64_C(  -485.97), SIMDE_FLOAT64_C(  -628.14), SIMDE_FLOAT64_C(   562.95), SIMDE_FLOAT64_C(  -825.33) },
+      {  INT64_C( 3828480033123739210), -INT64_C( 4064181004444504928),  INT64_C( 8987345126160565584), -INT64_C( 8042215876484424408),
+        -INT64_C( 8648875116389439114), -INT64_C( 7231953843027236110), -INT64_C( 1965879806825249419), -INT64_C( 6900540290189763737) },
+       INT32_C(         196),
+       INT32_C(           4),
+      {       -SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(   737.34), SIMDE_FLOAT64_C(  -198.25), SIMDE_FLOAT64_C(   190.56),
+              -SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(   419.34),             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(  -724.74) } },
+    { { SIMDE_FLOAT64_C(  -914.07), SIMDE_FLOAT64_C(  -415.16), SIMDE_FLOAT64_C(  -237.87), SIMDE_FLOAT64_C(   743.21),
+        SIMDE_FLOAT64_C(  -222.10), SIMDE_FLOAT64_C(  -483.84), SIMDE_FLOAT64_C(  -890.09), SIMDE_FLOAT64_C(  -521.38) },
+      UINT8_C( 94),
+      { SIMDE_FLOAT64_C(   388.65), SIMDE_FLOAT64_C(  -872.90), SIMDE_FLOAT64_C(  -772.92), SIMDE_FLOAT64_C(   412.93),
+        SIMDE_FLOAT64_C(  -100.91), SIMDE_FLOAT64_C(   949.46), SIMDE_FLOAT64_C(  -961.31), SIMDE_FLOAT64_C(  -163.77) },
+      { -INT64_C( 7747647170277795789), -INT64_C( 2068958539738910610), -INT64_C( 7364537277613166471),  INT64_C( 8019750113754386569),
+         INT64_C( 1621142655427335416),  INT64_C( 7382490425616324708), -INT64_C( 6735517960454655601),  INT64_C( 1791829159103709234) },
+       INT32_C(         175),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(  -914.07), SIMDE_FLOAT64_C(-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.00), SIMDE_FLOAT64_C(  -237.87), SIMDE_FLOAT64_C(179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.00),
+        SIMDE_FLOAT64_C(     1.00), SIMDE_FLOAT64_C(  -483.84), SIMDE_FLOAT64_C(    90.00), SIMDE_FLOAT64_C(  -521.38) } },
+    { { SIMDE_FLOAT64_C(   686.80), SIMDE_FLOAT64_C(  -159.56), SIMDE_FLOAT64_C(  -973.22), SIMDE_FLOAT64_C(   627.31),
+        SIMDE_FLOAT64_C(  -740.23), SIMDE_FLOAT64_C(    35.55), SIMDE_FLOAT64_C(   902.57), SIMDE_FLOAT64_C(  -716.46) },
+      UINT8_C(129),
+      { SIMDE_FLOAT64_C(  -407.25), SIMDE_FLOAT64_C(   362.18), SIMDE_FLOAT64_C(   959.46), SIMDE_FLOAT64_C(   106.78),
+        SIMDE_FLOAT64_C(   734.04), SIMDE_FLOAT64_C(   522.41), SIMDE_FLOAT64_C(   281.45), SIMDE_FLOAT64_C(   819.96) },
+      { -INT64_C( 5484883793420832659), -INT64_C( 2042665705498447570),  INT64_C( 2597525053820360864),  INT64_C( 9214161506851863387),
+        -INT64_C( 5770127615918425608),  INT64_C( 8004403754381332692), -INT64_C( 2837923639068772046), -INT64_C( 2812192438465685401) },
+       INT32_C(         207),
+       INT32_C(           4),
+      {             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(  -159.56), SIMDE_FLOAT64_C(  -973.22), SIMDE_FLOAT64_C(   627.31),
+        SIMDE_FLOAT64_C(  -740.23), SIMDE_FLOAT64_C(    35.55), SIMDE_FLOAT64_C(   902.57), SIMDE_FLOAT64_C(    -0.00) } },
+    { { SIMDE_FLOAT64_C(  -892.75), SIMDE_FLOAT64_C(  -956.42), SIMDE_FLOAT64_C(   563.18), SIMDE_FLOAT64_C(  -114.85),
+        SIMDE_FLOAT64_C(  -440.26), SIMDE_FLOAT64_C(   673.09), SIMDE_FLOAT64_C(   363.77), SIMDE_FLOAT64_C(   948.39) },
+      UINT8_C(252),
+      { SIMDE_FLOAT64_C(   800.19), SIMDE_FLOAT64_C(   590.85), SIMDE_FLOAT64_C(   361.32), SIMDE_FLOAT64_C(  -300.72),
+        SIMDE_FLOAT64_C(   540.31), SIMDE_FLOAT64_C(   400.01), SIMDE_FLOAT64_C(   535.51), SIMDE_FLOAT64_C(   227.12) },
+      { -INT64_C(  428796453657398273),  INT64_C( 6149015173420236554),  INT64_C( 3446323774883740808), -INT64_C( 1030610788686323035),
+         INT64_C( 2673924434332778299), -INT64_C( 8720053002828820753),  INT64_C( 6721086668545518305), -INT64_C( 5431686974176759622) },
+       INT32_C(          69),
+       INT32_C(           8),
+      { SIMDE_FLOAT64_C(  -892.75), SIMDE_FLOAT64_C(  -956.42), SIMDE_FLOAT64_C(     0.50),       -SIMDE_MATH_INFINITY,
+                    SIMDE_MATH_NAN, SIMDE_FLOAT64_C(     1.00), SIMDE_FLOAT64_C(   535.51), SIMDE_FLOAT64_C(     1.00) } },
+  };
+
+  simde__m512d a, b, r;
+  simde__m512i c;
+
+  a = simde_mm512_loadu_pd(test_vec[0].a);
+  b = simde_mm512_loadu_pd(test_vec[0].b);
+  c = simde_mm512_loadu_epi64(test_vec[0].c);
+  r = simde_mm512_mask_fixupimm_round_pd(a, test_vec[0].k, b, c, INT32_C(         140), INT32_C(           8));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[0].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[1].a);
+  b = simde_mm512_loadu_pd(test_vec[1].b);
+  c = simde_mm512_loadu_epi64(test_vec[1].c);
+  r = simde_mm512_mask_fixupimm_round_pd(a, test_vec[1].k, b, c, INT32_C(          10), INT32_C(           8));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[1].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[2].a);
+  b = simde_mm512_loadu_pd(test_vec[2].b);
+  c = simde_mm512_loadu_epi64(test_vec[2].c);
+  r = simde_mm512_mask_fixupimm_round_pd(a, test_vec[2].k, b, c, INT32_C(         137), INT32_C(           8));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[2].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[3].a);
+  b = simde_mm512_loadu_pd(test_vec[3].b);
+  c = simde_mm512_loadu_epi64(test_vec[3].c);
+  r = simde_mm512_mask_fixupimm_round_pd(a, test_vec[3].k, b, c, INT32_C(         228), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[3].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[4].a);
+  b = simde_mm512_loadu_pd(test_vec[4].b);
+  c = simde_mm512_loadu_epi64(test_vec[4].c);
+  r = simde_mm512_mask_fixupimm_round_pd(a, test_vec[4].k, b, c, INT32_C(         196), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[4].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[5].a);
+  b = simde_mm512_loadu_pd(test_vec[5].b);
+  c = simde_mm512_loadu_epi64(test_vec[5].c);
+  r = simde_mm512_mask_fixupimm_round_pd(a, test_vec[5].k, b, c, INT32_C(         175), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[5].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[6].a);
+  b = simde_mm512_loadu_pd(test_vec[6].b);
+  c = simde_mm512_loadu_epi64(test_vec[6].c);
+  r = simde_mm512_mask_fixupimm_round_pd(a, test_vec[6].k, b, c, INT32_C(         207), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[6].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[7].a);
+  b = simde_mm512_loadu_pd(test_vec[7].b);
+  c = simde_mm512_loadu_epi64(test_vec[7].c);
+  r = simde_mm512_mask_fixupimm_round_pd(a, test_vec[7].k, b, c, INT32_C(          69), INT32_C(           8));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float64 values[8 * 2 * sizeof(simde__m512d)];
+  simde_test_x86_random_f64x8_full(8, 2, values, -1000.0, 1000.0, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__m512d a = simde_test_x86_random_extract_f64x8(i, 2, 0, values);
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m512d b = simde_test_x86_random_extract_f64x8(i, 2, 1, values);
+    simde__m512i c = simde_test_x86_random_i64x8();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    int32_t sae = simde_test_codegen_rand() & 1 ? SIMDE_MM_FROUND_NO_EXC : SIMDE_MM_FROUND_CUR_DIRECTION;
+    simde__m512d r;
+    SIMDE_CONSTIFY_256_NEW(simde_mm512_mask_fixupimm_round_pd, r, simde_mm512_setzero_pd(), imm8, sae, a, k, b, c);
+
+    simde_test_x86_write_f64x8(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f64x8(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i64x8(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, sae, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f64x8(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm512_maskz_fixupimm_round_pd (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde__mmask8 k;
+    const simde_float64 a[8];
+    const simde_float64 b[8];
+    const int64_t c[8];
+    const int imm8;
+    const int sae;
+    const simde_float64 r[8];
+  } test_vec[] = {
+    { UINT8_C(110),
+      {             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(  -413.76),             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(   584.12),
+        SIMDE_FLOAT64_C(  -725.33), SIMDE_FLOAT64_C(  -298.11), SIMDE_FLOAT64_C(  -907.92), SIMDE_FLOAT64_C(   785.36) },
+      { SIMDE_FLOAT64_C(  -183.16),             SIMDE_MATH_NAN,             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(   -97.02),
+        SIMDE_FLOAT64_C(  -849.62), SIMDE_FLOAT64_C(   487.32), SIMDE_FLOAT64_C(   947.20), SIMDE_FLOAT64_C(    17.87) },
+      {  INT64_C( 3077269692546566682),  INT64_C( 3779625075164806554), -INT64_C( 8081995546433646526),  INT64_C( 1536048508374505365),
+        -INT64_C( 2084322984624152211), -INT64_C( 7157244168448152196), -INT64_C( 4298021534023928596),  INT64_C( 6396229586927470772) },
+       INT32_C(         154),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(     1.00),             SIMDE_MATH_NAN,             SIMDE_MATH_NAN,
+        SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(    -0.00), SIMDE_FLOAT64_C(    90.00), SIMDE_FLOAT64_C(     0.00) } },
+    { UINT8_C( 83),
+      { SIMDE_FLOAT64_C(  -890.57), SIMDE_FLOAT64_C(  -218.08), SIMDE_FLOAT64_C(   383.97), SIMDE_FLOAT64_C(   343.07),
+        SIMDE_FLOAT64_C(  -339.77), SIMDE_FLOAT64_C(   496.28), SIMDE_FLOAT64_C(    -3.73), SIMDE_FLOAT64_C(  -614.47) },
+      { SIMDE_FLOAT64_C(    51.45), SIMDE_FLOAT64_C(   631.11), SIMDE_FLOAT64_C(  -579.19), SIMDE_FLOAT64_C(  -448.65),
+        SIMDE_FLOAT64_C(   196.16), SIMDE_FLOAT64_C(   875.22), SIMDE_FLOAT64_C(  -444.72), SIMDE_FLOAT64_C(  -753.93) },
+      { -INT64_C( 5905316412531832121),  INT64_C( 2204814126618966454), -INT64_C( 4650298687117439530), -INT64_C( 4918251900231675863),
+         INT64_C( 5771212948264157030), -INT64_C( 2138606142991042192),  INT64_C( 3687839005881153650),  INT64_C( 4365777867147967207) },
+       INT32_C(         218),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(     0.50),             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(     0.00),
+               SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.00), SIMDE_FLOAT64_C(     0.00) } },
+    { UINT8_C(187),
+      { SIMDE_FLOAT64_C(  -538.54), SIMDE_FLOAT64_C(   258.01), SIMDE_FLOAT64_C(   830.19), SIMDE_FLOAT64_C(  -263.88),
+        SIMDE_FLOAT64_C(   959.91), SIMDE_FLOAT64_C(   922.26), SIMDE_FLOAT64_C(  -478.52), SIMDE_FLOAT64_C(  -223.26) },
+      { SIMDE_FLOAT64_C(   984.23), SIMDE_FLOAT64_C(  -425.15), SIMDE_FLOAT64_C(   679.72), SIMDE_FLOAT64_C(  -865.39),
+        SIMDE_FLOAT64_C(  -937.83), SIMDE_FLOAT64_C(   626.92), SIMDE_FLOAT64_C(   152.48), SIMDE_FLOAT64_C(  -828.40) },
+      {  INT64_C( 8103875811640469956), -INT64_C( 8945923102313224030),  INT64_C( 3593402579574243557), -INT64_C( 1085180403365267312),
+         INT64_C(  585951073928324499),  INT64_C( 6951837621371455903), -INT64_C( 2634674728066615389), -INT64_C( 2335679027541401223) },
+       INT32_C(         165),
+       INT32_C(           4),
+      {        SIMDE_MATH_INFINITY,             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(     0.00),       -SIMDE_MATH_INFINITY,
+        SIMDE_FLOAT64_C(  -937.83), SIMDE_FLOAT64_C(-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.00), SIMDE_FLOAT64_C(     0.00),       -SIMDE_MATH_INFINITY } },
+    { UINT8_C(177),
+      { SIMDE_FLOAT64_C(  -591.16), SIMDE_FLOAT64_C(  -463.55), SIMDE_FLOAT64_C(   514.67), SIMDE_FLOAT64_C(    69.07),
+        SIMDE_FLOAT64_C(  -967.27), SIMDE_FLOAT64_C(  -489.06), SIMDE_FLOAT64_C(   454.60), SIMDE_FLOAT64_C(    84.18) },
+      { SIMDE_FLOAT64_C(  -857.95), SIMDE_FLOAT64_C(   875.42), SIMDE_FLOAT64_C(   635.53), SIMDE_FLOAT64_C(   338.21),
+        SIMDE_FLOAT64_C(   750.64), SIMDE_FLOAT64_C(  -809.19), SIMDE_FLOAT64_C(   584.28), SIMDE_FLOAT64_C(  -787.91) },
+      { -INT64_C( 7133431174780998126),  INT64_C( 5979620192514581591), -INT64_C( 5635059649407126340), -INT64_C( 8187236827589480161),
+         INT64_C( 2956239125619661893),  INT64_C( 4072483850564115279), -INT64_C( 2981716414898604077), -INT64_C( 8986116949339199679) },
+       INT32_C(         194),
+       INT32_C(           8),
+      { SIMDE_FLOAT64_C(     1.57), SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(     0.00),
+               SIMDE_MATH_INFINITY,             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(    90.00) } },
+    { UINT8_C(242),
+      { SIMDE_FLOAT64_C(   448.82), SIMDE_FLOAT64_C(   414.47), SIMDE_FLOAT64_C(   -51.78), SIMDE_FLOAT64_C(   408.72),
+        SIMDE_FLOAT64_C(   336.73), SIMDE_FLOAT64_C(   469.70), SIMDE_FLOAT64_C(  -814.53), SIMDE_FLOAT64_C(   320.96) },
+      { SIMDE_FLOAT64_C(  -955.45), SIMDE_FLOAT64_C(   865.19), SIMDE_FLOAT64_C(   455.57), SIMDE_FLOAT64_C(  -893.28),
+        SIMDE_FLOAT64_C(   492.11), SIMDE_FLOAT64_C(  -391.96), SIMDE_FLOAT64_C(  -721.69), SIMDE_FLOAT64_C(   900.95) },
+      { -INT64_C( 6449143524669591362), -INT64_C( 2371473677438004414),  INT64_C( 6779962613230360491),  INT64_C( 3289585334132922823),
+        -INT64_C( 9174167525589568283),  INT64_C( 5495478556060732451),  INT64_C( 6243277222719539763), -INT64_C( 3384261688146921363) },
+       INT32_C(         227),
+       INT32_C(           8),
+      { SIMDE_FLOAT64_C(     0.00),       -SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(     0.00),
+        SIMDE_FLOAT64_C(   336.73),       -SIMDE_MATH_INFINITY,       -SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(     1.57) } },
+    { UINT8_C(135),
+      { SIMDE_FLOAT64_C(   144.50), SIMDE_FLOAT64_C(   792.98), SIMDE_FLOAT64_C(   -29.98), SIMDE_FLOAT64_C(   177.22),
+        SIMDE_FLOAT64_C(  -696.08), SIMDE_FLOAT64_C(  -575.37), SIMDE_FLOAT64_C(  -738.60), SIMDE_FLOAT64_C(  -554.02) },
+      { SIMDE_FLOAT64_C(  -699.96), SIMDE_FLOAT64_C(   896.93), SIMDE_FLOAT64_C(   784.19), SIMDE_FLOAT64_C(  -949.32),
+        SIMDE_FLOAT64_C(  -912.27), SIMDE_FLOAT64_C(   368.47), SIMDE_FLOAT64_C(  -737.22), SIMDE_FLOAT64_C(   536.55) },
+      { -INT64_C( 1061736057234306399),  INT64_C( 7012327536071505472), -INT64_C( 6784313744314221280),  INT64_C( 9184845007431449623),
+        -INT64_C(  141534917352240535),  INT64_C( 3368423202643199137),  INT64_C( 8503131857160247752), -INT64_C( 8985844429119554835) },
+       INT32_C(         169),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(    -0.00), SIMDE_FLOAT64_C(     0.50),             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(     0.00),
+        SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(    90.00) } },
+    { UINT8_C(163),
+      { SIMDE_FLOAT64_C(  -217.06), SIMDE_FLOAT64_C(   210.99), SIMDE_FLOAT64_C(   -54.73), SIMDE_FLOAT64_C(  -880.33),
+        SIMDE_FLOAT64_C(  -319.31), SIMDE_FLOAT64_C(   130.74), SIMDE_FLOAT64_C(   440.63), SIMDE_FLOAT64_C(  -274.76) },
+      { SIMDE_FLOAT64_C(    -4.07), SIMDE_FLOAT64_C(  -103.81), SIMDE_FLOAT64_C(  -168.04), SIMDE_FLOAT64_C(  -511.96),
+        SIMDE_FLOAT64_C(   504.24), SIMDE_FLOAT64_C(   110.28), SIMDE_FLOAT64_C(  -611.01), SIMDE_FLOAT64_C(  -351.27) },
+      {  INT64_C( 1958210809270697318),  INT64_C( 6246091724296614949), -INT64_C( 5598139918811358455), -INT64_C( 4239505320169899796),
+         INT64_C( 3365334653998600766), -INT64_C( 8813164609433507834),  INT64_C( 6272745079596974580),  INT64_C( 8097762618462105916) },
+       INT32_C(          27),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(    -4.07), SIMDE_FLOAT64_C(     1.57), SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(     0.00),
+        SIMDE_FLOAT64_C(     0.00),        SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(    90.00) } },
+    { UINT8_C(190),
+      { SIMDE_FLOAT64_C(   -96.74), SIMDE_FLOAT64_C(   359.01), SIMDE_FLOAT64_C(   825.96), SIMDE_FLOAT64_C(   207.18),
+        SIMDE_FLOAT64_C(   783.64), SIMDE_FLOAT64_C(  -912.64), SIMDE_FLOAT64_C(   653.16), SIMDE_FLOAT64_C(  -916.32) },
+      { SIMDE_FLOAT64_C(   984.28), SIMDE_FLOAT64_C(   437.35), SIMDE_FLOAT64_C(  -865.63), SIMDE_FLOAT64_C(  -927.99),
+        SIMDE_FLOAT64_C(  -194.18), SIMDE_FLOAT64_C(  -602.86), SIMDE_FLOAT64_C(   608.57), SIMDE_FLOAT64_C(   588.75) },
+      {  INT64_C( 7878522793235997010), -INT64_C( 5484864661059908953),  INT64_C( 1951984678309535023), -INT64_C( 6408977045583089337),
+         INT64_C( 9099517377118516510), -INT64_C( 4783109162989341372),  INT64_C( 7056543696481370905),  INT64_C( 3174685955444527122) },
+       INT32_C(         117),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(    -1.00), SIMDE_FLOAT64_C(     1.57), SIMDE_FLOAT64_C(   207.18),
+        SIMDE_FLOAT64_C(     1.00), SIMDE_FLOAT64_C(     1.00), SIMDE_FLOAT64_C(     0.00),        SIMDE_MATH_INFINITY } },
+  };
+
+  simde__m512d a, b, r;
+  simde__m512i c;
+
+  a = simde_mm512_loadu_pd(test_vec[0].a);
+  b = simde_mm512_loadu_pd(test_vec[0].b);
+  c = simde_mm512_loadu_epi64(test_vec[0].c);
+  r = simde_mm512_maskz_fixupimm_round_pd(test_vec[0].k, a, b, c, INT32_C(         154), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[0].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[1].a);
+  b = simde_mm512_loadu_pd(test_vec[1].b);
+  c = simde_mm512_loadu_epi64(test_vec[1].c);
+  r = simde_mm512_maskz_fixupimm_round_pd(test_vec[1].k, a, b, c, INT32_C(         218), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[1].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[2].a);
+  b = simde_mm512_loadu_pd(test_vec[2].b);
+  c = simde_mm512_loadu_epi64(test_vec[2].c);
+  r = simde_mm512_maskz_fixupimm_round_pd(test_vec[2].k, a, b, c, INT32_C(         165), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[2].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[3].a);
+  b = simde_mm512_loadu_pd(test_vec[3].b);
+  c = simde_mm512_loadu_epi64(test_vec[3].c);
+  r = simde_mm512_maskz_fixupimm_round_pd(test_vec[3].k, a, b, c, INT32_C(         194), INT32_C(           8));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[3].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[4].a);
+  b = simde_mm512_loadu_pd(test_vec[4].b);
+  c = simde_mm512_loadu_epi64(test_vec[4].c);
+  r = simde_mm512_maskz_fixupimm_round_pd(test_vec[4].k, a, b, c, INT32_C(         227), INT32_C(           8));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[4].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[5].a);
+  b = simde_mm512_loadu_pd(test_vec[5].b);
+  c = simde_mm512_loadu_epi64(test_vec[5].c);
+  r = simde_mm512_maskz_fixupimm_round_pd(test_vec[5].k, a, b, c, INT32_C(         169), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[5].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[6].a);
+  b = simde_mm512_loadu_pd(test_vec[6].b);
+  c = simde_mm512_loadu_epi64(test_vec[6].c);
+  r = simde_mm512_maskz_fixupimm_round_pd(test_vec[6].k, a, b, c, INT32_C(          27), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[6].r), 1);
+
+  a = simde_mm512_loadu_pd(test_vec[7].a);
+  b = simde_mm512_loadu_pd(test_vec[7].b);
+  c = simde_mm512_loadu_epi64(test_vec[7].c);
+  r = simde_mm512_maskz_fixupimm_round_pd(test_vec[7].k, a, b, c, INT32_C(         117), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x8(r, simde_mm512_loadu_pd(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float64 values[8 * 2 * sizeof(simde__m512d)];
+  simde_test_x86_random_f64x8_full(8, 2, values, -1000.0, 1000.0, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m512d a = simde_test_x86_random_extract_f64x8(i, 2, 0, values);
+    simde__m512d b = simde_test_x86_random_extract_f64x8(i, 2, 1, values);
+    simde__m512i c = simde_test_x86_random_i64x8();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    int32_t sae = simde_test_codegen_rand() & 1 ? SIMDE_MM_FROUND_NO_EXC : SIMDE_MM_FROUND_CUR_DIRECTION;
+    simde__m512d r;
+    SIMDE_CONSTIFY_256_NEW(simde_mm512_maskz_fixupimm_round_pd, r, simde_mm512_setzero_pd(), imm8, sae, k, a, b, c);
+
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_f64x8(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f64x8(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i64x8(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, sae, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f64x8(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm_fixupimm_round_ss (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde_float32 a[4];
+    const simde_float32 b[4];
+    const int32_t c[4];
+    const int imm8;
+    const int sae;
+    const simde_float32 r[4];
+  } test_vec[] = {
+    { {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   484.93),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   618.19) },
+      { SIMDE_FLOAT32_C(  -891.03),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -775.92) },
+      { -INT32_C(   915358689), -INT32_C(  1968983990), -INT32_C(   342607311), -INT32_C(   789356136) },
+       INT32_C(          90),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(    -1.00),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -775.92) } },
+    { { SIMDE_FLOAT32_C(   443.37), SIMDE_FLOAT32_C(  -980.89), SIMDE_FLOAT32_C(   660.39), SIMDE_FLOAT32_C(  -269.52) },
+      { SIMDE_FLOAT32_C(   110.75), SIMDE_FLOAT32_C(   728.41), SIMDE_FLOAT32_C(  -163.77), SIMDE_FLOAT32_C(   722.66) },
+      { -INT32_C(  1165806033), -INT32_C(  1673248677),  INT32_C(    45850437), -INT32_C(  1085504241) },
+       INT32_C(          40),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(   728.41), SIMDE_FLOAT32_C(  -163.77), SIMDE_FLOAT32_C(   722.66) } },
+    { { SIMDE_FLOAT32_C(  -743.62), SIMDE_FLOAT32_C(   272.76), SIMDE_FLOAT32_C(   742.68), SIMDE_FLOAT32_C(   419.71) },
+      { SIMDE_FLOAT32_C(  -453.13), SIMDE_FLOAT32_C(   780.52), SIMDE_FLOAT32_C(   968.73), SIMDE_FLOAT32_C(  -710.86) },
+      { -INT32_C(   808649764), -INT32_C(  2098125109), -INT32_C(  1045321589),  INT32_C(  1797090347) },
+       INT32_C(         176),
+       INT32_C(           4),
+      { SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(   780.52), SIMDE_FLOAT32_C(   968.73), SIMDE_FLOAT32_C(  -710.86) } },
+    { { SIMDE_FLOAT32_C(   481.89), SIMDE_FLOAT32_C(  -947.24), SIMDE_FLOAT32_C(   549.50), SIMDE_FLOAT32_C(  -760.98) },
+      { SIMDE_FLOAT32_C(   468.48), SIMDE_FLOAT32_C(    65.76), SIMDE_FLOAT32_C(   496.25), SIMDE_FLOAT32_C(  -826.51) },
+      { -INT32_C(      434509),  INT32_C(   248914205),  INT32_C(  2146058628),  INT32_C(   877312270) },
+       INT32_C(         171),
+       INT32_C(           4),
+      { SIMDE_FLOAT32_C(-340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(    65.76), SIMDE_FLOAT32_C(   496.25), SIMDE_FLOAT32_C(  -826.51) } },
+    { { SIMDE_FLOAT32_C(  -449.32), SIMDE_FLOAT32_C(   657.95), SIMDE_FLOAT32_C(   791.68), SIMDE_FLOAT32_C(  -340.35) },
+      { SIMDE_FLOAT32_C(  -616.66), SIMDE_FLOAT32_C(  -731.37), SIMDE_FLOAT32_C(  -116.27), SIMDE_FLOAT32_C(   826.71) },
+      { -INT32_C(  1628799103), -INT32_C(  1688757526),  INT32_C(  1213123562), -INT32_C(   429502779) },
+       INT32_C(          36),
+       INT32_C(           4),
+      { SIMDE_FLOAT32_C(340282346638528859811704183484516925440.00), SIMDE_FLOAT32_C(  -731.37), SIMDE_FLOAT32_C(  -116.27), SIMDE_FLOAT32_C(   826.71) } },
+    { { SIMDE_FLOAT32_C(  -712.26), SIMDE_FLOAT32_C(  -455.88), SIMDE_FLOAT32_C(  -442.81), SIMDE_FLOAT32_C(   398.50) },
+      { SIMDE_FLOAT32_C(  -727.47), SIMDE_FLOAT32_C(   393.42), SIMDE_FLOAT32_C(   121.16), SIMDE_FLOAT32_C(  -471.09) },
+      {  INT32_C(   857175273),  INT32_C(  1744880296), -INT32_C(  1779859946),  INT32_C(    41912168) },
+       INT32_C(         222),
+       INT32_C(           8),
+      {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   393.42), SIMDE_FLOAT32_C(   121.16), SIMDE_FLOAT32_C(  -471.09) } },
+    { { SIMDE_FLOAT32_C(  -333.82), SIMDE_FLOAT32_C(  -136.16), SIMDE_FLOAT32_C(   948.62), SIMDE_FLOAT32_C(   213.05) },
+      { SIMDE_FLOAT32_C(  -355.63), SIMDE_FLOAT32_C(   917.35), SIMDE_FLOAT32_C(   502.19), SIMDE_FLOAT32_C(  -873.74) },
+      { -INT32_C(  1682477515), -INT32_C(  1089479595), -INT32_C(  1230410430),  INT32_C(  1197399172) },
+       INT32_C(         220),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(   917.35), SIMDE_FLOAT32_C(   502.19), SIMDE_FLOAT32_C(  -873.74) } },
+    { { SIMDE_FLOAT32_C(   970.11), SIMDE_FLOAT32_C(    51.69), SIMDE_FLOAT32_C(  -634.73), SIMDE_FLOAT32_C(   438.59) },
+      { SIMDE_FLOAT32_C(  -882.56), SIMDE_FLOAT32_C(   861.52), SIMDE_FLOAT32_C(   612.08), SIMDE_FLOAT32_C(  -331.87) },
+      {  INT32_C(  1899414258), -INT32_C(  1316219707),  INT32_C(   753333950), -INT32_C(  1988001363) },
+       INT32_C(         144),
+       INT32_C(           4),
+      { SIMDE_FLOAT32_C(  -882.56), SIMDE_FLOAT32_C(   861.52), SIMDE_FLOAT32_C(   612.08), SIMDE_FLOAT32_C(  -331.87) } },
+  };
+
+  simde__m128 a, b, r;
+  simde__m128i c;
+
+  a = simde_mm_loadu_ps(test_vec[0].a);
+  b = simde_mm_loadu_ps(test_vec[0].b);
+  c = simde_x_mm_loadu_epi32(test_vec[0].c);
+  r = simde_mm_fixupimm_round_ss(a, b, c, INT32_C(          90), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[0].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[1].a);
+  b = simde_mm_loadu_ps(test_vec[1].b);
+  c = simde_x_mm_loadu_epi32(test_vec[1].c);
+  r = simde_mm_fixupimm_round_ss(a, b, c, INT32_C(          40), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[1].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[2].a);
+  b = simde_mm_loadu_ps(test_vec[2].b);
+  c = simde_x_mm_loadu_epi32(test_vec[2].c);
+  r = simde_mm_fixupimm_round_ss(a, b, c, INT32_C(         176), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[2].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[3].a);
+  b = simde_mm_loadu_ps(test_vec[3].b);
+  c = simde_x_mm_loadu_epi32(test_vec[3].c);
+  r = simde_mm_fixupimm_round_ss(a, b, c, INT32_C(         171), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[3].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[4].a);
+  b = simde_mm_loadu_ps(test_vec[4].b);
+  c = simde_x_mm_loadu_epi32(test_vec[4].c);
+  r = simde_mm_fixupimm_round_ss(a, b, c, INT32_C(          36), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[4].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[5].a);
+  b = simde_mm_loadu_ps(test_vec[5].b);
+  c = simde_x_mm_loadu_epi32(test_vec[5].c);
+  r = simde_mm_fixupimm_round_ss(a, b, c, INT32_C(         222), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[5].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[6].a);
+  b = simde_mm_loadu_ps(test_vec[6].b);
+  c = simde_x_mm_loadu_epi32(test_vec[6].c);
+  r = simde_mm_fixupimm_round_ss(a, b, c, INT32_C(         220), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[6].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[7].a);
+  b = simde_mm_loadu_ps(test_vec[7].b);
+  c = simde_x_mm_loadu_epi32(test_vec[7].c);
+  r = simde_mm_fixupimm_round_ss(a, b, c, INT32_C(         144), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float32 values[8 * 2 * sizeof(simde__m128)];
+  simde_test_x86_random_f32x4_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__m128 a = simde_test_x86_random_extract_f32x4(i, 2, 0, values);
+    simde__m128 b = simde_test_x86_random_extract_f32x4(i, 2, 1, values);
+    simde__m128i c = simde_test_x86_random_i32x4();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    int32_t sae = simde_test_codegen_rand() & 1 ? SIMDE_MM_FROUND_NO_EXC : SIMDE_MM_FROUND_CUR_DIRECTION;
+    simde__m128 r;
+    SIMDE_CONSTIFY_256_NEW(simde_mm_fixupimm_round_ss, r, simde_mm_setzero_ps(), imm8, sae, a, b, c);
+
+    simde_test_x86_write_f32x4(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_f32x4(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x4(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, sae, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x4(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm_mask_fixupimm_round_ss (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde_float32 a[4];
+    const simde__mmask8 k;
+    const simde_float32 b[4];
+    const int32_t c[4];
+    const int imm8;
+    const int sae;
+    const simde_float32 r[4];
+  } test_vec[] = {
+    { {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -558.97),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -941.38) },
+      UINT8_C( 22),
+      { SIMDE_FLOAT32_C(  -236.70),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   -20.79) },
+      { -INT32_C(  2101913748), -INT32_C(  1427155211), -INT32_C(  1712723787),  INT32_C(  2075410050) },
+       INT32_C(         159),
+       INT32_C(           8),
+      {            SIMDE_MATH_NANF,            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   -20.79) } },
+    { { SIMDE_FLOAT32_C(  -181.10), SIMDE_FLOAT32_C(  -469.17), SIMDE_FLOAT32_C(  -288.79), SIMDE_FLOAT32_C(   828.86) },
+      UINT8_C(145),
+      { SIMDE_FLOAT32_C(  -385.23), SIMDE_FLOAT32_C(  -485.60), SIMDE_FLOAT32_C(   234.17), SIMDE_FLOAT32_C(  -548.14) },
+      { -INT32_C(  2089761257), -INT32_C(   662730504),  INT32_C(  1429203870),  INT32_C(  1571562606) },
+       INT32_C(         207),
+       INT32_C(           8),
+      {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -485.60), SIMDE_FLOAT32_C(   234.17), SIMDE_FLOAT32_C(  -548.14) } },
+    { { SIMDE_FLOAT32_C(  -679.64), SIMDE_FLOAT32_C(   555.14), SIMDE_FLOAT32_C(  -225.16), SIMDE_FLOAT32_C(   284.74) },
+      UINT8_C(199),
+      { SIMDE_FLOAT32_C(   208.40), SIMDE_FLOAT32_C(   525.38), SIMDE_FLOAT32_C(   307.21), SIMDE_FLOAT32_C(   -55.02) },
+      { -INT32_C(  1774014473),  INT32_C(  1548763546),  INT32_C(  1126328530),  INT32_C(  1808472811) },
+       INT32_C(         242),
+       INT32_C(           4),
+      { SIMDE_FLOAT32_C(    -1.00), SIMDE_FLOAT32_C(   525.38), SIMDE_FLOAT32_C(   307.21), SIMDE_FLOAT32_C(   -55.02) } },
+    { { SIMDE_FLOAT32_C(   346.88), SIMDE_FLOAT32_C(  -488.37), SIMDE_FLOAT32_C(    44.08), SIMDE_FLOAT32_C(   364.14) },
+      UINT8_C(196),
+      { SIMDE_FLOAT32_C(  -915.27), SIMDE_FLOAT32_C(   534.98), SIMDE_FLOAT32_C(  -356.97), SIMDE_FLOAT32_C(   594.70) },
+      {  INT32_C(   354511430), -INT32_C(   942774580),  INT32_C(  1870054701), -INT32_C(  1397682085) },
+       INT32_C(         108),
+       INT32_C(           4),
+      { SIMDE_FLOAT32_C(   346.88), SIMDE_FLOAT32_C(   534.98), SIMDE_FLOAT32_C(  -356.97), SIMDE_FLOAT32_C(   594.70) } },
+    { { SIMDE_FLOAT32_C(   976.01), SIMDE_FLOAT32_C(   996.55), SIMDE_FLOAT32_C(   653.32), SIMDE_FLOAT32_C(  -260.69) },
+         UINT8_MAX,
+      { SIMDE_FLOAT32_C(   350.24), SIMDE_FLOAT32_C(  -433.84), SIMDE_FLOAT32_C(   718.52), SIMDE_FLOAT32_C(  -830.86) },
+      { -INT32_C(  1670737495), -INT32_C(  1178680838), -INT32_C(  1490877307), -INT32_C(   401740006) },
+       INT32_C(         182),
+       INT32_C(           4),
+      { SIMDE_FLOAT32_C(    -1.00), SIMDE_FLOAT32_C(  -433.84), SIMDE_FLOAT32_C(   718.52), SIMDE_FLOAT32_C(  -830.86) } },
+    { { SIMDE_FLOAT32_C(    96.99), SIMDE_FLOAT32_C(  -570.27), SIMDE_FLOAT32_C(   998.00), SIMDE_FLOAT32_C(   711.76) },
+      UINT8_C(  8),
+      { SIMDE_FLOAT32_C(   -55.87), SIMDE_FLOAT32_C(   232.17), SIMDE_FLOAT32_C(  -836.38), SIMDE_FLOAT32_C(   264.49) },
+      { -INT32_C(  1447797955), -INT32_C(  1523005217),  INT32_C(   842523336),  INT32_C(  1022570878) },
+       INT32_C(         234),
+       INT32_C(           4),
+      { SIMDE_FLOAT32_C(    96.99), SIMDE_FLOAT32_C(   232.17), SIMDE_FLOAT32_C(  -836.38), SIMDE_FLOAT32_C(   264.49) } },
+    { { SIMDE_FLOAT32_C(  -212.69), SIMDE_FLOAT32_C(   -61.54), SIMDE_FLOAT32_C(  -450.77), SIMDE_FLOAT32_C(   995.71) },
+      UINT8_C( 90),
+      { SIMDE_FLOAT32_C(  -536.16), SIMDE_FLOAT32_C(   856.44), SIMDE_FLOAT32_C(   -59.31), SIMDE_FLOAT32_C(   810.73) },
+      { -INT32_C(  1270731267),  INT32_C(   333508456), -INT32_C(  1402069512), -INT32_C(     9089593) },
+       INT32_C(         243),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(  -212.69), SIMDE_FLOAT32_C(   856.44), SIMDE_FLOAT32_C(   -59.31), SIMDE_FLOAT32_C(   810.73) } },
+    { { SIMDE_FLOAT32_C(  -631.93), SIMDE_FLOAT32_C(   984.78), SIMDE_FLOAT32_C(   174.87), SIMDE_FLOAT32_C(  -547.19) },
+      UINT8_C( 95),
+      { SIMDE_FLOAT32_C(   519.76), SIMDE_FLOAT32_C(   817.90), SIMDE_FLOAT32_C(  -952.49), SIMDE_FLOAT32_C(   495.77) },
+      {  INT32_C(  1184588635), -INT32_C(    61547300),  INT32_C(  2032750902), -INT32_C(   429354491) },
+       INT32_C(         165),
+       INT32_C(           8),
+      {     -SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(   817.90), SIMDE_FLOAT32_C(  -952.49), SIMDE_FLOAT32_C(   495.77) } },
+  };
+
+  simde__m128 a, b, r;
+  simde__m128i c;
+
+  a = simde_mm_loadu_ps(test_vec[0].a);
+  b = simde_mm_loadu_ps(test_vec[0].b);
+  c = simde_x_mm_loadu_epi32(test_vec[0].c);
+  r = simde_mm_mask_fixupimm_round_ss(a, test_vec[0].k, b, c, INT32_C(         159), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[0].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[1].a);
+  b = simde_mm_loadu_ps(test_vec[1].b);
+  c = simde_x_mm_loadu_epi32(test_vec[1].c);
+  r = simde_mm_mask_fixupimm_round_ss(a, test_vec[1].k, b, c, INT32_C(         207), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[1].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[2].a);
+  b = simde_mm_loadu_ps(test_vec[2].b);
+  c = simde_x_mm_loadu_epi32(test_vec[2].c);
+  r = simde_mm_mask_fixupimm_round_ss(a, test_vec[2].k, b, c, INT32_C(         242), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[2].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[3].a);
+  b = simde_mm_loadu_ps(test_vec[3].b);
+  c = simde_x_mm_loadu_epi32(test_vec[3].c);
+  r = simde_mm_mask_fixupimm_round_ss(a, test_vec[3].k, b, c, INT32_C(         108), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[3].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[4].a);
+  b = simde_mm_loadu_ps(test_vec[4].b);
+  c = simde_x_mm_loadu_epi32(test_vec[4].c);
+  r = simde_mm_mask_fixupimm_round_ss(a, test_vec[4].k, b, c, INT32_C(         182), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[4].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[5].a);
+  b = simde_mm_loadu_ps(test_vec[5].b);
+  c = simde_x_mm_loadu_epi32(test_vec[5].c);
+  r = simde_mm_mask_fixupimm_round_ss(a, test_vec[5].k, b, c, INT32_C(         234), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[5].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[6].a);
+  b = simde_mm_loadu_ps(test_vec[6].b);
+  c = simde_x_mm_loadu_epi32(test_vec[6].c);
+  r = simde_mm_mask_fixupimm_round_ss(a, test_vec[6].k, b, c, INT32_C(         243), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[6].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[7].a);
+  b = simde_mm_loadu_ps(test_vec[7].b);
+  c = simde_x_mm_loadu_epi32(test_vec[7].c);
+  r = simde_mm_mask_fixupimm_round_ss(a, test_vec[7].k, b, c, INT32_C(         165), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float32 values[8 * 2 * sizeof(simde__m128)];
+  simde_test_x86_random_f32x4_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__m128 a = simde_test_x86_random_extract_f32x4(i, 2, 0, values);
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m128 b = simde_test_x86_random_extract_f32x4(i, 2, 1, values);
+    simde__m128i c = simde_test_x86_random_i32x4();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    int32_t sae = simde_test_codegen_rand() & 1 ? SIMDE_MM_FROUND_NO_EXC : SIMDE_MM_FROUND_CUR_DIRECTION;
+    simde__m128 r;
+    SIMDE_CONSTIFY_256_NEW(simde_mm_mask_fixupimm_round_ss, r, simde_mm_setzero_ps(), imm8, sae, a, k, b, c);
+
+    simde_test_x86_write_f32x4(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x4(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x4(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, sae, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x4(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm_maskz_fixupimm_round_ss (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde__mmask8 k;
+    const simde_float32 a[4];
+    const simde_float32 b[4];
+    const int32_t c[4];
+    const int imm8;
+    const int sae;
+    const simde_float32 r[4];
+  } test_vec[] = {
+    { UINT8_C( 58),
+      {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   307.29),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -876.38) },
+      { SIMDE_FLOAT32_C(  -551.78),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -145.35) },
+      {  INT32_C(   746786872),  INT32_C(   187431713),  INT32_C(  2048184324), -INT32_C(   648375816) },
+       INT32_C(         211),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(     0.00),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -145.35) } },
+    { UINT8_C(154),
+      { SIMDE_FLOAT32_C(   264.77), SIMDE_FLOAT32_C(  -225.89), SIMDE_FLOAT32_C(  -925.52), SIMDE_FLOAT32_C(   548.42) },
+      { SIMDE_FLOAT32_C(   631.74), SIMDE_FLOAT32_C(   196.86), SIMDE_FLOAT32_C(  -431.88), SIMDE_FLOAT32_C(   393.44) },
+      {  INT32_C(   239257501), -INT32_C(  2046954745), -INT32_C(  1315621587), -INT32_C(  1934838175) },
+       INT32_C(         193),
+       INT32_C(           4),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   196.86), SIMDE_FLOAT32_C(  -431.88), SIMDE_FLOAT32_C(   393.44) } },
+    { UINT8_C( 85),
+      { SIMDE_FLOAT32_C(  -389.63), SIMDE_FLOAT32_C(  -191.75), SIMDE_FLOAT32_C(    71.86), SIMDE_FLOAT32_C(    93.04) },
+      { SIMDE_FLOAT32_C(  -406.32), SIMDE_FLOAT32_C(   719.70), SIMDE_FLOAT32_C(   466.37), SIMDE_FLOAT32_C(   602.75) },
+      {  INT32_C(   992970087), -INT32_C(  1206183086), -INT32_C(   125847371), -INT32_C(  1007974714) },
+       INT32_C(          11),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(     0.50), SIMDE_FLOAT32_C(   719.70), SIMDE_FLOAT32_C(   466.37), SIMDE_FLOAT32_C(   602.75) } },
+    { UINT8_C( 90),
+      { SIMDE_FLOAT32_C(  -790.82), SIMDE_FLOAT32_C(   600.66), SIMDE_FLOAT32_C(  -441.92), SIMDE_FLOAT32_C(  -847.40) },
+      { SIMDE_FLOAT32_C(  -232.61), SIMDE_FLOAT32_C(   558.96), SIMDE_FLOAT32_C(   820.52), SIMDE_FLOAT32_C(  -720.70) },
+      {  INT32_C(   434599255),  INT32_C(  1357857829), -INT32_C(   925542759), -INT32_C(  1394333807) },
+       INT32_C(         223),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   558.96), SIMDE_FLOAT32_C(   820.52), SIMDE_FLOAT32_C(  -720.70) } },
+    { UINT8_C( 42),
+      { SIMDE_FLOAT32_C(  -133.75), SIMDE_FLOAT32_C(   425.70), SIMDE_FLOAT32_C(  -597.08), SIMDE_FLOAT32_C(   314.47) },
+      { SIMDE_FLOAT32_C(  -774.51), SIMDE_FLOAT32_C(    63.45), SIMDE_FLOAT32_C(  -830.88), SIMDE_FLOAT32_C(   490.27) },
+      { -INT32_C(   236028699),  INT32_C(  1586685845),  INT32_C(   685041985), -INT32_C(   244516606) },
+       INT32_C(          73),
+       INT32_C(           4),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(    63.45), SIMDE_FLOAT32_C(  -830.88), SIMDE_FLOAT32_C(   490.27) } },
+    { UINT8_C(217),
+      { SIMDE_FLOAT32_C(   837.56), SIMDE_FLOAT32_C(  -756.40), SIMDE_FLOAT32_C(    38.68), SIMDE_FLOAT32_C(   469.30) },
+      { SIMDE_FLOAT32_C(   440.46), SIMDE_FLOAT32_C(   606.81), SIMDE_FLOAT32_C(  -137.25), SIMDE_FLOAT32_C(  -949.17) },
+      {  INT32_C(   629584454), -INT32_C(   578491828),  INT32_C(    56257045), -INT32_C(   303370405) },
+       INT32_C(          77),
+       INT32_C(           4),
+      {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   606.81), SIMDE_FLOAT32_C(  -137.25), SIMDE_FLOAT32_C(  -949.17) } },
+    { UINT8_C(217),
+      { SIMDE_FLOAT32_C(  -584.94), SIMDE_FLOAT32_C(   934.60), SIMDE_FLOAT32_C(   143.87), SIMDE_FLOAT32_C(     8.73) },
+      { SIMDE_FLOAT32_C(   654.30), SIMDE_FLOAT32_C(  -389.76), SIMDE_FLOAT32_C(  -388.51), SIMDE_FLOAT32_C(   863.48) },
+      {  INT32_C(  1691009051), -INT32_C(  1786572090),  INT32_C(  1917307372),  INT32_C(  1935447022) },
+       INT32_C(         113),
+       INT32_C(           4),
+      {      SIMDE_MATH_INFINITYF, SIMDE_FLOAT32_C(  -389.76), SIMDE_FLOAT32_C(  -388.51), SIMDE_FLOAT32_C(   863.48) } },
+    { UINT8_C( 56),
+      { SIMDE_FLOAT32_C(  -789.10), SIMDE_FLOAT32_C(   169.57), SIMDE_FLOAT32_C(  -983.92), SIMDE_FLOAT32_C(   -21.71) },
+      { SIMDE_FLOAT32_C(  -271.47), SIMDE_FLOAT32_C(   836.60), SIMDE_FLOAT32_C(   257.59), SIMDE_FLOAT32_C(   594.78) },
+      {  INT32_C(   119889594), -INT32_C(   567673974), -INT32_C(  1617017644),  INT32_C(   733046184) },
+       INT32_C(         250),
+       INT32_C(           8),
+      { SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   836.60), SIMDE_FLOAT32_C(   257.59), SIMDE_FLOAT32_C(   594.78) } },
+  };
+
+  simde__m128 a, b, r;
+  simde__m128i c;
+
+  a = simde_mm_loadu_ps(test_vec[0].a);
+  b = simde_mm_loadu_ps(test_vec[0].b);
+  c = simde_x_mm_loadu_epi32(test_vec[0].c);
+  r = simde_mm_maskz_fixupimm_round_ss(test_vec[0].k, a, b, c, INT32_C(         211), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[0].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[1].a);
+  b = simde_mm_loadu_ps(test_vec[1].b);
+  c = simde_x_mm_loadu_epi32(test_vec[1].c);
+  r = simde_mm_maskz_fixupimm_round_ss(test_vec[1].k, a, b, c, INT32_C(         193), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[1].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[2].a);
+  b = simde_mm_loadu_ps(test_vec[2].b);
+  c = simde_x_mm_loadu_epi32(test_vec[2].c);
+  r = simde_mm_maskz_fixupimm_round_ss(test_vec[2].k, a, b, c, INT32_C(          11), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[2].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[3].a);
+  b = simde_mm_loadu_ps(test_vec[3].b);
+  c = simde_x_mm_loadu_epi32(test_vec[3].c);
+  r = simde_mm_maskz_fixupimm_round_ss(test_vec[3].k, a, b, c, INT32_C(         223), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[3].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[4].a);
+  b = simde_mm_loadu_ps(test_vec[4].b);
+  c = simde_x_mm_loadu_epi32(test_vec[4].c);
+  r = simde_mm_maskz_fixupimm_round_ss(test_vec[4].k, a, b, c, INT32_C(          73), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[4].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[5].a);
+  b = simde_mm_loadu_ps(test_vec[5].b);
+  c = simde_x_mm_loadu_epi32(test_vec[5].c);
+  r = simde_mm_maskz_fixupimm_round_ss(test_vec[5].k, a, b, c, INT32_C(          77), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[5].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[6].a);
+  b = simde_mm_loadu_ps(test_vec[6].b);
+  c = simde_x_mm_loadu_epi32(test_vec[6].c);
+  r = simde_mm_maskz_fixupimm_round_ss(test_vec[6].k, a, b, c, INT32_C(         113), INT32_C(           4));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[6].r), 1);
+
+  a = simde_mm_loadu_ps(test_vec[7].a);
+  b = simde_mm_loadu_ps(test_vec[7].b);
+  c = simde_x_mm_loadu_epi32(test_vec[7].c);
+  r = simde_mm_maskz_fixupimm_round_ss(test_vec[7].k, a, b, c, INT32_C(         250), INT32_C(           8));
+  simde_test_x86_assert_equal_f32x4(r, simde_mm_loadu_ps(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float32 values[8 * 2 * sizeof(simde__m128)];
+  simde_test_x86_random_f32x4_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m128 a = simde_test_x86_random_extract_f32x4(i, 2, 0, values);
+    simde__m128 b = simde_test_x86_random_extract_f32x4(i, 2, 1, values);
+    simde__m128i c = simde_test_x86_random_i32x4();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    int32_t sae = simde_test_codegen_rand() & 1 ? SIMDE_MM_FROUND_NO_EXC : SIMDE_MM_FROUND_CUR_DIRECTION;
+    simde__m128 r;
+    SIMDE_CONSTIFY_256_NEW(simde_mm_maskz_fixupimm_round_ss, r, simde_mm_setzero_ps(), imm8, sae, k, a, b, c);
+
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_f32x4(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x4(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i32x4(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, sae, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f32x4(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm_fixupimm_round_sd (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde_float64 a[2];
+    const simde_float64 b[2];
+    const int64_t c[2];
+    const int imm8;
+    const int sae;
+    const simde_float64 r[2];
+  } test_vec[] = {
+    { { SIMDE_FLOAT64_C(  -953.69), SIMDE_FLOAT64_C(   256.71) },
+      { SIMDE_FLOAT64_C(   809.19), SIMDE_FLOAT64_C(   836.44) },
+      {  INT64_C( 3280897190386030812),  INT64_C( 5860799335009507841) },
+       INT32_C(          67),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(    -1.00), SIMDE_FLOAT64_C(   836.44) } },
+    { { SIMDE_FLOAT64_C(   913.50), SIMDE_FLOAT64_C(  -849.84) },
+      { SIMDE_FLOAT64_C(  -810.34), SIMDE_FLOAT64_C(  -668.11) },
+      {  INT64_C( 4739883477528554924),  INT64_C( 4760879747932446971) },
+       INT32_C(          32),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(     1.00), SIMDE_FLOAT64_C(  -668.11) } },
+    { { SIMDE_FLOAT64_C(  -763.75), SIMDE_FLOAT64_C(  -588.42) },
+      { SIMDE_FLOAT64_C(  -713.58), SIMDE_FLOAT64_C(  -405.59) },
+      { -INT64_C( 6254926502031689123),  INT64_C( 4921258895878462942) },
+       INT32_C(         175),
+       INT32_C(           4),
+      {       -SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(  -405.59) } },
+    { { SIMDE_FLOAT64_C(   304.21), SIMDE_FLOAT64_C(   507.99) },
+      { SIMDE_FLOAT64_C(  -588.46), SIMDE_FLOAT64_C(  -208.13) },
+      {  INT64_C( 2825227760063473335),  INT64_C(  746274746142014323) },
+       INT32_C(         222),
+       INT32_C(           8),
+      { SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(  -208.13) } },
+    { { SIMDE_FLOAT64_C(   -39.31), SIMDE_FLOAT64_C(  -161.31) },
+      { SIMDE_FLOAT64_C(  -595.73), SIMDE_FLOAT64_C(  -204.23) },
+      { -INT64_C( 6365151145013362151),  INT64_C( 8233843147673010840) },
+       INT32_C(          32),
+       INT32_C(           4),
+      {             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(  -204.23) } },
+    { { SIMDE_FLOAT64_C(   224.13), SIMDE_FLOAT64_C(  -927.98) },
+      { SIMDE_FLOAT64_C(  -547.78), SIMDE_FLOAT64_C(   777.79) },
+      { -INT64_C( 3137625675804197125), -INT64_C( 7800167410701080648) },
+       INT32_C(         146),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(     0.50), SIMDE_FLOAT64_C(   777.79) } },
+    { { SIMDE_FLOAT64_C(  -356.62), SIMDE_FLOAT64_C(   -26.60) },
+      { SIMDE_FLOAT64_C(  -695.32), SIMDE_FLOAT64_C(  -318.09) },
+      {  INT64_C( 4170577878658233243),  INT64_C( 1660455729788304233) },
+       INT32_C(         181),
+       INT32_C(           4),
+      {        SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(  -318.09) } },
+    { { SIMDE_FLOAT64_C(    60.59), SIMDE_FLOAT64_C(   998.85) },
+      { SIMDE_FLOAT64_C(  -448.50), SIMDE_FLOAT64_C(   -69.04) },
+      { -INT64_C( 6314926335164457582),  INT64_C( 6750152718740046181) },
+       INT32_C(         168),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(  -448.50), SIMDE_FLOAT64_C(   -69.04) } },
+  };
+
+  simde__m128d a, b, r;
+  simde__m128i c;
+
+  a = simde_mm_loadu_pd(test_vec[0].a);
+  b = simde_mm_loadu_pd(test_vec[0].b);
+  c = simde_x_mm_loadu_epi64(test_vec[0].c);
+  r = simde_mm_fixupimm_round_sd(a, b, c, INT32_C(          67), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[0].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[1].a);
+  b = simde_mm_loadu_pd(test_vec[1].b);
+  c = simde_x_mm_loadu_epi64(test_vec[1].c);
+  r = simde_mm_fixupimm_round_sd(a, b, c, INT32_C(          32), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[1].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[2].a);
+  b = simde_mm_loadu_pd(test_vec[2].b);
+  c = simde_x_mm_loadu_epi64(test_vec[2].c);
+  r = simde_mm_fixupimm_round_sd(a, b, c, INT32_C(         175), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[2].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[3].a);
+  b = simde_mm_loadu_pd(test_vec[3].b);
+  c = simde_x_mm_loadu_epi64(test_vec[3].c);
+  r = simde_mm_fixupimm_round_sd(a, b, c, INT32_C(         222), INT32_C(           8));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[3].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[4].a);
+  b = simde_mm_loadu_pd(test_vec[4].b);
+  c = simde_x_mm_loadu_epi64(test_vec[4].c);
+  r = simde_mm_fixupimm_round_sd(a, b, c, INT32_C(          32), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[4].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[5].a);
+  b = simde_mm_loadu_pd(test_vec[5].b);
+  c = simde_x_mm_loadu_epi64(test_vec[5].c);
+  r = simde_mm_fixupimm_round_sd(a, b, c, INT32_C(         146), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[5].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[6].a);
+  b = simde_mm_loadu_pd(test_vec[6].b);
+  c = simde_x_mm_loadu_epi64(test_vec[6].c);
+  r = simde_mm_fixupimm_round_sd(a, b, c, INT32_C(         181), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[6].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[7].a);
+  b = simde_mm_loadu_pd(test_vec[7].b);
+  c = simde_x_mm_loadu_epi64(test_vec[7].c);
+  r = simde_mm_fixupimm_round_sd(a, b, c, INT32_C(         168), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float64 values[8 * 2 * sizeof(simde__m128d)];
+  simde_test_x86_random_f64x2_full(8, 2, values, -1000.0f, 1000.0f, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__m128d a = simde_test_x86_random_f64x2(SIMDE_FLOAT64_C(-1000.0), SIMDE_FLOAT64_C(1000.0));
+    simde__m128d b = simde_test_x86_random_f64x2(SIMDE_FLOAT64_C(-1000.0), SIMDE_FLOAT64_C(1000.0));
+    simde__m128i c = simde_test_x86_random_i64x2();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    int32_t sae = simde_test_codegen_rand() & 1 ? SIMDE_MM_FROUND_NO_EXC : SIMDE_MM_FROUND_CUR_DIRECTION;
+    simde__m128d r;
+    SIMDE_CONSTIFY_256_NEW(simde_mm_fixupimm_round_sd, r, simde_mm_setzero_pd(), imm8, sae, a, b, c);
+
+    simde_test_x86_write_f64x2(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_f64x2(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i64x2(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, sae, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f64x2(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm_mask_fixupimm_round_sd (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde_float64 a[2];
+    const simde__mmask8 k;
+    const simde_float64 b[2];
+    const int64_t c[2];
+    const int imm8;
+    const int sae;
+    const simde_float64 r[2];
+  } test_vec[] = {
+    { {             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(   404.73) },
+      UINT8_C( 32),
+      { SIMDE_FLOAT64_C(   932.69),             SIMDE_MATH_NAN },
+      { -INT64_C(   51085584167345319),  INT64_C( 2661215540945904134) },
+       INT32_C(         163),
+       INT32_C(           8),
+      {             SIMDE_MATH_NAN,             SIMDE_MATH_NAN } },
+    { {             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(  -504.38) },
+      UINT8_C( 49),
+      {             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(  -242.90) },
+      {  INT64_C( 4625955115680741900),  INT64_C( 7269392653037636562) },
+       INT32_C(          17),
+       INT32_C(           8),
+      { SIMDE_FLOAT64_C(    90.00), SIMDE_FLOAT64_C(  -242.90) } },
+    { { SIMDE_FLOAT64_C(    47.12), SIMDE_FLOAT64_C(   322.15) },
+      UINT8_C( 54),
+      { SIMDE_FLOAT64_C(  -426.81), SIMDE_FLOAT64_C(   260.13) },
+      { -INT64_C( 3669492556995353489),  INT64_C( 7658286746966695816) },
+       INT32_C(         243),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(    47.12), SIMDE_FLOAT64_C(   260.13) } },
+    { { SIMDE_FLOAT64_C(  -103.51), SIMDE_FLOAT64_C(   362.68) },
+      UINT8_C( 16),
+      { SIMDE_FLOAT64_C(   777.81), SIMDE_FLOAT64_C(   152.75) },
+      {  INT64_C( 8872436809921223721), -INT64_C( 5394584877202960272) },
+       INT32_C(          98),
+       INT32_C(           8),
+      { SIMDE_FLOAT64_C(  -103.51), SIMDE_FLOAT64_C(   152.75) } },
+    { { SIMDE_FLOAT64_C(  -912.26), SIMDE_FLOAT64_C(   431.56) },
+      UINT8_C( 13),
+      { SIMDE_FLOAT64_C(   315.05), SIMDE_FLOAT64_C(  -179.60) },
+      {  INT64_C( 1812819379976898077), -INT64_C( 5896131593818975619) },
+       INT32_C(          54),
+       INT32_C(           8),
+      { SIMDE_FLOAT64_C(   315.05), SIMDE_FLOAT64_C(  -179.60) } },
+    { { SIMDE_FLOAT64_C(  -326.42), SIMDE_FLOAT64_C(   161.18) },
+      UINT8_C(224),
+      { SIMDE_FLOAT64_C(  -594.41), SIMDE_FLOAT64_C(   617.36) },
+      {  INT64_C( 8302220109294176618), -INT64_C( 8188782830068083338) },
+       INT32_C(         178),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(  -326.42), SIMDE_FLOAT64_C(   617.36) } },
+    { { SIMDE_FLOAT64_C(   429.63), SIMDE_FLOAT64_C(  -473.06) },
+      UINT8_C(109),
+      { SIMDE_FLOAT64_C(  -219.37), SIMDE_FLOAT64_C(   654.64) },
+      { -INT64_C(  364693081483905308),  INT64_C( 6861435413895338553) },
+       INT32_C(          42),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(     1.00), SIMDE_FLOAT64_C(   654.64) } },
+    { { SIMDE_FLOAT64_C(  -880.66), SIMDE_FLOAT64_C(  -859.45) },
+      UINT8_C( 26),
+      { SIMDE_FLOAT64_C(   470.45), SIMDE_FLOAT64_C(  -123.09) },
+      { -INT64_C( 7234881268756186947), -INT64_C( 8760867323632255754) },
+       INT32_C(          31),
+       INT32_C(           8),
+      { SIMDE_FLOAT64_C(  -880.66), SIMDE_FLOAT64_C(  -123.09) } },
+  };
+
+  simde__m128d a, b, r;
+  simde__m128i c;
+
+  a = simde_mm_loadu_pd(test_vec[0].a);
+  b = simde_mm_loadu_pd(test_vec[0].b);
+  c = simde_x_mm_loadu_epi64(test_vec[0].c);
+  r = simde_mm_mask_fixupimm_round_sd(a, test_vec[0].k, b, c, INT32_C(         163), INT32_C(           8));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[0].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[1].a);
+  b = simde_mm_loadu_pd(test_vec[1].b);
+  c = simde_x_mm_loadu_epi64(test_vec[1].c);
+  r = simde_mm_mask_fixupimm_round_sd(a, test_vec[1].k, b, c, INT32_C(          17), INT32_C(           8));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[1].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[2].a);
+  b = simde_mm_loadu_pd(test_vec[2].b);
+  c = simde_x_mm_loadu_epi64(test_vec[2].c);
+  r = simde_mm_mask_fixupimm_round_sd(a, test_vec[2].k, b, c, INT32_C(         243), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[2].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[3].a);
+  b = simde_mm_loadu_pd(test_vec[3].b);
+  c = simde_x_mm_loadu_epi64(test_vec[3].c);
+  r = simde_mm_mask_fixupimm_round_sd(a, test_vec[3].k, b, c, INT32_C(          98), INT32_C(           8));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[3].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[4].a);
+  b = simde_mm_loadu_pd(test_vec[4].b);
+  c = simde_x_mm_loadu_epi64(test_vec[4].c);
+  r = simde_mm_mask_fixupimm_round_sd(a, test_vec[4].k, b, c, INT32_C(          54), INT32_C(           8));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[4].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[5].a);
+  b = simde_mm_loadu_pd(test_vec[5].b);
+  c = simde_x_mm_loadu_epi64(test_vec[5].c);
+  r = simde_mm_mask_fixupimm_round_sd(a, test_vec[5].k, b, c, INT32_C(         178), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[5].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[6].a);
+  b = simde_mm_loadu_pd(test_vec[6].b);
+  c = simde_x_mm_loadu_epi64(test_vec[6].c);
+  r = simde_mm_mask_fixupimm_round_sd(a, test_vec[6].k, b, c, INT32_C(          42), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[6].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[7].a);
+  b = simde_mm_loadu_pd(test_vec[7].b);
+  c = simde_x_mm_loadu_epi64(test_vec[7].c);
+  r = simde_mm_mask_fixupimm_round_sd(a, test_vec[7].k, b, c, INT32_C(          31), INT32_C(           8));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float64 values[8 * 2 * sizeof(simde__m128d)];
+  simde_test_x86_random_f64x2_full(8, 2, values, -1000.0, 1000.0, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__m128d a = simde_test_x86_random_extract_f64x2(i, 2, 0, values);
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m128d b = simde_test_x86_random_extract_f64x2(i, 2, 1, values);
+    simde__m128i c = simde_test_x86_random_i64x2();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    int32_t sae = simde_test_codegen_rand() & 1 ? SIMDE_MM_FROUND_NO_EXC : SIMDE_MM_FROUND_CUR_DIRECTION;
+    simde__m128d r;
+    SIMDE_CONSTIFY_256_NEW(simde_mm_mask_fixupimm_round_sd, r, simde_mm_setzero_pd(), imm8, sae, a, k, b, c);
+
+    simde_test_x86_write_f64x2(2, a, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f64x2(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i64x2(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, sae, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f64x2(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+static int
+test_simde_mm_maskz_fixupimm_round_sd (SIMDE_MUNIT_TEST_ARGS) {
+#if 1
+  static const struct {
+    const simde__mmask8 k;
+    const simde_float64 a[2];
+    const simde_float64 b[2];
+    const int64_t c[2];
+    const int imm8;
+    const int sae;
+    const simde_float64 r[2];
+  } test_vec[] = {
+    { UINT8_C( 48),
+      {             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(  -177.10) },
+      { SIMDE_FLOAT64_C(   528.84),             SIMDE_MATH_NAN },
+      { -INT64_C( 6201633210150594401), -INT64_C(  573665116826378555) },
+       INT32_C(          75),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(     0.00),             SIMDE_MATH_NAN } },
+    { UINT8_C(247),
+      {             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(  -228.85) },
+      {             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(  -796.90) },
+      {  INT64_C( 5983593281465449366), -INT64_C( 7979780809577224146) },
+       INT32_C(         200),
+       INT32_C(           8),
+      {        SIMDE_MATH_INFINITY, SIMDE_FLOAT64_C(  -796.90) } },
+    { UINT8_C( 12),
+      { SIMDE_FLOAT64_C(   953.39), SIMDE_FLOAT64_C(  -594.87) },
+      { SIMDE_FLOAT64_C(   759.29), SIMDE_FLOAT64_C(  -333.77) },
+      {  INT64_C( 1460268679395913021), -INT64_C(  501602774970017310) },
+       INT32_C(          70),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(  -333.77) } },
+    { UINT8_C( 67),
+      { SIMDE_FLOAT64_C(  -196.84), SIMDE_FLOAT64_C(   130.21) },
+      { SIMDE_FLOAT64_C(  -305.90), SIMDE_FLOAT64_C(  -321.71) },
+      {  INT64_C(  587512381103693072),  INT64_C( 3476593014681723983) },
+       INT32_C(         106),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(  -321.71) } },
+    { UINT8_C(249),
+      { SIMDE_FLOAT64_C(  -703.20), SIMDE_FLOAT64_C(   263.96) },
+      { SIMDE_FLOAT64_C(    92.63), SIMDE_FLOAT64_C(  -639.53) },
+      { -INT64_C( 8780730181033511444),  INT64_C( 3814065157984957655) },
+       INT32_C(          81),
+       INT32_C(           4),
+      {             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(  -639.53) } },
+    { UINT8_C(134),
+      { SIMDE_FLOAT64_C(  -499.89), SIMDE_FLOAT64_C(  -179.42) },
+      { SIMDE_FLOAT64_C(   710.44), SIMDE_FLOAT64_C(  -137.29) },
+      {  INT64_C( 2216264640608260444),  INT64_C(  306455746345938362) },
+       INT32_C(          69),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(     0.00), SIMDE_FLOAT64_C(  -137.29) } },
+    { UINT8_C( 69),
+      { SIMDE_FLOAT64_C(   696.58), SIMDE_FLOAT64_C(   275.21) },
+      { SIMDE_FLOAT64_C(  -998.14), SIMDE_FLOAT64_C(   248.06) },
+      { -INT64_C( 9166773650349969295), -INT64_C( 5976202023298587239) },
+       INT32_C(          97),
+       INT32_C(           4),
+      {             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(   248.06) } },
+    { UINT8_C( 59),
+      { SIMDE_FLOAT64_C(   678.73), SIMDE_FLOAT64_C(   700.41) },
+      { SIMDE_FLOAT64_C(   774.71), SIMDE_FLOAT64_C(  -293.18) },
+      { -INT64_C( 7934929338711951501), -INT64_C( 2429077280845114435) },
+       INT32_C(         175),
+       INT32_C(           4),
+      { SIMDE_FLOAT64_C(     0.50), SIMDE_FLOAT64_C(  -293.18) } },
+  };
+
+  simde__m128d a, b, r;
+  simde__m128i c;
+
+  a = simde_mm_loadu_pd(test_vec[0].a);
+  b = simde_mm_loadu_pd(test_vec[0].b);
+  c = simde_x_mm_loadu_epi64(test_vec[0].c);
+  r = simde_mm_maskz_fixupimm_round_sd(test_vec[0].k, a, b, c, INT32_C(          75), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[0].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[1].a);
+  b = simde_mm_loadu_pd(test_vec[1].b);
+  c = simde_x_mm_loadu_epi64(test_vec[1].c);
+  r = simde_mm_maskz_fixupimm_round_sd(test_vec[1].k, a, b, c, INT32_C(         200), INT32_C(           8));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[1].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[2].a);
+  b = simde_mm_loadu_pd(test_vec[2].b);
+  c = simde_x_mm_loadu_epi64(test_vec[2].c);
+  r = simde_mm_maskz_fixupimm_round_sd(test_vec[2].k, a, b, c, INT32_C(          70), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[2].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[3].a);
+  b = simde_mm_loadu_pd(test_vec[3].b);
+  c = simde_x_mm_loadu_epi64(test_vec[3].c);
+  r = simde_mm_maskz_fixupimm_round_sd(test_vec[3].k, a, b, c, INT32_C(         106), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[3].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[4].a);
+  b = simde_mm_loadu_pd(test_vec[4].b);
+  c = simde_x_mm_loadu_epi64(test_vec[4].c);
+  r = simde_mm_maskz_fixupimm_round_sd(test_vec[4].k, a, b, c, INT32_C(          81), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[4].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[5].a);
+  b = simde_mm_loadu_pd(test_vec[5].b);
+  c = simde_x_mm_loadu_epi64(test_vec[5].c);
+  r = simde_mm_maskz_fixupimm_round_sd(test_vec[5].k, a, b, c, INT32_C(          69), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[5].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[6].a);
+  b = simde_mm_loadu_pd(test_vec[6].b);
+  c = simde_x_mm_loadu_epi64(test_vec[6].c);
+  r = simde_mm_maskz_fixupimm_round_sd(test_vec[6].k, a, b, c, INT32_C(          97), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[6].r), 1);
+
+  a = simde_mm_loadu_pd(test_vec[7].a);
+  b = simde_mm_loadu_pd(test_vec[7].b);
+  c = simde_x_mm_loadu_epi64(test_vec[7].c);
+  r = simde_mm_maskz_fixupimm_round_sd(test_vec[7].k, a, b, c, INT32_C(         175), INT32_C(           4));
+  simde_test_x86_assert_equal_f64x2(r, simde_mm_loadu_pd(test_vec[7].r), 1);
+
+  return 0;
+#else
+  fputc('\n', stdout);
+  simde_float64 values[8 * 2 * sizeof(simde__m128d)];
+  simde_test_x86_random_f64x2_full(8, 2, values, -1000.0, 1000.0, SIMDE_TEST_VEC_FLOAT_NAN);
+
+  for (size_t i = 0 ; i < 8 ; i++) {
+    simde__mmask8 k = simde_test_x86_random_mmask8();
+    simde__m128d a = simde_test_x86_random_extract_f64x2(i, 2, 0, values);
+    simde__m128d b = simde_test_x86_random_extract_f64x2(i, 2, 1, values);
+    simde__m128i c = simde_test_x86_random_i64x2();
+    int32_t imm8 = simde_test_codegen_random_i32() & 255;
+    int32_t sae = simde_test_codegen_rand() & 1 ? SIMDE_MM_FROUND_NO_EXC : SIMDE_MM_FROUND_CUR_DIRECTION;
+    simde__m128d r;
+    SIMDE_CONSTIFY_256_NEW(simde_mm_maskz_fixupimm_round_sd, r, simde_mm_setzero_pd(), imm8, sae, k, a, b, c);
+
+    simde_test_x86_write_mmask8(2, k, SIMDE_TEST_VEC_POS_FIRST);
+    simde_test_x86_write_f64x2(2, a, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f64x2(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_i64x2(2, c, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, imm8, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_codegen_write_i32(2, sae, SIMDE_TEST_VEC_POS_MIDDLE);
+    simde_test_x86_write_f64x2(2, r, SIMDE_TEST_VEC_POS_LAST);
+  }
+  return 1;
+#endif
+}
+
+SIMDE_TEST_FUNC_LIST_BEGIN
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm512_fixupimm_round_ps)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm512_mask_fixupimm_round_ps)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm512_maskz_fixupimm_round_ps)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm512_fixupimm_round_pd)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm512_mask_fixupimm_round_pd)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm512_maskz_fixupimm_round_pd)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_fixupimm_round_ss)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_mask_fixupimm_round_ss)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_maskz_fixupimm_round_ss)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_fixupimm_round_sd)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_mask_fixupimm_round_sd)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_maskz_fixupimm_round_sd)
+SIMDE_TEST_FUNC_LIST_END
+
+#include <test/x86/avx512/test-avx512-footer.h>


### PR DESCRIPTION
Implements mm_fixupimm_ps.
Tests were generated using intel-all-gcc-10.