### PR TITLE
Allow non-immediate values in _mm_slli_epi api

### DIFF
--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -5862,7 +5862,8 @@ simde_mm_sra_epi32 (simde__m128i a, simde__m128i count) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_mm_slli_epi16 (simde__m128i a, const int imm8)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
+    // SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)   - this API can use non-constant values
+{
   if (HEDLEY_UNLIKELY((imm8 > 15))) {
     return simde_mm_setzero_si128();
   }
@@ -5892,7 +5893,7 @@ simde_mm_slli_epi16 (simde__m128i a, const int imm8)
       simde__m128i_from_neon_i16( \
         ((imm8) > 15) ? \
           vandq_s16(simde__m128i_to_neon_i16(a), vdupq_n_s16(0)) : \
-          vshlq_n_s16(simde__m128i_to_neon_i16(a), ((imm8) & 15))))
+          vshlq_s16(simde__m128i_to_neon_i16(a), vdupq_n_s16((imm8) & 15))))
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
   #define simde_mm_slli_epi16(a, imm8) \
     ((imm8 < 16) ? wasm_i16x8_shl(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i16x8_const(0,0,0,0,0,0,0,0))
@@ -5907,7 +5908,8 @@ simde_mm_slli_epi16 (simde__m128i a, const int imm8)
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_mm_slli_epi32 (simde__m128i a, const int imm8)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
+    // SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  
+{
   if (HEDLEY_UNLIKELY((imm8 > 31))) {
     return simde_mm_setzero_si128();
   }
@@ -5935,7 +5937,7 @@ simde_mm_slli_epi32 (simde__m128i a, const int imm8)
       simde__m128i_from_neon_i32( \
         ((imm8) > 31) ? \
           vandq_s32(simde__m128i_to_neon_i32(a), vdupq_n_s32(0)) : \
-          vshlq_n_s32(simde__m128i_to_neon_i32(a), ((imm8) & 31))))
+          vshlq_s32(simde__m128i_to_neon_i32(a), vdupq_n_s32((imm8) & 31))))
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
   #define simde_mm_slli_epi32(a, imm8) \
     ((imm8 < 32) ? wasm_i32x4_shl(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i32x4_const(0,0,0,0))
@@ -5962,7 +5964,8 @@ simde_mm_slli_epi32 (simde__m128i a, const int imm8)
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_mm_slli_epi64 (simde__m128i a, const int imm8)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
+    // SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  
+{
   if (HEDLEY_UNLIKELY((imm8 > 63))) {
     return simde_mm_setzero_si128();
   }
@@ -5990,7 +5993,7 @@ simde_mm_slli_epi64 (simde__m128i a, const int imm8)
       simde__m128i_from_neon_i64( \
         ((imm8) > 63) ? \
           vandq_s64(simde__m128i_to_neon_i64(a), vdupq_n_s64(0)) : \
-          vshlq_n_s64(simde__m128i_to_neon_i64(a), ((imm8) & 63))))
+          vshlq_s64(simde__m128i_to_neon_i64(a), vdupq_n_s64((imm8) & 63))))
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
   #define simde_mm_slli_epi64(a, imm8) \
     ((imm8 < 64) ? wasm_i64x2_shl(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i64x2_const(0,0))

--- a/test/x86/sse2.c
+++ b/test/x86/sse2.c
@@ -7702,6 +7702,10 @@ test_simde_mm_slli_epi16(SIMDE_MUNIT_TEST_ARGS) {
     simde__m128i r = simde_mm_slli_epi16(test_vec[i].a, 3);
     simde_assert_m128i_i16(r, ==, test_vec[i].r);
 
+    int shift = 3;
+    r = simde_mm_slli_epi16(test_vec[i].a, shift);
+    simde_assert_m128i_i16(r, ==, test_vec[i].r);
+
     r = simde_mm_slli_epi16(test_vec[i].a, 0);
     simde_assert_m128i_i16(r, ==, test_vec[i].a);
 
@@ -7826,6 +7830,10 @@ test_simde_mm_slli_epi32(SIMDE_MUNIT_TEST_ARGS) {
     simde__m128i r = simde_mm_slli_epi32(test_vec[i].a, 5);
     simde_assert_m128i_i32(r, ==, test_vec[i].r);
 
+    int shift=5; // SSE2 allows non-immediate shifts
+    r = simde_mm_slli_epi32(test_vec[i].a, shift);
+    simde_assert_m128i_i32(r, ==, test_vec[i].r);
+
     r = simde_mm_slli_epi32(test_vec[i].a, 0);
     simde_assert_m128i_i32(r, ==, test_vec[i].a);
 
@@ -7944,6 +7952,10 @@ test_simde_mm_slli_epi64(SIMDE_MUNIT_TEST_ARGS) {
     simde__m128i zeros = simde_mm_set1_epi64x(INT64_C(0));
 
     simde__m128i r = simde_mm_slli_epi64(test_vec[i].a, 7);
+    simde_assert_m128i_i32(r, ==, test_vec[i].r);
+
+    int shift = 7;
+    r = simde_mm_slli_epi64(test_vec[i].a, shift);
     simde_assert_m128i_i32(r, ==, test_vec[i].r);
 
     r = simde_mm_slli_epi64(test_vec[i].a, 0);


### PR DESCRIPTION
_mm_slli_epi32 and their ilk allow non-constant values, for instance like `int shift=2; _mm_slli_epi32(a, shift);`. The SIMDE translation of these apis to `vshlq_n_s32` and so on required shift to be immediate mode (functionally constexpr) meaning valid SSE2 code would not compile.

This diff changes the API to `vshlq_s32` with the associated broadcast of the shift register, adds tests, removes the constant constraint on the API. All tests pass on my macos 12.4 / xcode 14 M1 macbook.