### PR TITLE
avx, avx2: fix maskload illegal mem access

### DIFF
--- a/simde/x86/avx2.h
+++ b/simde/x86/avx2.h
@@ -2864,7 +2864,7 @@ simde_mm_maskload_epi64 (const int64_t mem_addr[HEDLEY_ARRAY_PARAM(2)], simde__m
       mask_shr_;
 
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i64 = vandq_s64(mem_.neon_i64, vshrq_n_s64(mask_.neon_i64, 63));
+      mask_shr_.neon_i64 = vshrq_n_s64(mask_.neon_i64, 63);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(mask_.i64) / sizeof(mask_.i64[0])) ; i++) {

--- a/simde/x86/avx2.h
+++ b/simde/x86/avx2.h
@@ -2803,18 +2803,23 @@ simde_mm_maskload_epi32 (const int32_t mem_addr[HEDLEY_ARRAY_PARAM(4)], simde__m
     return _mm_maskload_epi32(mem_addr, mask);
   #else
     simde__m128i_private
-      mem_ = simde__m128i_to_private(simde_x_mm_loadu_epi32(mem_addr)),
       r_,
-      mask_ = simde__m128i_to_private(mask);
+      mask_ = simde__m128i_to_private(mask),
+      mask_shr_;
 
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i32 = vandq_s32(mem_.neon_i32, vshrq_n_s32(mask_.neon_i32, 31));
+      mask_shr_.neon_i32 = vshrq_n_s32(mask_.neon_i32, 31);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-        r_.i32[i] = mem_.i32[i] & (mask_.i32[i] >> 31);
+        mask_shr_.i32[i] = mask_.i32[i] >> 31;
       }
     #endif
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = mask_shr_.i32[i] ? mem_addr[i] : 0.0;
+      }
 
     return simde__m128i_from_private(r_);
   #endif
@@ -2832,11 +2837,11 @@ simde_mm256_maskload_epi32 (const int32_t mem_addr[HEDLEY_ARRAY_PARAM(4)], simde
   #else
     simde__m256i_private
       mask_ = simde__m256i_to_private(mask),
-      r_ = simde__m256i_to_private(simde_x_mm256_loadu_epi32(mem_addr));
+      r_;
 
     SIMDE_VECTORIZE
     for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-      r_.i32[i] &= mask_.i32[i] >> 31;
+      r_.i32[i] = (mask_.i32[i] >> 31) ? mem_addr[i] : 0;
     }
 
     return simde__m256i_from_private(r_);
@@ -2854,18 +2859,23 @@ simde_mm_maskload_epi64 (const int64_t mem_addr[HEDLEY_ARRAY_PARAM(2)], simde__m
     return _mm_maskload_epi64(HEDLEY_REINTERPRET_CAST(const long long *, mem_addr), mask);
   #else
     simde__m128i_private
-      mem_ = simde__m128i_to_private(simde_x_mm_loadu_epi64((mem_addr))),
       r_,
-      mask_ = simde__m128i_to_private(mask);
+      mask_ = simde__m128i_to_private(mask),
+      mask_shr_;
 
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_i64 = vandq_s64(mem_.neon_i64, vshrq_n_s64(mask_.neon_i64, 63));
     #else
       SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
-        r_.i64[i] = mem_.i64[i] & (mask_.i64[i] >> 63);
+      for (size_t i = 0 ; i < (sizeof(mask_.i64) / sizeof(mask_.i64[0])) ; i++) {
+        mask_shr_.i64[i] = mask_.i64[i] >> 63;
       }
     #endif
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = mask_shr_.i64[i] ? mem_addr[i] : 0;
+    }
 
     return simde__m128i_from_private(r_);
   #endif
@@ -2883,11 +2893,11 @@ simde_mm256_maskload_epi64 (const int64_t mem_addr[HEDLEY_ARRAY_PARAM(4)], simde
   #else
     simde__m256i_private
       mask_ = simde__m256i_to_private(mask),
-      r_ = simde__m256i_to_private(simde_x_mm256_loadu_epi64((mem_addr)));
+      r_;
 
     SIMDE_VECTORIZE
     for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
-      r_.i64[i] &= mask_.i64[i] >> 63;
+      r_.i64[i] = (mask_.i64[i] >> 63) ? mem_addr[i] : 0;
     }
 
     return simde__m256i_from_private(r_);

