### PR TITLE
Test some Wasm instructions more strictly

### DIFF
--- a/test/test.h
+++ b/test/test.h
@@ -628,7 +628,7 @@ simde_test_equal_f32(simde_float32 a, simde_float32 b, simde_float32 slop) {
   } else if (simde_math_isinf(a)) {
     return !((a < b) || (a > b));
   } else if (slop == SIMDE_FLOAT32_C(0.0)) {
-    return a == b;
+    return !simde_memcmp(&a, &b, sizeof(simde_float32));
   } else {
     simde_float32 lo = a - slop;
     if (HEDLEY_UNLIKELY(lo == a))
@@ -658,7 +658,7 @@ simde_test_equal_f64(simde_float64 a, simde_float64 b, simde_float64 slop) {
   } else if (simde_math_isinf(a)) {
     return !((a < b) || (a > b));
   } else if (slop == SIMDE_FLOAT64_C(0.0)) {
-    return a == b;
+    return !simde_memcmp(&a, &b, sizeof(simde_float64));
   } else {
     simde_float64 lo = a - slop;
     if (HEDLEY_UNLIKELY(lo == a))

--- a/test/wasm/simd128/demote.c
+++ b/test/wasm/simd128/demote.c
@@ -55,7 +55,7 @@ test_simde_wasm_f32x4_demote_f64x2_zero(SIMDE_MUNIT_TEST_ARGS) {
     for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
       simde_v128_t a = simde_wasm_v128_load(test_vec[i].a);
       simde_v128_t r = simde_wasm_f32x4_demote_f64x2_zero(a);
-      simde_test_wasm_f32x4_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), 1);
+      simde_test_wasm_f32x4_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), INT_MAX);
     }
     return 0;
   #else

--- a/test/wasm/simd128/floor.c
+++ b/test/wasm/simd128/floor.c
@@ -55,7 +55,7 @@ test_simde_wasm_f32x4_floor(SIMDE_MUNIT_TEST_ARGS) {
     for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
       simde_v128_t a = simde_wasm_v128_load(test_vec[i].a);
       simde_v128_t r = simde_wasm_f32x4_floor(a);
-      simde_test_wasm_f32x4_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), 1);
+      simde_test_wasm_f32x4_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), INT_MAX);
     }
     return 0;
   #else
@@ -106,7 +106,7 @@ test_simde_wasm_f64x2_floor(SIMDE_MUNIT_TEST_ARGS) {
     for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
       simde_v128_t a = simde_wasm_v128_load(test_vec[i].a);
       simde_v128_t r = simde_wasm_f64x2_floor(a);
-      simde_test_wasm_f64x2_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), 1);
+      simde_test_wasm_f64x2_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), INT_MAX);
     }
     return 0;
   #else

--- a/test/wasm/simd128/max.c
+++ b/test/wasm/simd128/max.c
@@ -467,7 +467,7 @@ test_simde_wasm_f32x4_max(SIMDE_MUNIT_TEST_ARGS) {
       simde_v128_t a = simde_wasm_v128_load(test_vec[i].a);
       simde_v128_t b = simde_wasm_v128_load(test_vec[i].b);
       simde_v128_t r = simde_wasm_f32x4_max(a, b);
-      simde_test_wasm_f32x4_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), 1);
+      simde_test_wasm_f32x4_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), INT_MAX);
     }
     return 0;
   #else
@@ -530,7 +530,7 @@ test_simde_wasm_f64x2_max(SIMDE_MUNIT_TEST_ARGS) {
       simde_v128_t a = simde_wasm_v128_load(test_vec[i].a);
       simde_v128_t b = simde_wasm_v128_load(test_vec[i].b);
       simde_v128_t r = simde_wasm_f64x2_max(a, b);
-      simde_test_wasm_f64x2_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), 1);
+      simde_test_wasm_f64x2_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), INT_MAX);
     }
     return 0;
   #else

--- a/test/wasm/simd128/min.c
+++ b/test/wasm/simd128/min.c
@@ -467,7 +467,7 @@ test_simde_wasm_f32x4_min(SIMDE_MUNIT_TEST_ARGS) {
       simde_v128_t a = simde_wasm_v128_load(test_vec[i].a);
       simde_v128_t b = simde_wasm_v128_load(test_vec[i].b);
       simde_v128_t r = simde_wasm_f32x4_min(a, b);
-      simde_test_wasm_f32x4_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), 1);
+      simde_test_wasm_f32x4_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), INT_MAX);
     }
     return 0;
   #else
@@ -530,7 +530,7 @@ test_simde_wasm_f64x2_min(SIMDE_MUNIT_TEST_ARGS) {
       simde_v128_t a = simde_wasm_v128_load(test_vec[i].a);
       simde_v128_t b = simde_wasm_v128_load(test_vec[i].b);
       simde_v128_t r = simde_wasm_f64x2_min(a, b);
-      simde_test_wasm_f64x2_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), 1);
+      simde_test_wasm_f64x2_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), INT_MAX);
     }
     return 0;
   #else

