### PR TITLE
[NEON] Add qtbl/qtbx polyfills for A32V7

### DIFF
--- a/simde/arm/neon/qtbl.h
+++ b/simde/arm/neon/qtbl.h
@@ -41,7 +41,8 @@ simde_vqtbl1_u8(simde_uint8x16_t t, simde_uint8x8_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbl1_u8(t, idx);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    uint8x8x2_t split = {{ vget_low_u8(t), vget_high_u8(t) }};
+    uint8x8x2_t split;
+    simde_memcpy(&split, &t, sizeof(split));
     return vtbl2_u8(split, idx);
   #else
     simde_uint8x16_private t_ = simde_uint8x16_to_private(t);
@@ -90,10 +91,8 @@ simde_vqtbl2_u8(simde_uint8x16x2_t t, simde_uint8x8_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbl2_u8(t, idx);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    uint8x8x4_t split = {{
-      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
-      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
-    }};
+    uint8x8x4_t split;
+    simde_memcpy(&split, &t, sizeof(split));
     return vtbl4_u8(split, idx);
   #else
     simde_uint8x16_private t_[2] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]) };
@@ -146,13 +145,10 @@ simde_vqtbl3_u8(simde_uint8x16x3_t t, simde_uint8x8_t idx) {
     return vqtbl3_u8(t, idx);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     uint8x8_t idx_hi = vsub_u8(idx, vdup_n_u8(32));
-    uint8x8x4_t split_lo = {{
-      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
-      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
-    }};
-    uint8x8x2_t split_hi = {{
-      vget_low_u8(t.val[2]), vget_high_u8(t.val[2])
-    }};
+    uint8x8x4_t split_lo;
+    uint8x8x2_t split_hi;
+    simde_memcpy(&split_lo, &t.val[0], sizeof(split_lo));
+    simde_memcpy(&split_hi, &t.val[2], sizeof(split_hi));
     uint8x8_t lo = vtbl4_u8(split_lo, idx);
     uint8x8_t hi = vtbl2_u8(split_hi, idx_hi);
     return vorr_u8(lo, hi);
@@ -210,14 +206,10 @@ simde_vqtbl4_u8(simde_uint8x16x4_t t, simde_uint8x8_t idx) {
     return vqtbl4_u8(t, idx);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     uint8x8_t idx_hi = vsub_u8(idx, vdup_n_u8(32));
-    uint8x8x4_t split_lo = {{
-      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
-      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
-    }};
-    uint8x8x4_t split_hi = {{
-      vget_low_u8(t.val[2]), vget_high_u8(t.val[2]),
-      vget_low_u8(t.val[3]), vget_high_u8(t.val[3])
-    }};
+    uint8x8x4_t split_lo;
+    uint8x8x4_t split_hi;
+    simde_memcpy(&split_lo, &t.val[0], sizeof(split_lo));
+    simde_memcpy(&split_hi, &t.val[2], sizeof(split_hi));
     uint8x8_t lo = vtbl4_u8(split_lo, idx);
     uint8x8_t hi = vtbl4_u8(split_hi, idx_hi);
     return vorr_u8(lo, hi);
@@ -279,7 +271,8 @@ simde_vqtbl1q_u8(simde_uint8x16_t t, simde_uint8x16_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbl1q_u8(t, idx);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    uint8x8x2_t split = {{ vget_low_u8(t), vget_high_u8(t) }};
+    uint8x8x2_t split;
+    simde_memcpy(&split, &t, sizeof(split));
     uint8x8_t lo = vtbl2_u8(split, vget_low_u8(idx));
     uint8x8_t hi = vtbl2_u8(split, vget_high_u8(idx));
     return vcombine_u8(lo, hi);
@@ -332,10 +325,8 @@ simde_vqtbl2q_u8(simde_uint8x16x2_t t, simde_uint8x16_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbl2q_u8(t, idx);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    uint8x8x4_t split = {{
-      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
-      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
-    }};
+    uint8x8x4_t split;
+    simde_memcpy(&split, &t, sizeof(split));
     uint8x8_t lo = vtbl4_u8(split, vget_low_u8(idx));
     uint8x8_t hi = vtbl4_u8(split, vget_high_u8(idx));
     return vcombine_u8(lo, hi);
@@ -394,13 +385,10 @@ simde_vqtbl3q_u8(simde_uint8x16x3_t t, simde_uint8x16_t idx) {
     return vqtbl3q_u8(t, idx);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     uint8x16_t idx_hi = vsubq_u8(idx, vdupq_n_u8(32));
-    uint8x8x4_t split_lo = {{
-      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
-      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
-    }};
-    uint8x8x2_t split_hi = {{
-      vget_low_u8(t.val[2]), vget_high_u8(t.val[2])
-    }};
+    uint8x8x4_t split_lo;
+    uint8x8x2_t split_hi;
+    simde_memcpy(&split_lo, &t.val[0], sizeof(split_lo));
+    simde_memcpy(&split_hi, &t.val[2], sizeof(split_hi));
     uint8x8_t hi_lo = vtbl2_u8(split_hi, vget_low_u8(idx_hi));
     uint8x8_t hi_hi = vtbl2_u8(split_hi, vget_high_u8(idx_hi));
     uint8x8_t lo = vtbx4_u8(hi_lo, split_lo, vget_low_u8(idx));
@@ -467,14 +455,10 @@ simde_vqtbl4q_u8(simde_uint8x16x4_t t, simde_uint8x16_t idx) {
     return vqtbl4q_u8(t, idx);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     uint8x16_t idx_hi = vsubq_u8(idx, vdupq_n_u8(32));
-    uint8x8x4_t split_lo = {{
-      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
-      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
-    }};
-    uint8x8x4_t split_hi = {{
-      vget_low_u8(t.val[2]), vget_high_u8(t.val[2]),
-      vget_low_u8(t.val[3]), vget_high_u8(t.val[3])
-    }};
+    uint8x8x4_t split_lo;
+    uint8x8x4_t split_hi;
+    simde_memcpy(&split_lo, &t.val[0], sizeof(split_lo));
+    simde_memcpy(&split_hi, &t.val[2], sizeof(split_hi));
     uint8x8_t lo_lo = vtbl4_u8(split_lo, vget_low_u8(idx));
     uint8x8_t lo_hi = vtbl4_u8(split_lo, vget_high_u8(idx));
     uint8x8_t lo = vtbx4_u8(lo_lo, split_hi, vget_low_u8(idx_hi));

--- a/simde/arm/neon/qtbl.h
+++ b/simde/arm/neon/qtbl.h
@@ -40,6 +40,9 @@ simde_uint8x8_t
 simde_vqtbl1_u8(simde_uint8x16_t t, simde_uint8x8_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbl1_u8(t, idx);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    uint8x8x2_t split = {{ vget_low_u8(t), vget_high_u8(t) }};
+    return vtbl2_u8(split, idx);
   #else
     simde_uint8x16_private t_ = simde_uint8x16_to_private(t);
     simde_uint8x8_private
@@ -86,6 +89,12 @@ simde_uint8x8_t
 simde_vqtbl2_u8(simde_uint8x16x2_t t, simde_uint8x8_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbl2_u8(t, idx);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    uint8x8x4_t split = {{
+      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
+      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
+    }};
+    return vtbl4_u8(split, idx);
   #else
     simde_uint8x16_private t_[2] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]) };
     simde_uint8x8_private
@@ -135,6 +144,18 @@ simde_uint8x8_t
 simde_vqtbl3_u8(simde_uint8x16x3_t t, simde_uint8x8_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbl3_u8(t, idx);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    uint8x8_t idx_hi = vsub_u8(idx, vdup_n_u8(32));
+    uint8x8x4_t split_lo = {{
+      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
+      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
+    }};
+    uint8x8x2_t split_hi = {{
+      vget_low_u8(t.val[2]), vget_high_u8(t.val[2])
+    }};
+    uint8x8_t lo = vtbl4_u8(split_lo, idx);
+    uint8x8_t hi = vtbl2_u8(split_hi, idx_hi);
+    return vorr_u8(lo, hi);
   #else
     simde_uint8x16_private t_[3] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]),
                                      simde_uint8x16_to_private(t.val[2]) };
@@ -187,6 +208,19 @@ simde_uint8x8_t
 simde_vqtbl4_u8(simde_uint8x16x4_t t, simde_uint8x8_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbl4_u8(t, idx);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    uint8x8_t idx_hi = vsub_u8(idx, vdup_n_u8(32));
+    uint8x8x4_t split_lo = {{
+      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
+      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
+    }};
+    uint8x8x4_t split_hi = {{
+      vget_low_u8(t.val[2]), vget_high_u8(t.val[2]),
+      vget_low_u8(t.val[3]), vget_high_u8(t.val[3])
+    }};
+    uint8x8_t lo = vtbl4_u8(split_lo, idx);
+    uint8x8_t hi = vtbl4_u8(split_hi, idx_hi);
+    return vorr_u8(lo, hi);
   #else
     simde_uint8x16_private t_[4] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]),
                                      simde_uint8x16_to_private(t.val[2]), simde_uint8x16_to_private(t.val[3]) };
@@ -244,6 +278,11 @@ simde_uint8x16_t
 simde_vqtbl1q_u8(simde_uint8x16_t t, simde_uint8x16_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbl1q_u8(t, idx);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    uint8x8x2_t split = {{ vget_low_u8(t), vget_high_u8(t) }};
+    uint8x8_t lo = vtbl2_u8(split, vget_low_u8(idx));
+    uint8x8_t hi = vtbl2_u8(split, vget_high_u8(idx));
+    return vcombine_u8(lo, hi);
   #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_and(vec_perm(t, t, idx), vec_cmplt(idx, vec_splats(HEDLEY_STATIC_CAST(unsigned char, 16))));
   #else
@@ -292,6 +331,14 @@ simde_uint8x16_t
 simde_vqtbl2q_u8(simde_uint8x16x2_t t, simde_uint8x16_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbl2q_u8(t, idx);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    uint8x8x4_t split = {{
+      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
+      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
+    }};
+    uint8x8_t lo = vtbl4_u8(split, vget_low_u8(idx));
+    uint8x8_t hi = vtbl4_u8(split, vget_high_u8(idx));
+    return vcombine_u8(lo, hi);
   #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_and(vec_perm(t.val[0], t.val[1], idx),
                   vec_cmplt(idx, vec_splats(HEDLEY_STATIC_CAST(unsigned char, 32))));
@@ -345,6 +392,20 @@ simde_uint8x16_t
 simde_vqtbl3q_u8(simde_uint8x16x3_t t, simde_uint8x16_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbl3q_u8(t, idx);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    uint8x16_t idx_hi = vsubq_u8(idx, vdupq_n_u8(32));
+    uint8x8x4_t split_lo = {{
+      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
+      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
+    }};
+    uint8x8x2_t split_hi = {{
+      vget_low_u8(t.val[2]), vget_high_u8(t.val[2])
+    }};
+    uint8x8_t hi_lo = vtbl2_u8(split_hi, vget_low_u8(idx_hi));
+    uint8x8_t hi_hi = vtbl2_u8(split_hi, vget_high_u8(idx_hi));
+    uint8x8_t lo = vtbx4_u8(hi_lo, split_lo, vget_low_u8(idx));
+    uint8x8_t hi = vtbx4_u8(hi_hi, split_lo, vget_high_u8(idx));
+    return vcombine_u8(lo, hi);
   #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) r_01 = vec_perm(t.val[0], t.val[1], idx);
     SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) r_2  = vec_perm(t.val[2], t.val[2], idx);
@@ -404,6 +465,21 @@ simde_uint8x16_t
 simde_vqtbl4q_u8(simde_uint8x16x4_t t, simde_uint8x16_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbl4q_u8(t, idx);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    uint8x16_t idx_hi = vsubq_u8(idx, vdupq_n_u8(32));
+    uint8x8x4_t split_lo = {{
+      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
+      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
+    }};
+    uint8x8x4_t split_hi = {{
+      vget_low_u8(t.val[2]), vget_high_u8(t.val[2]),
+      vget_low_u8(t.val[3]), vget_high_u8(t.val[3])
+    }};
+    uint8x8_t lo_lo = vtbl4_u8(split_lo, vget_low_u8(idx));
+    uint8x8_t lo_hi = vtbl4_u8(split_lo, vget_high_u8(idx));
+    uint8x8_t lo = vtbx4_u8(lo_lo, split_hi, vget_low_u8(idx_hi));
+    uint8x8_t hi = vtbx4_u8(lo_hi, split_hi, vget_high_u8(idx_hi));
+    return vcombine_u8(lo, hi);
   #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) r_01 = vec_perm(t.val[0], t.val[1], idx);
     SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) r_23 = vec_perm(t.val[2], t.val[3], idx);

--- a/simde/arm/neon/qtbx.h
+++ b/simde/arm/neon/qtbx.h
@@ -40,6 +40,9 @@ simde_uint8x8_t
 simde_vqtbx1_u8(simde_uint8x8_t a, simde_uint8x16_t t, simde_uint8x8_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbx1_u8(a, t, idx);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    uint8x8x2_t split = {{ vget_low_u8(t), vget_high_u8(t) }};
+    return vtbx2_u8(a, split, idx);
   #else
     simde_uint8x16_private t_ = simde_uint8x16_to_private(t);
     simde_uint8x8_private
@@ -89,6 +92,12 @@ simde_uint8x8_t
 simde_vqtbx2_u8(simde_uint8x8_t a, simde_uint8x16x2_t t, simde_uint8x8_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbx2_u8(a, t, idx);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    uint8x8x4_t split = {{
+      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
+      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
+    }};
+    return vtbx4_u8(a, split, idx);
   #else
     simde_uint8x16_private t_[2] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]) };
     simde_uint8x8_private
@@ -140,6 +149,17 @@ simde_uint8x8_t
 simde_vqtbx3_u8(simde_uint8x8_t a, simde_uint8x16x3_t t, simde_uint8x8_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbx3_u8(a, t, idx);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    uint8x8_t idx_hi = vsub_u8(idx, vdup_n_u8(32));
+    uint8x8x4_t split_lo = {{
+      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
+      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
+    }};
+    uint8x8x2_t split_hi = {{
+      vget_low_u8(t.val[2]), vget_high_u8(t.val[2])
+    }};
+    uint8x8_t hi = vtbx2_u8(a, split_hi, idx_hi);
+    return vtbx4_u8(hi, split_lo, idx);
   #else
     simde_uint8x16_private t_[3] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]), simde_uint8x16_to_private(t.val[2]) };
     simde_uint8x8_private
