### PR TITLE
Fixed parameters to _mm_clflush

### DIFF
--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -1354,7 +1354,7 @@ simde_mm_clflush (void const* p) {
   #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_clflush(a, b) simde_mm_clflush()
+  #define _mm_clflush(p) simde_mm_clflush(p)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES


### PR DESCRIPTION
_mm_clflush had two parameters, but needs only one, and was not passing it to simde_mm_clflush