### PR TITLE
wasm: load lane memcpy instead of cast to address UBSAN issues

### DIFF
--- a/simde/wasm/simd128.h
+++ b/simde/wasm/simd128.h
@@ -7934,7 +7934,9 @@ simde_wasm_v128_load16_lane (const void * a, simde_v128_t vec, const int lane)
   simde_v128_private
     a_ = simde_v128_to_private(vec);
 
-  a_.i16[lane] = *HEDLEY_REINTERPRET_CAST(const int16_t *, a);
+  int16_t tmp = 0;
+  simde_memcpy(&tmp, a, sizeof(int16_t));
+  a_.i16[lane] = tmp;
 
   return simde_v128_from_private(a_);
 }
@@ -7952,7 +7954,9 @@ simde_wasm_v128_load32_lane (const void * a, simde_v128_t vec, const int lane)
   simde_v128_private
     a_ = simde_v128_to_private(vec);
 
-  a_.i32[lane] = *HEDLEY_REINTERPRET_CAST(const int32_t *, a);
+  int32_t tmp = 0;
+  simde_memcpy(&tmp, a, sizeof(int32_t));
+  a_.i32[lane] = tmp;
 
   return simde_v128_from_private(a_);
 }
@@ -7970,7 +7974,9 @@ simde_wasm_v128_load64_lane (const void * a, simde_v128_t vec, const int lane)
   simde_v128_private
     a_ = simde_v128_to_private(vec);
 
-  a_.i64[lane] = *HEDLEY_REINTERPRET_CAST(const int64_t *, a);
+  int64_t tmp = 0;
+  simde_memcpy(&tmp, a, sizeof(int64_t));
+  a_.i64[lane] = tmp;
 
   return simde_v128_from_private(a_);
 }


### PR DESCRIPTION
This pull request addresses the issue identified in https://github.com/WebAssembly/wabt/pull/2021#issuecomment-1330271681 in which the casts in load16_lane, load32_lane, and load64_lane cause UBSAN errors by replacing the casts with a call to `simde_memcpy`. 