--- a/test/x86/avx.c
+++ b/test/x86/avx.c
@@ -9802,8 +9802,8 @@ test_simde_mm_maskload_pd_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS) {
   #else
     simde_float64 *ptr = HEDLEY_STATIC_CAST(simde_float64 *, mmap(NULL, 2 * sizeof(simde_float64), PROT_NONE , MAP_PRIVATE, -1, 0));
   #endif
-  const simde__m128i mask = simde_mm_set_epi64(INT64_C(0), INT64_C(0));
-  simde__m128 test = simde_mm_maskload_pd(ptr, mask);
+  const simde__m128i mask = simde_mm_set_epi64x(INT64_C(0), INT64_C(0));
+  simde__m128d test = simde_mm_maskload_pd(ptr, mask);
   simde_float64 r[2] = { SIMDE_FLOAT64_C(0.00), SIMDE_FLOAT64_C(0.00) };
   simde_test_x86_assert_equal_f64x2(test, simde_mm_loadu_pd(r), 1);
   return 0;
@@ -9864,7 +9864,7 @@ test_simde_mm256_maskload_pd_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS) {
     simde_float64 *ptr = HEDLEY_STATIC_CAST(simde_float64 *, mmap(NULL, 4 * sizeof(simde_float64), PROT_NONE , MAP_PRIVATE, -1, 0));
   #endif
   const simde__m256i mask = simde_mm256_set_epi64x(INT64_C(0), INT64_C(0), INT64_C(0), INT64_C(0));
-  simde__m256 test = simde_mm256_maskload_pd(ptr, mask);
+  simde__m256d test = simde_mm256_maskload_pd(ptr, mask);
   simde_float64 r[4] = { SIMDE_FLOAT64_C(0.00), SIMDE_FLOAT64_C(0.00), SIMDE_FLOAT64_C(0.00), SIMDE_FLOAT64_C(0.00) };
   simde_test_x86_assert_equal_f64x4(test, simde_mm256_loadu_pd(r), 1);
   return 0;
@@ -16364,6 +16364,13 @@ SIMDE_TEST_FUNC_LIST_BEGIN
   SIMDE_TEST_FUNC_LIST_ENTRY(mm256_maskload_pd)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm_maskload_ps)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm256_maskload_ps)
+
+  #if !defined(HEDLEY_MSVC_VERSION)
+    SIMDE_TEST_FUNC_LIST_ENTRY(mm_maskload_pd_no_illegal_memory_access)
+    SIMDE_TEST_FUNC_LIST_ENTRY(mm256_maskload_pd_no_illegal_memory_access)
+    SIMDE_TEST_FUNC_LIST_ENTRY(mm_maskload_ps_no_illegal_memory_access)
+    SIMDE_TEST_FUNC_LIST_ENTRY(mm256_maskload_ps_no_illegal_memory_access)
+  #endif
 
   SIMDE_TEST_FUNC_LIST_ENTRY(mm_maskstore_pd)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm256_maskstore_pd)

--- a/test/x86/avx.c
+++ b/test/x86/avx.c
@@ -22,8 +22,14 @@
  */
 
 #define SIMDE_TESTS_CURRENT_ISAX avx
+#if !defined(__clang__) && (defined(__linux__) || defined(__linux) || defined(__gnu_linux__)) && !defined(_GNU_SOURCE)
+  #define _GNU_SOURCE 1  // for MAP_ANONYMOUS
+#endif
 #include <simde/x86/avx.h>
 #include <test/x86/test-avx.h>
