### PR TITLE
CI fixes: Update OSSAR versions

### DIFF
--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -29,9 +29,9 @@ jobs:
 
       # Install dotnet, used by OSSAR
     - name: Install .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '3.1.201'
+        dotnet-version: '6.0.x'
 
       # Run open source static analysis tools
     - name: Run OSSAR
@@ -40,6 +40,6 @@ jobs:
 
       # Upload results to the Security tab
     - name: Upload OSSAR results
-      uses: github/codeql-action/upload-sarif@v1
+      uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: ${{ steps.ossar.outputs.sarifFile }}


### PR DESCRIPTION
This pull request addresses issues and warnings with the OSSAR action:
- OSSAR requires .NET version 6.0.0
- upload-serif is now at version 2

There doesn't seem to be an update yet for `github/ossar-action` so it still emits warnings. 