### PR TITLE
Suppress min/max macro definitions from windows.h

### DIFF
--- a/simde/x86/sse.h
+++ b/simde/x86/sse.h
@@ -33,6 +33,7 @@
 #include "mmx.h"
 
 #if defined(_WIN32) && !defined(SIMDE_X86_SSE_NATIVE) && defined(_MSC_VER)
+  #define NOMINMAX
   #include <windows.h>
 #endif
 


### PR DESCRIPTION
`windows.h` for backwards compatibility defines the `min` and `max` macros, which is a problem because it conflicts with C++ functions that happen to be named min/max as well. Especially since this is a header file and included by other projects (at least once such project, vvenc, sees compilation errors due to this transitive include).

So this PR suppress the definitions of these macros.