@@ -193,6 +213,18 @@ simde_uint8x8_t
 simde_vqtbx4_u8(simde_uint8x8_t a, simde_uint8x16x4_t t, simde_uint8x8_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbx4_u8(a, t, idx);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    uint8x8_t idx_hi = vsub_u8(idx, vdup_n_u8(32));
+    uint8x8x4_t split_lo = {{
+      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
+      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
+    }};
+    uint8x8x4_t split_hi = {{
+      vget_low_u8(t.val[2]), vget_high_u8(t.val[2]),
+      vget_low_u8(t.val[3]), vget_high_u8(t.val[3])
+    }};
+    uint8x8_t lo = vtbx4_u8(a, split_lo, idx);
+    return vtbx4_u8(lo, split_hi, idx_hi);
   #else
     simde_uint8x16_private t_[4] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]), simde_uint8x16_to_private(t.val[2]), simde_uint8x16_to_private(t.val[3]) };
     simde_uint8x8_private
@@ -251,6 +283,11 @@ simde_uint8x16_t
 simde_vqtbx1q_u8(simde_uint8x16_t a, simde_uint8x16_t t, simde_uint8x16_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbx1q_u8(a, t, idx);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    uint8x8x2_t split = {{ vget_low_u8(t), vget_high_u8(t) }};
+    uint8x8_t lo = vtbx2_u8(vget_low_u8(a), split, vget_low_u8(idx));
+    uint8x8_t hi = vtbx2_u8(vget_high_u8(a), split, vget_high_u8(idx));
+    return vcombine_u8(lo, hi);
   #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_sel(a,
                    vec_perm(t, t, idx),
@@ -304,6 +341,14 @@ simde_uint8x16_t
 simde_vqtbx2q_u8(simde_uint8x16_t a, simde_uint8x16x2_t t, simde_uint8x16_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbx2q_u8(a, t, idx);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    uint8x8x4_t split = {{
+      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
+      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
+    }};
+    uint8x8_t lo = vtbx4_u8(vget_low_u8(a), split, vget_low_u8(idx));
+    uint8x8_t hi = vtbx4_u8(vget_high_u8(a), split, vget_high_u8(idx));
+    return vcombine_u8(lo, hi);
   #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     return vec_sel(a, vec_perm(t.val[0], t.val[1], idx),
                    vec_cmplt(idx, vec_splats(HEDLEY_STATIC_CAST(unsigned char, 32))));
@@ -360,6 +405,20 @@ simde_uint8x16_t
 simde_vqtbx3q_u8(simde_uint8x16_t a, simde_uint8x16x3_t t, simde_uint8x16_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbx3q_u8(a, t, idx);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    uint8x16_t idx_hi = vsubq_u8(idx, vdupq_n_u8(32));
+    uint8x8x4_t split_lo = {{
+      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
+      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
+    }};
+    uint8x8x2_t split_hi = {{
+      vget_low_u8(t.val[2]), vget_high_u8(t.val[2])
+    }};
+    uint8x8_t hi_lo = vtbx2_u8(vget_low_u8(a), split_hi, vget_low_u8(idx_hi));
+    uint8x8_t hi_hi = vtbx2_u8(vget_high_u8(a), split_hi, vget_high_u8(idx_hi));
+    uint8x8_t lo_lo = vtbx4_u8(hi_lo, split_lo, vget_low_u8(idx));
+    uint8x8_t lo_hi = vtbx4_u8(hi_hi, split_lo, vget_high_u8(idx));
+    return vcombine_u8(lo_lo, lo_hi);
   #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) r_01 = vec_perm(t.val[0], t.val[1], idx);
     SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) r_2  = vec_perm(t.val[2], t.val[2], idx);
@@ -422,6 +481,21 @@ simde_uint8x16_t
 simde_vqtbx4q_u8(simde_uint8x16_t a, simde_uint8x16x4_t t, simde_uint8x16_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbx4q_u8(a, t, idx);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    uint8x16_t idx_hi = vsubq_u8(idx, vdupq_n_u8(32));
+    uint8x8x4_t split_lo = {{
+      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
+      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
+    }};
+    uint8x8x4_t split_hi = {{
+      vget_low_u8(t.val[2]), vget_high_u8(t.val[2]),
+      vget_low_u8(t.val[3]), vget_high_u8(t.val[3])
+    }};
+    uint8x8_t lo_lo = vtbx4_u8(vget_low_u8(a), split_lo, vget_low_u8(idx));
+    uint8x8_t lo_hi = vtbx4_u8(vget_high_u8(a), split_lo, vget_high_u8(idx));
+    uint8x8_t lo = vtbx4_u8(lo_lo, split_hi, vget_low_u8(idx_hi));
+    uint8x8_t hi = vtbx4_u8(lo_hi, split_hi, vget_high_u8(idx_hi));
+    return vcombine_u8(lo, hi);
   #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
     SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) r_01 = vec_perm(t.val[0], t.val[1], idx);
     SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) r_23 = vec_perm(t.val[2], t.val[3], idx);

