### PR TITLE
CI Fixes: SDE fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,14 @@ jobs:
     strategy:
       matrix:
         isax:
+        - -mavx512bw -mavx512vl -mavx512cd -mavx512dq -mavx512vbmi -mavx512ifma -mavx512vpopcntdq -mavx512bitalg -mavx512vnni -mvpclmulqdq
+        - -mavx512bw -mavx512vl -DSIMDE_NATURAL_VECTOR_SIZE=256
+        - -mavx512f
+        - -mavx512bw
+        - -mavx512vl
+        - -mavx512vl -mavx512dq
+        - -mavx512cd
+        - -mavx512dq
         - -msse2
         - -msse3
         - -mssse3
@@ -88,47 +96,6 @@ jobs:
         submodules: recursive
     - name: CPU Information
       run: cat /proc/cpuinfo
-    - name: Install APT Dependencies
-      run: sudo apt-get update && sudo apt-get install -y ninja-build ninja-build meson parallel gcovr
-    - name: Configure
-      run: meson setup build -Db_coverage=true
-    - name: Build
-      run: ninja -C build -v
-    - name: Test
-      run: meson test -C build --print-errorlogs --wrapper "${GITHUB_WORKSPACE}/test/check-flags.sh sde"
-    - name: Coverage Report
-      run: ninja -C build -v coverage-xml
-    - name: CodeCov.io
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./build/meson-logs/coverage.xml
-
-  x86-avx512:
-    runs-on: ubuntu-22.04
-    continue-on-error: true
-    strategy:
-      matrix:
-        isax:
-        # mavx512vnni and mavx512vpopcntdq require Knights Mill architecture
-        #- -mavx512bw -mavx512vl -mavx512cd -mavx512dq -mavx512vbmi -mavx512ifma -mavx512vpopcntdq -mavx512bitalg -mavx512vnni -mvpclmulqdq
-        - -mavx512bw -mavx512vl -DSIMDE_NATURAL_VECTOR_SIZE=256
-        - -mavx512f
-        - -mavx512bw
-        - -mavx512vl
-        - -mavx512vl -mavx512dq
-        - -mavx512cd
-        - -mavx512dq
-    env:
-      CFLAGS: -Wall -Wextra -Werror ${{ matrix.isax }}
-      CXXFLAGS: -Wall -Wextra -Werror ${{ matrix.isax }}
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: CPU Information
-      run: cat /proc/cpuinfo
-    - name: AVX512 Feature Check
-      run: cat /proc/cpuinfo | grep avx512
     - name: Install APT Dependencies
       run: sudo apt-get update && sudo apt-get install -y ninja-build ninja-build meson parallel gcovr
     - name: Configure

--- a/test/check-flags.sh
+++ b/test/check-flags.sh
@@ -50,7 +50,7 @@ elif [ "$COMMAND" = "sde" ]; then
       "$(dirname "$0")"/download-sde.sh "${SDE_PATH}"
     fi
   ) 9>/tmp/sde-download.lock
-  "${SDE_PATH}/sde64" -- $@
+  "${SDE_PATH}/sde64" -future -- $@
   exit $?
 else
   echo "Flags not supported, skipping"


### PR DESCRIPTION
This pull request recombines the x86 tests and passes the `-future` flag to Intel SDE, which should provide support for current and future architecture extensions.

According to the previous SDE error message, it was defaulting to the host's CPUID because no flag had been set. If the host machine did not support a particular architecture, the test would fail. 

Here is the list of flags from running `./sde64 --help` that could be used instead for a particular processor microarchitecture:
```
     -quark              Set chip-check and CPUID for Intel(R) Quark CPU
     -p4                 Set chip-check and CPUID for Intel(R) Pentium4 CPU
     -p4p                Set chip-check and CPUID for Intel(R) Pentium4 Prescott CPU
     -mrm                Set chip-check and CPUID for Intel(R) Merom CPU
     -pnr                Set chip-check and CPUID for Intel(R) Penryn CPU
     -nhm                Set chip-check and CPUID for Intel(R) Nehalem CPU
     -wsm                Set chip-check and CPUID for Intel(R) Westmere CPU
     -snb                Set chip-check and CPUID for Intel(R) Sandy Bridge CPU
     -ivb                Set chip-check and CPUID for Intel(R) Ivy Bridge CPU
     -hsw                Set chip-check and CPUID for Intel(R) Haswell CPU
     -bdw                Set chip-check and CPUID for Intel(R) Broadwell CPU
     -slt                Set chip-check and CPUID for Intel(R) Saltwell CPU
     -slm                Set chip-check and CPUID for Intel(R) Silvermont CPU
     -glm                Set chip-check and CPUID for Intel(R) Goldmont CPU
     -glp                Set chip-check and CPUID for Intel(R) Goldmont Plus CPU
     -tnt                Set chip-check and CPUID for Intel(R) Tremont CPU
     -snr                Set chip-check and CPUID for Intel(R) Snow Ridge CPU
     -skl                Set chip-check and CPUID for Intel(R) Skylake CPU
     -cnl                Set chip-check and CPUID for Intel(R) Cannon Lake CPU
     -icl                Set chip-check and CPUID for Intel(R) Ice Lake CPU
     -skx                Set chip-check and CPUID for Intel(R) Skylake server CPU
     -clx                Set chip-check and CPUID for Intel(R) Cascade Lake CPU
     -cpx                Set chip-check and CPUID for Intel(R) Cooper Lake CPU
     -icx                Set chip-check and CPUID for Intel(R) Ice Lake server CPU
     -knl                Set chip-check and CPUID for Intel(R) Knights landing CPU
     -knm                Set chip-check and CPUID for Intel(R) Knights mill CPU
     -tgl                Set chip-check and CPUID for Intel(R) Tiger Lake CPU
     -adl                Set chip-check and CPUID for Intel(R) Alder Lake CPU
     -spr                Set chip-check and CPUID for Intel(R) Sapphire Rapids CPU
     -gnr                Set chip-check and CPUID for Intel(R) Granite Rapids CPU
     -srf                Set chip-check and CPUID for Intel(R) Sierra Forest CPU
     -grr                Set chip-check and CPUID for Intel(R) Grand Ridge CPU
     -future             Set chip-check and CPUID for Intel(R) Future chip CPU
```