### PR TITLE
added checks so `windows.h` is only included when it is actually need…

### DIFF
--- a/simde/x86/sse.h
+++ b/simde/x86/sse.h
@@ -32,7 +32,7 @@
 
 #include "mmx.h"
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(SIMDE_X86_SSE_NATIVE) && defined(_MSC_VER)
   #include <windows.h>
 #endif
 


### PR DESCRIPTION
…ed (to use `MemoryBarrier`).

If you follow the preprocessor define checks, you'll see that MemoryBarrier is only used in very specific circumstances, and not just when `_WIN32` is defined. These additional checks make sure that Windows.h is only included in these circumstances.