--- a/simde/arm/neon/qtbx.h
+++ b/simde/arm/neon/qtbx.h
@@ -41,7 +41,8 @@ simde_vqtbx1_u8(simde_uint8x8_t a, simde_uint8x16_t t, simde_uint8x8_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbx1_u8(a, t, idx);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    uint8x8x2_t split = {{ vget_low_u8(t), vget_high_u8(t) }};
+    uint8x8x2_t split;
+    simde_memcpy(&split, &t, sizeof(split));
     return vtbx2_u8(a, split, idx);
   #else
     simde_uint8x16_private t_ = simde_uint8x16_to_private(t);
@@ -93,10 +94,8 @@ simde_vqtbx2_u8(simde_uint8x8_t a, simde_uint8x16x2_t t, simde_uint8x8_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbx2_u8(a, t, idx);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    uint8x8x4_t split = {{
-      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
-      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
-    }};
+    uint8x8x4_t split;
+    simde_memcpy(&split, &t, sizeof(split));
     return vtbx4_u8(a, split, idx);
   #else
     simde_uint8x16_private t_[2] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]) };
@@ -151,13 +150,10 @@ simde_vqtbx3_u8(simde_uint8x8_t a, simde_uint8x16x3_t t, simde_uint8x8_t idx) {
     return vqtbx3_u8(a, t, idx);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     uint8x8_t idx_hi = vsub_u8(idx, vdup_n_u8(32));
-    uint8x8x4_t split_lo = {{
-      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
-      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
-    }};
-    uint8x8x2_t split_hi = {{
-      vget_low_u8(t.val[2]), vget_high_u8(t.val[2])
-    }};
+    uint8x8x4_t split_lo;
+    uint8x8x2_t split_hi;
+    simde_memcpy(&split_lo, &t.val[0], sizeof(split_lo));
+    simde_memcpy(&split_hi, &t.val[2], sizeof(split_hi));
     uint8x8_t hi = vtbx2_u8(a, split_hi, idx_hi);
     return vtbx4_u8(hi, split_lo, idx);
   #else
@@ -215,14 +211,10 @@ simde_vqtbx4_u8(simde_uint8x8_t a, simde_uint8x16x4_t t, simde_uint8x8_t idx) {
     return vqtbx4_u8(a, t, idx);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     uint8x8_t idx_hi = vsub_u8(idx, vdup_n_u8(32));
-    uint8x8x4_t split_lo = {{
-      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
-      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
-    }};
-    uint8x8x4_t split_hi = {{
-      vget_low_u8(t.val[2]), vget_high_u8(t.val[2]),
-      vget_low_u8(t.val[3]), vget_high_u8(t.val[3])
-    }};
+    uint8x8x4_t split_lo;
+    uint8x8x4_t split_hi;
+    simde_memcpy(&split_lo, &t.val[0], sizeof(split_lo));
+    simde_memcpy(&split_hi, &t.val[2], sizeof(split_hi));
     uint8x8_t lo = vtbx4_u8(a, split_lo, idx);
     return vtbx4_u8(lo, split_hi, idx_hi);
   #else
@@ -284,7 +276,8 @@ simde_vqtbx1q_u8(simde_uint8x16_t a, simde_uint8x16_t t, simde_uint8x16_t idx) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbx1q_u8(a, t, idx);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    uint8x8x2_t split = {{ vget_low_u8(t), vget_high_u8(t) }};
+    uint8x8x2_t split;
+    simde_memcpy(&split, &t, sizeof(split));
     uint8x8_t lo = vtbx2_u8(vget_low_u8(a), split, vget_low_u8(idx));
     uint8x8_t hi = vtbx2_u8(vget_high_u8(a), split, vget_high_u8(idx));
     return vcombine_u8(lo, hi);
@@ -342,10 +335,8 @@ simde_vqtbx2q_u8(simde_uint8x16_t a, simde_uint8x16x2_t t, simde_uint8x16_t idx)
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vqtbx2q_u8(a, t, idx);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    uint8x8x4_t split = {{
-      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
-      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
-    }};
+    uint8x8x4_t split;
+    simde_memcpy(&split, &t, sizeof(split));
     uint8x8_t lo = vtbx4_u8(vget_low_u8(a), split, vget_low_u8(idx));
     uint8x8_t hi = vtbx4_u8(vget_high_u8(a), split, vget_high_u8(idx));
     return vcombine_u8(lo, hi);
@@ -407,13 +398,10 @@ simde_vqtbx3q_u8(simde_uint8x16_t a, simde_uint8x16x3_t t, simde_uint8x16_t idx)
     return vqtbx3q_u8(a, t, idx);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     uint8x16_t idx_hi = vsubq_u8(idx, vdupq_n_u8(32));
-    uint8x8x4_t split_lo = {{
-      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
-      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
-    }};
-    uint8x8x2_t split_hi = {{
-      vget_low_u8(t.val[2]), vget_high_u8(t.val[2])
-    }};
+    uint8x8x4_t split_lo;
+    uint8x8x2_t split_hi;
+    simde_memcpy(&split_lo, &t.val[0], sizeof(split_lo));
+    simde_memcpy(&split_hi, &t.val[2], sizeof(split_hi));
     uint8x8_t hi_lo = vtbx2_u8(vget_low_u8(a), split_hi, vget_low_u8(idx_hi));
     uint8x8_t hi_hi = vtbx2_u8(vget_high_u8(a), split_hi, vget_high_u8(idx_hi));
     uint8x8_t lo_lo = vtbx4_u8(hi_lo, split_lo, vget_low_u8(idx));
@@ -483,14 +471,10 @@ simde_vqtbx4q_u8(simde_uint8x16_t a, simde_uint8x16x4_t t, simde_uint8x16_t idx)
     return vqtbx4q_u8(a, t, idx);
   #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     uint8x16_t idx_hi = vsubq_u8(idx, vdupq_n_u8(32));
-    uint8x8x4_t split_lo = {{
-      vget_low_u8(t.val[0]), vget_high_u8(t.val[0]),
-      vget_low_u8(t.val[1]), vget_high_u8(t.val[1])
-    }};
-    uint8x8x4_t split_hi = {{
-      vget_low_u8(t.val[2]), vget_high_u8(t.val[2]),
-      vget_low_u8(t.val[3]), vget_high_u8(t.val[3])
-    }};
+    uint8x8x4_t split_lo;
+    uint8x8x4_t split_hi;
+    simde_memcpy(&split_lo, &t.val[0], sizeof(split_lo));
+    simde_memcpy(&split_hi, &t.val[2], sizeof(split_hi));
     uint8x8_t lo_lo = vtbx4_u8(vget_low_u8(a), split_lo, vget_low_u8(idx));
     uint8x8_t lo_hi = vtbx4_u8(vget_high_u8(a), split_lo, vget_high_u8(idx));
     uint8x8_t lo = vtbx4_u8(lo_lo, split_hi, vget_low_u8(idx_hi));


### PR DESCRIPTION
Similar to _mm_shuffle_epi8, qtbl/qtbx now split up to multiple shuffles on A32V7. With multi-vector shuffles, two tables are created, the indexes are subtracted, and either TBX'd on the result of the other table or ORR'd together (TBX is mandatory for qtbx, but ORR is chosen when the lookups would be theoretically dual issued).

The code seems like a lot but it really boils down to in the worst case
```
vmov.i8 tmp, #32
vsub.i8 idx_hi, idx, tmp
vtbx.8 lo(a), {t0-t3}, lo(idx)
vtbx.8 hi(a), {t0-t3}, hi(idx)
vtbx.8 lo(a), {t4-t7}, lo(idx_hi)
vtbx.8 hi(a), {t4-t7}, hi(idx_hi)
```

**Note that there are compile errors with A32V7 in other files** (is there even a test vector?) but the qtbl/qtbx tests pass when the errors are fixed.