### PR TITLE
Add Packit CI.

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,0 +1,31 @@
+# See the `.packit/README.md` for details.
+
+# The used RPM spec file path.
+# A minimal RPM spec file to run the tests.
+specfile_path: .packit/simde.spec
+
+jobs:
+  - &copr
+    # Use Fedora COPR in the CI.
+    # https://packit.dev/docs/configuration/#copr_build
+    job: copr_build
+    trigger: pull_request
+    # Enable internet access in the COPR.
+    enable_net: true
+    # Executed targets in the CI.
+    # Available targets are below.
+    # https://packit.dev/docs/configuration/#available-copr-build-targets
+    targets:
+      - fedora-rawhide-x86_64
+      # Comment out the i386 (i686) case as it takes much longer time.
+      # TODO: Implement a flexible way to run only specific tests.
+      # - fedora-rawhide-i386
+      - fedora-rawhide-aarch64
+      - fedora-rawhide-ppc64le
+      - fedora-rawhide-s390x
+  - <<: *copr
+    # Run on push to any branch.
+    trigger: commit
+    # Run except the "master*" branches.
+    # https://github.com/packit/packit/issues/1986
+    branch: '(?!master)'

--- a/.packit/README.md
+++ b/.packit/README.md
@@ -1,0 +1,26 @@
+# Packit
+
+This document is to use Packit CI that enables us to test SIMDe on Fedora project's native CPU environments, x86_64, i686, aarch64, ppc64le and s390x as of June 2023. Packit CI can be executed on pull-request and push, and create a RPM package based on the specified RPM spec (recipe) file, then run commands in the `%check` section in the RPM spec file in the environments. We use a minimal RPM spec file only to run tests on the environments.
+
+* The configuration document: https://packit.dev/docs/configuration
+* Report issues (bugs or feature suggestions): https://github.com/packit/packit/issues
+* Pipeline history: https://dashboard.packit.dev/pipelines
+
+## How to check the CI results
+
+1. Enable Packit CI for your forked simde repository. See the [onboarding guide](https://packit.dev/docs/guide/).
+2. When you push branches to your repository, the CI is triggered. Go to the [Pipelines](https://dashboard.packit.dev/pipelines) page to see your pipeline.
+3. Do browser-search by "simde".
+4. Click a "fedora-*-*" button on the Jobs to go to the job detailed page.
+5. You can see 3 links below. You can check the Build Logs first, and the SRPM Logs second if it is necessary.
+    * **SRPM Logs**: A log of the preparation of the test such as installing the used RPM packages to test. This is a log that the system creates Source RPM (SRPM) from the RPM spec file.
+    * **Web URL**: Go to the jobs page in Fedora Copr web system used to run the RPM.
+    * **Build Logs**: It includes the testing log and the result. This is a log that the system builds a RPM package from the SRPM. The tests are executed in a part of the processes.
+
+## Customize the CI
+
+* `.packit.yml`
+  * You can customize the executed CPU pipelines at the `jobs - targets`, when you see infra issues in the specific CPU pipelines.
+* `.packit/ci.sh`
+  * You can customize if the CI fails when the tests fail at the "Customized constants" section.
+  * You can customize the tests to be executed to save the CI's total running time at the "Customized constants" section.

--- a/.packit/ci.sh
+++ b/.packit/ci.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Define variables
+JOBS="$(nproc)"
+
+# Functions
+function _time {
+  /bin/time -f '=> [%E]' ${@}
+}
+
+function _setup {
+  if ! meson setup "${BUILD_DIR}"; then
+    cat "${BUILD_DIR}/meson-logs/meson-log.txt"
+    return 1
+  fi
+}
+
+function _build {
+  rm -f build.log
+  if ! _time ninja -C "${BUILD_DIR}" -v -j "${JOBS}" >& build.log; then
+    cat build.log
+    return 1
+  fi
+  head -4 build.log
+  tail -3 build.log
+}
+
+function _test {
+  if ! _time meson test -C "${BUILD_DIR}" \
+    -q --no-rebuild --print-errorlogs; then
+    return 1
+  fi
+}
+
+function _run_test {
+  if ! _setup; then
+    return 1
+  fi
+
+  if ! _build; then
+    return 2
+  fi
+
+  if ! _test; then
+    return 3
+  fi
+}
+
+# Print system info.
+cat /proc/cpuinfo
+cat /proc/meminfo
+
+# Install additional packages.
+pip3 install meson==0.55.0
+
+# Run test.
+
+# Customized constants.
+#
+# If the value is true, the CI returns the exit status zero even if the tests
+# fail as a compromised way.
+IGNORE_EXIT_STATUS=
+# Set true if you want to skip specific tests to save total running time.
+SKIP_GCC=
+SKIP_GCC_O2=
+SKIP_GCC_RPM=true
+SKIP_CLANG=true
+SKIP_CLANG_O2=true
+SKIP_CLANG_RPM=true
+
+exit_status=0
+result_gcc="skipped"
+result_gcc_O2="skipped"
+result_gcc_rpm="skipped"
+result_clang="skipped"
+result_clang_O2="skipped"
+result_clang_rpm="skipped"
+
+# Print compiler versions.
+gcc --version
+g++ --version
+clang --version
+clang++ --version
+
+echo "== Tests on gcc without flags =="
+if [ ! "${SKIP_GCC}" = true ]; then
+  result_gcc="ok"
+  if ! BUILD_DIR="build/gcc" CC="gcc" CXX="g++" \
+    _run_test; then
+    exit_status=1
+    result_gcc="not ok"
+  fi
+fi
+
+echo "== Tests on clang without flags =="
+if [ ! "${SKIP_CLANG}" = true ]; then
+  result_clang="ok"
+  if ! BUILD_DIR="build/clang" CC="clang" CXX="clang++" \
+    _run_test; then
+    exit_status=1
+    result_clang="not ok"
+  fi
+fi
+
+echo "== Tests on gcc with O2 flag =="
+if [ ! "${SKIP_GCC_O2}" = true ]; then
+  result_gcc_O2="ok"
+  if ! BUILD_DIR="build/gcc-O2" CC="gcc" CXX="g++" \
+    CFLAGS="-O2" CXXFLAGS="-O2" \
+    _run_test; then
+    exit_status=1
+    result_gcc_O2="not ok"
+  fi
+fi
+
+echo "== Tests on clang with O2 flag =="
+if [ ! "${SKIP_CLANG_O2}" = true ]; then
+  result_clang_O2="ok"
+  if ! BUILD_DIR="build/clang-O2" CC="clang" CXX="clang++" \
+    CFLAGS="-O2" CXXFLAGS="-O2" \
+    _run_test; then
+    exit_status=1
+    result_clang_O2="not ok"
+  fi
+fi
+
+# This is an advanced test.
+echo "== Tests on gcc with flags used in RPM package build =="
+if [ ! "${SKIP_GCC_RPM}" = true ]; then
+  result_gcc_rpm="ok"
+  if ! BUILD_DIR="build/gcc-rpm" CC="gcc" CXX="g++" \
+    CFLAGS="${CI_GCC_RPM_CFLAGS}" CXXFLAGS="${CI_GCC_RPM_CXXFLAGS}" \
+    LDFLAGS="${CI_GCC_RPM_LDFLAGS}" \
+    _run_test; then
+    exit_status=1
+    result_gcc_rpm="not ok"
+  fi
+fi
+
+# This is an advanced test.
+echo "== Tests on clang with flags used in RPM package build =="
+if [ ! "${SKIP_CLANG_RPM}" = true ]; then
+  result_clang_rpm="ok"
+  if ! BUILD_DIR="build/clang-rpm" CC="clang" CXX="clang++" \
+    CFLAGS="${CI_CLANG_RPM_CFLAGS}" CXXFLAGS="${CI_CLANG_RPM_CXXFLAGS}" \
+    LDFLAGS="${CI_CLANG_RPM_LDFLAGS}" \
+    _run_test; then
+    exit_status=1
+    result_clang_rpm="not ok"
+  fi
+fi
+
+# Print results.
+cat <<EOF
+== Results ==
+Exit status: ${exit_status}
+${result_gcc} gcc without flags
+${result_gcc_O2} gcc with -O2 flag
+${result_gcc_rpm} gcc with RPM build flags
+${result_clang} clang without flags
+${result_clang_O2} clang with -O2 flag
+${result_clang_rpm} clang with RPM build flags
+EOF
+
+if [ "${IGNORE_EXIT_STATUS}" = true ]; then
+  echo "warning: Exiting always with exit status zero is not ideal."
+  exit 0
+else
+  exit ${exit_status}
+fi

--- a/.packit/simde.spec
+++ b/.packit/simde.spec
@@ -1,0 +1,91 @@
+Name: simde
+Version: 1
+Release: 1%{?dist}
+Summary: Dummy
+License: MIT
+URL: https://github.com/simd-everywhere/simde
+# This value is magically replaced with the archive tar.gz file created by
+# `git archive` in the process of the CI.
+# Set the exsiting file `README.md` in case of creating SRPM from this RPM spec
+# file on local for testing purpose.
+Source0: README.md
+# A path to the CI script.
+Source1: ci.sh
+
+# List up the needed RPM package names to test here.
+# clang, clang++
+BuildRequires: clang
+BuildRequires: gcc
+# g++
+BuildRequires: gcc-c++
+# ninja
+BuildRequires: ninja-build
+# pip and setuptools are needed to install and use meson PyPI package.
+BuildRequires: python3-devel
+BuildRequires: python3-pip
+BuildRequires: python3-setuptools
+# The GNU time (/bin/time) is used for testing. Use this GNU time rather than
+# the embedded time function in bash.
+# https://www.gnu.org/software/time/
+BuildRequires: time
+
+# RPM package description.
+%description
+
+# The bash commands to prepare are executed.
+%prep
+# Print the replaced value of the Source0.
+echo "Source0: %{SOURCE0}"
+# Create a dummy file for a valid RPM spec file.
+touch dummy.txt
+
+# The bash commands to test are executed.
+%check
+# Check the directory structure in the tar.gz file.
+tar tzvf "%{SOURCE0}" > source_files.txt
+head -2 source_files.txt
+# Check if the submodule munit is included.
+grep munit source_files.txt
+# Extract the source archive file.
+tar xzf "%{SOURCE0}"
+
+pushd simde-*
+# Set the flags used to build the actual RPM package.
+# These can be used in the CI testing script.
+%global toolchain clang
+export CI_CLANG_RPM_CFLAGS="%{build_cflags}"
+export CI_CLANG_RPM_CXXFLAGS="%{build_cxxflags}"
+export CI_CLANG_RPM_LDFLAGS="%{build_ldflags}"
+%global toolchain gcc
+export CI_GCC_RPM_CFLAGS="%{build_cflags}"
+export CI_GCC_RPM_CXXFLAGS="%{build_cxxflags}"
+export CI_GCC_RPM_LDFLAGS="%{build_ldflags}"
+
+# Unset unused environment variables to prevent the `meson setup` from reading
+# unintentionally in the in the CI script.
+# See <https://src.fedoraproject.org/rpms/redhat-rpm-config/blob/rawhide/f/macros>
+# - set_build_flags macro to check the set environment variables.
+unset CC
+unset CFLAGS
+unset LDFLAGS
+unset CXX
+unset CXXFLAGS
+unset LDFLAGS
+# Unset other environment variables not used in the `meson setup` too.
+unset FFLAGS
+unset FCFLAGS
+unset VALAFLAGS
+unset RUSTFLAGS
+
+echo "Running the CI script %{SOURCE1}."
+/bin/time -f '=> [%E]' "%{SOURCE1}"
+popd
+
+# Files included in the built RPM package.
+%files
+%doc dummy.txt
+
+# Changelog entries for the RPM package.
+%changelog
+* Fri Jun 02 2023 Dummy Dummy <dummy@dummy.com> - 1-1
+- Dummy.


### PR DESCRIPTION
This PR fixes https://github.com/simd-everywhere/simde/issues/1036.

## Why Packit CI?

In my investigation, [Packit CI](https://packit.dev/docs/guide/) is the best to test SIMDe in Fedora rawhide cases.

Pros:
* Test with Fedora project's native CPU environments, x86_64, i686, aarch64, ppc64le and s390x.
* No limits or very long time limits for running time. I checked at least possible to run a job for 1 hour 57 minutes.
* The internally used infra ([Fedora COPR](https://copr.fedorainfracloud.org/coprs/)) is also used in Fedora project. We can expect a level of stability and longevity.

Cons:
* In my impression, very early stage of the product. However, I see even popular open source projects such as [Podman](https://github.com/containers/podman) using it. It can be polished. The CI sometimes doesn't have features that other CI have. But we can open the issue tickets and report the issues on their issues page <https://github.com/packit/packit/issues>.
* The CI accesses the infra via RPM spec file. I tried to minimize the content of the RPM spec file for an easier onboarding experience.

## README document

I created the README document `.packit/README.md`.

## CI results for this PR

[Here](https://copr.fedorainfracloud.org/coprs/packit/junaruga-simde-wip-ci-packit/build/6059310/) is the CI result for this PR running 2 tests ("ok gcc without flags" and "ok gcc with -O2 flag" tests). You can click the "builder-live.log.gz" link to see the results of the tests. I executed it on my forked repository.

## Why I commented out the i386 (i686) case.

[Here](https://copr.fedorainfracloud.org/coprs/packit/junaruga-simde-wip-ci-packit/build/6059218/) is the CI logs page that I ran for all the CPU cases with all the tests (total 6 tests) with the following customized values.

.packit.yml
```
    targets:
      - fedora-rawhide-x86_64
      - fedora-rawhide-i386
      - fedora-rawhide-aarch64
      - fedora-rawhide-ppc64le
      - fedora-rawhide-s390x
```

.packit/ci.sh
```
SKIP_GCC=
SKIP_GCC_O2=
SKIP_GCC_RPM=
SKIP_CLANG=
SKIP_CLANG_O2=
SKIP_CLANG_RPM=
```

Then the results are below. The i386 case takes much longer time than other CPU cases. It's almost double.

* x86_64: 61 minutes + alpha
* i386 (machine CPU: i686): more than 117 minutes (1 hour 57 minutes).
* aarch64: 39 minutes (fastest)
* ppc64le: 42 minutes
* s390x: 50 minutes


## Why I only run the 2 tests (GCC default case and GCC + O2 flag case)

According to [CI results](https://copr.fedorainfracloud.org/coprs/packit/junaruga-simde-wip-ci-packit/build/6059218/) with 6 tests (all the tests) in the CI script again, below are the result of the tests.

The "gcc without flags", "gcc with -O2 flag" and "gcc with RPM build flags" tests are ok in the CPU cases except the i686 (i386) case. And considering the current other CI's running time, I assumed that we should keep the total running time less than 20 minutes. So, maybe the number of the maximum running tests is 2.

So, I picked up the "ok gcc without flags" and "ok gcc with -O2 flag". In the 2 picked tests, we can run the CI without using enabling the `IGNORE_EXIT_STATUS=true` option. In this option, the CI is always successful even if the tests fail. It's beneficial when we don't use the option.

**x86_64**

```
== Results ==
Exit status: 1
ok gcc without flags
ok gcc with -O2 flag
ok gcc with RPM build flags
ok clang without flags
not ok clang with -O2 flag
not ok clang with RPM build flags
```

**i386 (machine cpu: i686)**

```
== Results ==
Exit status: 1
not ok gcc without flags
ok gcc with -O2 flag
not ok gcc with RPM build flags
not ok clang without flags
not ok clang with -O2 flag
not ok clang with RPM build flags
```

**aarch64**

```
== Results ==
Exit status: 1
ok gcc without flags
ok gcc with -O2 flag
ok gcc with RPM build flags
ok clang without flags
not ok clang with -O2 flag
not ok clang with RPM build flags
```

**ppc64le**

```
== Results ==
Exit status: 1
ok gcc without flags
ok gcc with -O2 flag
ok gcc with RPM build flags
ok clang without flags
not ok clang with -O2 flag
not ok clang with RPM build flags
```

**s390x**

```
== Results ==
Exit status: 1
ok gcc without flags
ok gcc with -O2 flag
ok gcc with RPM build flags
not ok clang without flags
not ok clang with -O2 flag
not ok clang with RPM build flags
```

The customized values to run the 2 tests above are below.

```
SKIP_GCC=
SKIP_GCC_O2=
SKIP_GCC_RPM=true
SKIP_CLANG=true
SKIP_CLANG_O2=true
SKIP_CLANG_RPM=true
```

## What do you think?

What do you think? Feedback welcome!
