### PR TITLE
Packit: Update a document of why and refactoring

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -12,9 +12,11 @@ jobs:
     trigger: pull_request
     # Enable internet access in the COPR.
     enable_net: true
-    # Executed targets in the CI.
-    # Available targets are below.
+    # Executed targets in the CI. Available targets are below.
     # https://packit.dev/docs/configuration/#available-copr-build-targets
+    #
+    # Note that we keep the Fedora rawhide. See the `.packit/README.md` -
+    # "Motivation and context" for details.
     targets:
       - fedora-rawhide-x86_64
       # Comment out the i386 (i686) case as it takes much longer time.

--- a/.packit/README.md
+++ b/.packit/README.md
@@ -6,6 +6,10 @@ This document is to use Packit CI that enables us to test SIMDe on Fedora projec
 * Report issues (bugs or feature suggestions): https://github.com/packit/packit/issues
 * Pipeline history: https://dashboard.packit.dev/pipelines
 
+## Motivation and context
+
+We want to keep [Fedora rawhide](https://docs.fedoraproject.org/en-US/releases/rawhide/) cases in the CI. Fedora rawhide is the latest development version of Fedora Linux, not a named release that might go out of support later. Because the gcc and clang new versions are landing on Fedora rawhide earlier than other Linux distributions.
+
 ## How to check the CI results
 
 1. Enable Packit CI for your forked simde repository. See the [onboarding guide](https://packit.dev/docs/guide/).

--- a/.packit/simde.spec
+++ b/.packit/simde.spec
@@ -67,7 +67,6 @@ export CI_GCC_RPM_LDFLAGS="%{build_ldflags}"
 # - set_build_flags macro to check the set environment variables.
 unset CC
 unset CFLAGS
-unset LDFLAGS
 unset CXX
 unset CXXFLAGS
 unset LDFLAGS


### PR DESCRIPTION
This PR has 2 commits.

* Packit: Refactoring: Remove a duplicated command to unset LDFLAGS.
  I found a small issue.
* Packit: Add a document of why we want to keep Fedora rawhide in CI.
  I added a note about the topic mentioned at https://github.com/simd-everywhere/simde/issues/1036#issuecomment-1573502939. 