--- a/test/wasm/simd128/pmax.c
+++ b/test/wasm/simd128/pmax.c
@@ -65,7 +65,7 @@ test_simde_wasm_f32x4_pmax(SIMDE_MUNIT_TEST_ARGS) {
       simde_v128_t a = simde_wasm_v128_load(test_vec[i].a);
       simde_v128_t b = simde_wasm_v128_load(test_vec[i].b);
       simde_v128_t r = simde_wasm_f32x4_pmax(a, b);
-      simde_test_wasm_f32x4_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), 1);
+      simde_test_wasm_f32x4_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), INT_MAX);
     }
     return 0;
   #else
@@ -128,7 +128,7 @@ test_simde_wasm_f64x2_pmax(SIMDE_MUNIT_TEST_ARGS) {
       simde_v128_t a = simde_wasm_v128_load(test_vec[i].a);
       simde_v128_t b = simde_wasm_v128_load(test_vec[i].b);
       simde_v128_t r = simde_wasm_f64x2_pmax(a, b);
-      simde_test_wasm_f64x2_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), 1);
+      simde_test_wasm_f64x2_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), INT_MAX);
     }
     return 0;
   #else

--- a/test/wasm/simd128/pmin.c
+++ b/test/wasm/simd128/pmin.c
@@ -65,7 +65,7 @@ test_simde_wasm_f32x4_pmin(SIMDE_MUNIT_TEST_ARGS) {
       simde_v128_t a = simde_wasm_v128_load(test_vec[i].a);
       simde_v128_t b = simde_wasm_v128_load(test_vec[i].b);
       simde_v128_t r = simde_wasm_f32x4_pmin(a, b);
-      simde_test_wasm_f32x4_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), 1);
+      simde_test_wasm_f32x4_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), INT_MAX);
     }
     return 0;
   #else
@@ -128,7 +128,7 @@ test_simde_wasm_f64x2_pmin(SIMDE_MUNIT_TEST_ARGS) {
       simde_v128_t a = simde_wasm_v128_load(test_vec[i].a);
       simde_v128_t b = simde_wasm_v128_load(test_vec[i].b);
       simde_v128_t r = simde_wasm_f64x2_pmin(a, b);
-      simde_test_wasm_f64x2_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), 1);
+      simde_test_wasm_f64x2_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), INT_MAX);
     }
     return 0;
   #else

--- a/test/wasm/simd128/trunc.c
+++ b/test/wasm/simd128/trunc.c
@@ -55,7 +55,7 @@ test_simde_wasm_f32x4_trunc(SIMDE_MUNIT_TEST_ARGS) {
     for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
       simde_v128_t a = simde_wasm_v128_load(test_vec[i].a);
       simde_v128_t r = simde_wasm_f32x4_trunc(a);
-      simde_test_wasm_f32x4_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), 1);
+      simde_test_wasm_f32x4_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), INT_MAX);
     }
     return 0;
   #else
@@ -106,7 +106,7 @@ test_simde_wasm_f64x2_trunc(SIMDE_MUNIT_TEST_ARGS) {
     for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
       simde_v128_t a = simde_wasm_v128_load(test_vec[i].a);
       simde_v128_t r = simde_wasm_f64x2_trunc(a);
-      simde_test_wasm_f64x2_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), 1);
+      simde_test_wasm_f64x2_assert_equal(r, simde_wasm_v128_load(test_vec[i].r), INT_MAX);
     }
     return 0;
   #else


### PR DESCRIPTION
Hi, thank you for SIMDe! I'm working on wasm2c and trying to get the full Wasm testsuite passing when using SIMDe as backend for the Wasm simd128 operations. We're seeing a small number of differences from the Wasm-specified behavior (https://github.com/WebAssembly/wabt/pull/2021#issuecomment-1396386135), most involving either negative zero or NaNs.

As a first step, here is a PR that cranks up the strictness of the Wasm tests for demote, floor, max, min, ~nearest,~ pmax, pmin, and trunc. Currently these are tested to within the nearest 0.1; this PR would change that to an exact comparison (which I think is acceptable even in a fast-math situation as these are basically all selectors or integer truncation?). This also changes the overall test.h to do an exact bitwise comparison when slop=0, rather than `==`.

The intention is to write tests that capture the Wasm behavior related to negative zero and implement these instructions in a conforming way. (E.g., Wasm requires that min(-0, 0) → -0 , and checking that requires a bitwise comparison or at least `signbit()`.)

(Update: removed `nearest` from this list because it already has a test that involves negative zero. This test passes on GCC using `__builtin_roundeven` but fails on clang with SIMDe's C implementation of `simde_math_roundeven`.)