### PR TITLE
CI Fixes: Address CI warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,13 +334,13 @@ jobs:
       run: ctest -C test/build ---output-on-failure
 
   macos:
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       matrix:
         # https://www.jessesquires.com/blog/2020/01/06/selecting-an-xcode-version-on-github-ci/
         # https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md#xcode
-        xcode: ["11.3.1", "11.7", "12.3", "12.4"]
-        # xcode: ["11.7", "12.4", "12.5.1"] # for macos-11
+        # xcode: ["11.3.1", "11.7", "12.3", "12.4"]
+        xcode: ["11.7", "12.4", "12.5.1"] # for macos-11
     env:
       DEVELOPER_DIR:  /Applications/Xcode_${{ matrix.xcode }}.app
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
     - name: Coverage Report
       run: ninja -C build -v coverage-xml
     - name: CodeCov.io
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         file: ./build/meson-logs/coverage.xml
 
@@ -172,7 +172,7 @@ jobs:
     - name: Coverage Report
       run: ninja -C build -v coverage-xml
     - name: CodeCov.io
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         file: ./build/meson-logs/coverage.xml
 
@@ -198,7 +198,7 @@ jobs:
     - name: Coverage Report
       run: ninja -C build -v coverage-xml
     - name: CodeCov.io
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         file: ./build/meson-logs/coverage.xml
 
@@ -362,7 +362,7 @@ jobs:
     - name: Coverage Report
       run: ninja -C build -v coverage-xml
     - name: CodeCov.io
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         file: ./build/meson-logs/coverage.xml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,18 +215,18 @@ jobs:
         # - version: 4.9
         #   distro: ubuntu-16.04
         #   arch_flags: -mavx2
-        - version: 5
-          distro: ubuntu-18.04
-          arch_flags: -mavx2
+        #- version: 5
+        #  distro: ubuntu-18.04
+        #  arch_flags: -mavx2
         # - version: 6
         #   distro: ubuntu-18.04
         #   arch_flags: -march=native
         # - version: 7
         #   distro: ubuntu-18.04
         #   arch_flags: -march=native
-        - version: 8
-          distro: ubuntu-18.04
-          arch_flags: -march=native
+        #- version: 8
+        #  distro: ubuntu-18.04
+        #  arch_flags: -march=native
         # - version: 9
         #   distro: ubuntu-20.04
         #   arch_flags: -march=native
@@ -279,15 +279,15 @@ jobs:
         # - version: "3.8"
         #   distro: ubuntu-16.04
         #   arch_flags: -mavx2
-        - version: "3.9"
-          distro: ubuntu-18.04
-          arch_flags: -mavx2
+        #- version: "3.9"
+        #  distro: ubuntu-18.04
+        #  arch_flags: -mavx2
         # - version: "4.0"
         #   distro: ubuntu-18.04
         #   arch_flags: -mavx2
-        - version: "5.0"
-          distro: ubuntu-18.04
-          arch_flags: -mavx2
+        #- version: "5.0"
+        #  distro: ubuntu-18.04
+        #  arch_flags: -mavx2
         # - version: "6.0"
         #   distro: ubuntu-20.04
         #   arch_flags: -march=native

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   formatting:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 2
     - name: Install pcre2grep
@@ -91,7 +91,7 @@ jobs:
       CFLAGS: -Wall -Wextra -Werror ${{ matrix.isax }}
       CXXFLAGS: -Wall -Wextra -Werror ${{ matrix.isax }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: CPU Information
@@ -118,7 +118,7 @@ jobs:
       CXXFLAGS: -Weverything -Werror -O2 -msimd128 -Wno-unsafe-buffer-usage
       LDFLAGS: -s ENVIRONMENT=shell -s ASSERTIONS=1
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: CPU Information
@@ -154,7 +154,7 @@ jobs:
       CFLAGS: -DSIMDE_ENABLE_NATIVE_ALIASES -DSIMDE_NATIVE_ALIASES_TESTING -march=native -Wall -Wextra -Werror
       CXXFLAGS: -DSIMDE_ENABLE_NATIVE_ALIASES -DSIMDE_NATIVE_ALIASES_TESTING -march=native -Wall -Wextra -Werror
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: CPU Information
@@ -182,7 +182,7 @@ jobs:
       CFLAGS: -march=native -Wall -Wextra -Werror
       CXXFLAGS: -march=native -Wall -Wextra -Werror
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: CPU Information
@@ -249,7 +249,7 @@ jobs:
       CFLAGS: ${{ matrix.arch_flags }} -Wall -Wextra -Werror
       CXXFLAGS: ${{ matrix.arch_flags }} -Wall -Wextra -Werror
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: CPU Information
@@ -319,7 +319,7 @@ jobs:
       CFLAGS: ${{ matrix.arch_flags }} -Wall -Weverything -Werror -fno-lax-vector-conversions
       CXXFLAGS: ${{ matrix.arch_flags }} -Wall -Weverything -Werror -fno-lax-vector-conversions
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: CPU Information
@@ -344,7 +344,7 @@ jobs:
     env:
       DEVELOPER_DIR:  /Applications/Xcode_${{ matrix.xcode }}.app
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: System Information
@@ -374,7 +374,7 @@ jobs:
       CFLAGS: -Wall -Werror -march=native -fp-model precise
       CXXFLAGS: -Wall -Werror -march=native -fp-model precise
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: CPU Information
       run: cat /proc/cpuinfo
     - name: Install APT Dependencies

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
   no-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
          persist-credentials: false
          fetch-depth: 0
@@ -28,11 +28,11 @@ jobs:
   status:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         persist-credentials: false
         fetch-depth: 0
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
         repository: simd-everywhere/implementation-status

--- a/.github/workflows/msvc-arm.yml
+++ b/.github/workflows/msvc-arm.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: [windows-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Install Meson, Ninja and coverage

--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       # Checkout your code repository to scan
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.


### PR DESCRIPTION
This pull request addresses CI warnings about deprecated, or soon to be unsupported build tools: 
- `actions/checkout` is updated to v3 to use Node 16
- The macos build is set to macOS version 11
- The 18.04 gcc and clang builds are commented out
- `codecov/codecov-action` is set to v3

I was able to verify all but the codecov changes on my fork. According to the [codecov readme](https://github.com/codecov/codecov-action/blob/main/README.md), there may be some breaking changes between the two versions. 