+#if !defined(HEDLEY_MSVC_VERSION)
+  #include <sys/mman.h>
+#endif
 
 static simde_float32 u32_to_f32(uint32_t u32) {
   simde_float32 f32;
@@ -9785,6 +9791,25 @@ test_simde_mm_maskload_pd (SIMDE_MUNIT_TEST_ARGS) {
   return 0;
 }
 
+#if !defined(HEDLEY_MSVC_VERSION)
+static int
+test_simde_mm_maskload_pd_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS) {
+  // ref: https://github.com/simd-everywhere/simde/issues/998
+  // make sure maskload never accesses memory for masked out regions
+  // will segfault in case memory is accessed
+  #if defined(_GNU_SOURCE)
+    simde_float64 *ptr = HEDLEY_STATIC_CAST(simde_float64 *, mmap(NULL, 2 * sizeof(simde_float64), PROT_NONE , MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  #else
+    simde_float64 *ptr = HEDLEY_STATIC_CAST(simde_float64 *, mmap(NULL, 2 * sizeof(simde_float64), PROT_NONE , MAP_PRIVATE, -1, 0));
+  #endif
+  const simde__m128i mask = simde_mm_set_epi64(INT64_C(0), INT64_C(0));
+  simde__m128 test = simde_mm_maskload_pd(ptr, mask);
+  simde_float64 r[2] = { SIMDE_FLOAT64_C(0.00), SIMDE_FLOAT64_C(0.00) };
+  simde_test_x86_assert_equal_f64x2(test, simde_mm_loadu_pd(r), 1);
+  return 0;
+}
+#endif
+
 static int
 test_simde_mm256_maskload_pd (SIMDE_MUNIT_TEST_ARGS) {
   static const struct {
@@ -9827,6 +9852,25 @@ test_simde_mm256_maskload_pd (SIMDE_MUNIT_TEST_ARGS) {
   return 0;
 }
 
+#if !defined(HEDLEY_MSVC_VERSION)
+static int
+test_simde_mm256_maskload_pd_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS) {
+  // ref: https://github.com/simd-everywhere/simde/issues/998
+  // make sure maskload never accesses memory for masked out regions
+  // will segfault in case memory is accessed
+  #if defined(_GNU_SOURCE)
+    simde_float64 *ptr = HEDLEY_STATIC_CAST(simde_float64 *, mmap(NULL, 4 * sizeof(simde_float64), PROT_NONE , MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  #else
+    simde_float64 *ptr = HEDLEY_STATIC_CAST(simde_float64 *, mmap(NULL, 4 * sizeof(simde_float64), PROT_NONE , MAP_PRIVATE, -1, 0));
+  #endif
+  const simde__m256i mask = simde_mm256_set_epi64x(INT64_C(0), INT64_C(0), INT64_C(0), INT64_C(0));
+  simde__m256 test = simde_mm256_maskload_pd(ptr, mask);
+  simde_float64 r[4] = { SIMDE_FLOAT64_C(0.00), SIMDE_FLOAT64_C(0.00), SIMDE_FLOAT64_C(0.00), SIMDE_FLOAT64_C(0.00) };
+  simde_test_x86_assert_equal_f64x4(test, simde_mm256_loadu_pd(r), 1);
+  return 0;
+}
+#endif
+
 static int
 test_simde_mm_maskload_ps (SIMDE_MUNIT_TEST_ARGS) {
   static const struct {
@@ -9868,6 +9912,26 @@ test_simde_mm_maskload_ps (SIMDE_MUNIT_TEST_ARGS) {
 
   return 0;
 }
+
+#if !defined(HEDLEY_MSVC_VERSION)
+static int
+test_simde_mm_maskload_ps_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS) {
+  // ref: https://github.com/simd-everywhere/simde/issues/998
+  // make sure maskload never accesses memory for masked out regions
+  // will segfault in case memory is accessed
+  #if defined(_GNU_SOURCE)
+    simde_float32 *ptr = HEDLEY_STATIC_CAST(simde_float32 *, mmap(NULL, 4 * sizeof(simde_float32), PROT_NONE , MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  #else
+    simde_float32 *ptr = HEDLEY_STATIC_CAST(simde_float32 *, mmap(NULL, 4 * sizeof(simde_float32), PROT_NONE , MAP_PRIVATE, -1, 0));
+  #endif
+  const simde__m128i mask = simde_mm_set_epi32(0, 0, 0, 0);
+  simde__m128 test = simde_mm_maskload_ps(ptr, mask);
+  simde_float32 r[4] = { SIMDE_FLOAT32_C(0.00), SIMDE_FLOAT32_C(0.00), SIMDE_FLOAT32_C(0.00), SIMDE_FLOAT32_C(0.00) };
+  simde_test_x86_assert_equal_f32x4(test, simde_mm_loadu_ps(r), 1);
+  return 0;
+}
+#endif
+
 
 static int
 test_simde_mm256_maskload_ps (SIMDE_MUNIT_TEST_ARGS) {
@@ -9926,6 +9990,26 @@ test_simde_mm256_maskload_ps (SIMDE_MUNIT_TEST_ARGS) {
 
   return 0;
 }
+
+#if !defined(HEDLEY_MSVC_VERSION)
+static int
+test_simde_mm256_maskload_ps_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS) {
+  // ref: https://github.com/simd-everywhere/simde/issues/998
+  // make sure maskload never accesses memory for masked out regions
+  // will segfault in case memory is accessed
+  #if defined(_GNU_SOURCE)
+    simde_float32 *ptr = HEDLEY_STATIC_CAST(simde_float32 *, mmap(NULL, 8 * sizeof(simde_float32), PROT_NONE , MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  #else
+    simde_float32 *ptr = HEDLEY_STATIC_CAST(simde_float32 *, mmap(NULL, 8 * sizeof(simde_float32), PROT_NONE , MAP_PRIVATE, -1, 0));
+  #endif
+  const simde__m256i mask = simde_mm256_set_epi32(0, 0, 0, 0, 0, 0, 0, 0);
+  simde__m256 test = simde_mm256_maskload_ps(ptr, mask);
+  simde_float32 r[8] = { SIMDE_FLOAT32_C(0.00), SIMDE_FLOAT32_C(0.00), SIMDE_FLOAT32_C(0.00), SIMDE_FLOAT32_C(0.00),
+                         SIMDE_FLOAT32_C(0.00), SIMDE_FLOAT32_C(0.00), SIMDE_FLOAT32_C(0.00), SIMDE_FLOAT32_C(0.00) };
+  simde_test_x86_assert_equal_f32x8(test, simde_mm256_loadu_ps(r), 1);
+  return 0;
+}
+#endif
 
 static int
 test_simde_mm_maskstore_pd(SIMDE_MUNIT_TEST_ARGS) {

--- a/test/x86/avx2.c
+++ b/test/x86/avx2.c
@@ -7934,7 +7934,12 @@ test_simde_mm_maskload_epi64_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS) {
     int64_t *ptr = HEDLEY_STATIC_CAST(int64_t *, mmap(NULL, 2 * sizeof(int64_t), PROT_NONE , MAP_PRIVATE, -1, 0));
   #endif
   const simde__m128i mask = simde_mm_set_epi64x(INT64_C(0), INT64_C(0));
-  simde__m128i test = simde_mm_maskload_epi64(ptr, mask);
+  simde__m128i test;
+  #if defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_NATIVE_ALIASES_TESTING)
+    test = simde_mm_maskload_epi64(HEDLEY_REINTERPRET_CAST(const long long *, ptr), mask);
+  #else
+    test = simde_mm_maskload_epi64(ptr, mask);
+  #endif
   int64_t r[2] = { INT64_C(0), INT64_C(0) };
   simde_test_x86_assert_equal_i64x2(test, simde_x_mm_loadu_epi64(r));
   return 0;
@@ -8000,7 +8005,12 @@ test_simde_mm256_maskload_epi64_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS)
     int64_t *ptr = HEDLEY_STATIC_CAST(int64_t *, mmap(NULL, 4 * sizeof(int64_t), PROT_NONE , MAP_PRIVATE, -1, 0));
   #endif
   const simde__m256i mask = simde_mm256_set_epi64x(INT64_C(0), INT64_C(0), INT64_C(0), INT64_C(0));
-  simde__m256i test = simde_mm256_maskload_epi64(ptr, mask);
+  simde__m256i test;
+  #if defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_NATIVE_ALIASES_TESTING)
+    test = simde_mm256_maskload_epi64(HEDLEY_REINTERPRET_CAST(const long long *, ptr), mask);
+  #else
+    test = simde_mm256_maskload_epi64(ptr, mask);
+  #endif
   int64_t r[4] = { INT64_C(0), INT64_C(0), INT64_C(0), INT64_C(0) };
   simde_test_x86_assert_equal_i64x4(test, simde_x_mm256_loadu_epi64(r));
   return 0;

--- a/test/x86/avx2.c
+++ b/test/x86/avx2.c
@@ -7801,9 +7801,9 @@ test_simde_mm_maskload_epi32_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS) {
   // make sure maskload never accesses memory for masked out regions
   // will segfault in case memory is accessed
   #if defined(_GNU_SOURCE)
-    simde_int32 *ptr = HEDLEY_STATIC_CAST(simde_int32 *, mmap(NULL, 4 * sizeof(simde_int32), PROT_NONE , MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    int32_t *ptr = HEDLEY_STATIC_CAST(int32_t *, mmap(NULL, 4 * sizeof(int32_t), PROT_NONE , MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
   #else
-    simde_int32 *ptr = HEDLEY_STATIC_CAST(simde_int32 *, mmap(NULL, 4 * sizeof(simde_int32), PROT_NONE , MAP_PRIVATE, -1, 0));
+    int32_t *ptr = HEDLEY_STATIC_CAST(int32_t *, mmap(NULL, 4 * sizeof(int32_t), PROT_NONE , MAP_PRIVATE, -1, 0));
   #endif
   const simde__m128i mask = simde_mm_set_epi32(0, 0, 0, 0);
   simde__m128i test = simde_mm_maskload_epi32(ptr, mask);
@@ -7862,9 +7862,9 @@ test_simde_mm256_maskload_epi32_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS)
   // make sure maskload never accesses memory for masked out regions
   // will segfault in case memory is accessed
   #if defined(_GNU_SOURCE)
-    simde_int32 *ptr = HEDLEY_STATIC_CAST(simde_int32 *, mmap(NULL, 8 * sizeof(simde_int32), PROT_NONE , MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    int32_t *ptr = HEDLEY_STATIC_CAST(int32_t *, mmap(NULL, 8 * sizeof(int32_t), PROT_NONE , MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
   #else
-    simde_int32 *ptr = HEDLEY_STATIC_CAST(simde_int32 *, mmap(NULL, 8 * sizeof(simde_int32), PROT_NONE , MAP_PRIVATE, -1, 0));
+    int32_t *ptr = HEDLEY_STATIC_CAST(int32_t *, mmap(NULL, 8 * sizeof(int32_t), PROT_NONE , MAP_PRIVATE, -1, 0));
   #endif
   const simde__m256i mask = simde_mm_set_epi32(0, 0, 0, 0, 0, 0, 0, 0);
   simde__m256i test = simde_mm256_maskload_epi32(ptr, mask);
@@ -7929,9 +7929,9 @@ test_simde_mm_maskload_epi64_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS) {
   // make sure maskload never accesses memory for masked out regions
   // will segfault in case memory is accessed
   #if defined(_GNU_SOURCE)
-    simde_int64 *ptr = HEDLEY_STATIC_CAST(simde_int64 *, mmap(NULL, 2 * sizeof(simde_int64), PROT_NONE , MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    int64_t *ptr = HEDLEY_STATIC_CAST(int64_t *, mmap(NULL, 2 * sizeof(int64_t), PROT_NONE , MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
   #else
-    simde_int64 *ptr = HEDLEY_STATIC_CAST(simde_int64 *, mmap(NULL, 2 * sizeof(simde_int64), PROT_NONE , MAP_PRIVATE, -1, 0));
+    int64_t *ptr = HEDLEY_STATIC_CAST(int64_t *, mmap(NULL, 2 * sizeof(int64_t), PROT_NONE , MAP_PRIVATE, -1, 0));
   #endif
   const simde__m128i mask = simde_mm_set_epi64(INT64_C(0), INT64_C(0));
   simde__m128i test = simde_mm_maskload_epi64(ptr, mask);
@@ -7995,9 +7995,9 @@ test_simde_mm256_maskload_epi64_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS)
   // make sure maskload never accesses memory for masked out regions
   // will segfault in case memory is accessed
   #if defined(_GNU_SOURCE)
-    simde_int64 *ptr = HEDLEY_STATIC_CAST(simde_int64 *, mmap(NULL, 4 * sizeof(simde_int64), PROT_NONE , MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    int64_t *ptr = HEDLEY_STATIC_CAST(int64_t *, mmap(NULL, 4 * sizeof(int64_t), PROT_NONE , MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
   #else
-    simde_int64 *ptr = HEDLEY_STATIC_CAST(simde_int64 *, mmap(NULL, 4 * sizeof(simde_int64), PROT_NONE , MAP_PRIVATE, -1, 0));
+    int64_t *ptr = HEDLEY_STATIC_CAST(int64_t *, mmap(NULL, 4 * sizeof(int64_t), PROT_NONE , MAP_PRIVATE, -1, 0));
   #endif
   const simde__m256i mask = simde_mm256_set_epi64(INT64_C(0), INT64_C(0), INT64_C(0), INT64_C(0));
   simde__m256i test = simde_mm256_maskload_epi64(ptr, mask);
@@ -16712,6 +16712,13 @@ SIMDE_TEST_FUNC_LIST_BEGIN
   SIMDE_TEST_FUNC_LIST_ENTRY(mm256_maskload_epi32)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm_maskload_epi64)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm256_maskload_epi64)
+
+  #if !defined(HEDLEY_MSVC_VERSION)
+    SIMDE_TEST_FUNC_LIST_ENTRY(mm_maskload_epi32_no_illegal_memory_access)
+    SIMDE_TEST_FUNC_LIST_ENTRY(mm256_maskload_epi32_no_illegal_memory_access)
+    SIMDE_TEST_FUNC_LIST_ENTRY(mm_maskload_epi64_no_illegal_memory_access)
+    SIMDE_TEST_FUNC_LIST_ENTRY(mm256_maskload_epi64_no_illegal_memory_access)
+  #endif
 
   SIMDE_TEST_FUNC_LIST_ENTRY(mm_maskstore_epi32)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm256_maskstore_epi32)

--- a/test/x86/avx2.c
+++ b/test/x86/avx2.c
@@ -7807,8 +7807,8 @@ test_simde_mm_maskload_epi32_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS) {
   #endif
   const simde__m128i mask = simde_mm_set_epi32(0, 0, 0, 0);
   simde__m128i test = simde_mm_maskload_epi32(ptr, mask);
-  int32_t r[4] = { SIMDE_INT32_C(0), SIMDE_INT32_C(0), SIMDE_INT32_C(0), SIMDE_INT32_C(0) };
-  simde_test_x86_assert_equal_i32x4(test, simde_mm_loadu_epi32(r), 1);
+  int32_t r[4] = { INT32_C(0), INT32_C(0), INT32_C(0), INT32_C(0) };
+  simde_test_x86_assert_equal_i32x4(test, simde_mm_loadu_epi32(r));
   return 0;
 }
 #endif
@@ -7866,11 +7866,11 @@ test_simde_mm256_maskload_epi32_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS)
   #else
     int32_t *ptr = HEDLEY_STATIC_CAST(int32_t *, mmap(NULL, 8 * sizeof(int32_t), PROT_NONE , MAP_PRIVATE, -1, 0));
   #endif
-  const simde__m256i mask = simde_mm_set_epi32(0, 0, 0, 0, 0, 0, 0, 0);
+  const simde__m256i mask = simde_mm256_set_epi32(0, 0, 0, 0, 0, 0, 0, 0);
   simde__m256i test = simde_mm256_maskload_epi32(ptr, mask);
-  int32_t r[8] = { SIMDE_INT32_C(0), SIMDE_INT32_C(0), SIMDE_INT32_C(0), SIMDE_INT32_C(0),
-                   SIMDE_INT32_C(0), SIMDE_INT32_C(0), SIMDE_INT32_C(0), SIMDE_INT32_C(0)};
-  simde_test_x86_assert_equal_i32x8(test, simde_mm256_loadu_epi32(r), 1);
+  int32_t r[8] = { INT32_C(0), INT32_C(0), INT32_C(0), INT32_C(0),
+                   INT32_C(0), INT32_C(0), INT32_C(0), INT32_C(0)};
+  simde_test_x86_assert_equal_i32x8(test, simde_mm256_loadu_epi32(r));
   return 0;
 }
 #endif
@@ -7933,10 +7933,10 @@ test_simde_mm_maskload_epi64_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS) {
   #else
     int64_t *ptr = HEDLEY_STATIC_CAST(int64_t *, mmap(NULL, 2 * sizeof(int64_t), PROT_NONE , MAP_PRIVATE, -1, 0));
   #endif
-  const simde__m128i mask = simde_mm_set_epi64(INT64_C(0), INT64_C(0));
+  const simde__m128i mask = simde_mm_set_epi64x(INT64_C(0), INT64_C(0));
   simde__m128i test = simde_mm_maskload_epi64(ptr, mask);
   int64_t r[2] = { INT64_C(0), INT64_C(0) };
-  simde_test_x86_assert_equal_i64x2(test, simde_mm_loadu_pd(r), 1);
+  simde_test_x86_assert_equal_i64x2(test, simde_x_mm_loadu_epi64(r));
   return 0;
 }
 #endif
@@ -7999,10 +7999,10 @@ test_simde_mm256_maskload_epi64_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS)
   #else
     int64_t *ptr = HEDLEY_STATIC_CAST(int64_t *, mmap(NULL, 4 * sizeof(int64_t), PROT_NONE , MAP_PRIVATE, -1, 0));
   #endif
-  const simde__m256i mask = simde_mm256_set_epi64(INT64_C(0), INT64_C(0), INT64_C(0), INT64_C(0));
+  const simde__m256i mask = simde_mm256_set_epi64x(INT64_C(0), INT64_C(0), INT64_C(0), INT64_C(0));
   simde__m256i test = simde_mm256_maskload_epi64(ptr, mask);
   int64_t r[4] = { INT64_C(0), INT64_C(0), INT64_C(0), INT64_C(0) };
-  simde_test_x86_assert_equal_i64x4(test, simde_mm_loadu_pd(r), 1);
+  simde_test_x86_assert_equal_i64x4(test, simde_x_mm256_loadu_epi64(r));
   return 0;
 }
 #endif

--- a/test/x86/avx2.c
+++ b/test/x86/avx2.c
@@ -22,8 +22,14 @@
  */
 
 #define SIMDE_TESTS_CURRENT_ISAX avx2
+#if !defined(__clang__) && (defined(__linux__) || defined(__linux) || defined(__gnu_linux__)) && !defined(_GNU_SOURCE)
+  #define _GNU_SOURCE 1  // for MAP_ANONYMOUS
+#endif
 #include <simde/x86/avx2.h>
 #include <test/x86/test-avx.h>
+#if !defined(HEDLEY_MSVC_VERSION)
+  #include <sys/mman.h>
+#endif
 
 static int
 test_simde_mm256_abs_epi8(SIMDE_MUNIT_TEST_ARGS) {
@@ -7788,6 +7794,25 @@ test_simde_mm_maskload_epi32 (SIMDE_MUNIT_TEST_ARGS) {
   return 0;
 }
 
+#if !defined(HEDLEY_MSVC_VERSION)
+static int
+test_simde_mm_maskload_epi32_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS) {
+  // ref: https://github.com/simd-everywhere/simde/issues/998
+  // make sure maskload never accesses memory for masked out regions
+  // will segfault in case memory is accessed
+  #if defined(_GNU_SOURCE)
+    simde_int32 *ptr = HEDLEY_STATIC_CAST(simde_int32 *, mmap(NULL, 4 * sizeof(simde_int32), PROT_NONE , MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  #else
+    simde_int32 *ptr = HEDLEY_STATIC_CAST(simde_int32 *, mmap(NULL, 4 * sizeof(simde_int32), PROT_NONE , MAP_PRIVATE, -1, 0));
+  #endif
+  const simde__m128i mask = simde_mm_set_epi32(0, 0, 0, 0);
+  simde__m128i test = simde_mm_maskload_epi32(ptr, mask);
+  int32_t r[4] = { SIMDE_INT32_C(0), SIMDE_INT32_C(0), SIMDE_INT32_C(0), SIMDE_INT32_C(0) };
+  simde_test_x86_assert_equal_i32x4(test, simde_mm_loadu_epi32(r), 1);
+  return 0;
+}
+#endif
+
 static int
 test_simde_mm256_maskload_epi32 (SIMDE_MUNIT_TEST_ARGS) {
   static const struct {
@@ -7829,6 +7854,26 @@ test_simde_mm256_maskload_epi32 (SIMDE_MUNIT_TEST_ARGS) {
 
   return 0;
 }
+
+#if !defined(HEDLEY_MSVC_VERSION)
+static int
+test_simde_mm256_maskload_epi32_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS) {
+  // ref: https://github.com/simd-everywhere/simde/issues/998
+  // make sure maskload never accesses memory for masked out regions
+  // will segfault in case memory is accessed
+  #if defined(_GNU_SOURCE)
+    simde_int32 *ptr = HEDLEY_STATIC_CAST(simde_int32 *, mmap(NULL, 8 * sizeof(simde_int32), PROT_NONE , MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  #else
+    simde_int32 *ptr = HEDLEY_STATIC_CAST(simde_int32 *, mmap(NULL, 8 * sizeof(simde_int32), PROT_NONE , MAP_PRIVATE, -1, 0));
+  #endif
+  const simde__m256i mask = simde_mm_set_epi32(0, 0, 0, 0, 0, 0, 0, 0);
+  simde__m256i test = simde_mm256_maskload_epi32(ptr, mask);
+  int32_t r[8] = { SIMDE_INT32_C(0), SIMDE_INT32_C(0), SIMDE_INT32_C(0), SIMDE_INT32_C(0),
+                   SIMDE_INT32_C(0), SIMDE_INT32_C(0), SIMDE_INT32_C(0), SIMDE_INT32_C(0)};
+  simde_test_x86_assert_equal_i32x8(test, simde_mm256_loadu_epi32(r), 1);
+  return 0;
+}
+#endif
 
 static int
 test_simde_mm_maskload_epi64 (SIMDE_MUNIT_TEST_ARGS) {
@@ -7877,6 +7922,25 @@ test_simde_mm_maskload_epi64 (SIMDE_MUNIT_TEST_ARGS) {
   return 0;
 }
 
+#if !defined(HEDLEY_MSVC_VERSION)
+static int
+test_simde_mm_maskload_epi64_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS) {
+  // ref: https://github.com/simd-everywhere/simde/issues/998
+  // make sure maskload never accesses memory for masked out regions
+  // will segfault in case memory is accessed
+  #if defined(_GNU_SOURCE)
+    simde_int64 *ptr = HEDLEY_STATIC_CAST(simde_int64 *, mmap(NULL, 2 * sizeof(simde_int64), PROT_NONE , MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  #else
+    simde_int64 *ptr = HEDLEY_STATIC_CAST(simde_int64 *, mmap(NULL, 2 * sizeof(simde_int64), PROT_NONE , MAP_PRIVATE, -1, 0));
+  #endif
+  const simde__m128i mask = simde_mm_set_epi64(INT64_C(0), INT64_C(0));
+  simde__m128i test = simde_mm_maskload_epi64(ptr, mask);
+  int64_t r[2] = { INT64_C(0), INT64_C(0) };
+  simde_test_x86_assert_equal_i64x2(test, simde_mm_loadu_pd(r), 1);
+  return 0;
+}
+#endif
+
 static int
 test_simde_mm256_maskload_epi64 (SIMDE_MUNIT_TEST_ARGS) {
   static const struct {
@@ -7923,6 +7987,25 @@ test_simde_mm256_maskload_epi64 (SIMDE_MUNIT_TEST_ARGS) {
 
   return 0;
 }
+
+#if !defined(HEDLEY_MSVC_VERSION)
+static int
+test_simde_mm256_maskload_epi64_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS) {
+  // ref: https://github.com/simd-everywhere/simde/issues/998
+  // make sure maskload never accesses memory for masked out regions
+  // will segfault in case memory is accessed
+  #if defined(_GNU_SOURCE)
+    simde_int64 *ptr = HEDLEY_STATIC_CAST(simde_int64 *, mmap(NULL, 4 * sizeof(simde_int64), PROT_NONE , MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  #else
+    simde_int64 *ptr = HEDLEY_STATIC_CAST(simde_int64 *, mmap(NULL, 4 * sizeof(simde_int64), PROT_NONE , MAP_PRIVATE, -1, 0));
+  #endif
+  const simde__m256i mask = simde_mm256_set_epi64(INT64_C(0), INT64_C(0), INT64_C(0), INT64_C(0));
+  simde__m256i test = simde_mm256_maskload_epi64(ptr, mask);
+  int64_t r[4] = { INT64_C(0), INT64_C(0), INT64_C(0), INT64_C(0) };
+  simde_test_x86_assert_equal_i64x4(test, simde_mm_loadu_pd(r), 1);
+  return 0;
+}
+#endif
 
 static int
 test_simde_mm_maskstore_epi32 (SIMDE_MUNIT_TEST_ARGS) {


### PR DESCRIPTION
makes sure memory is only accessed when mask value is negative, prevents preemptive access that might lead to segfaults.

~~There are also the `maskload` variants in `avx2.h` - should I adapt them accordingly in this PR or should this be done separately?~~

fixes #998