### PR TITLE
Packit: Reimplement the testing matrix adding pending status.

### DIFF
--- a/.packit/ci.sh
+++ b/.packit/ci.sh
@@ -49,6 +49,39 @@ function _run_test {
   fi
 }
 
+function _run_test_and_get_result {
+  local exit_status=0
+  local result="skipped"
+
+  if [ "${#}" -lt 1 ]; then
+    echo "Argument error" 2>&1
+    exit 1
+  fi
+  local cond="${1}"
+
+  if [ "${cond}" = "include" ] || [ "${cond}" = "pend" ]; then
+    if _run_test; then
+      if [ "${cond}" = "include" ]; then
+        result="ok"
+      else
+        exit_status=1
+        result="pending - passed unexpectedly"
+      fi
+    else
+      if [ "${cond}" = "include" ]; then
+        exit_status=1
+        result="not ok"
+      else
+        result="pending - failed expectedly"
+      fi
+    fi
+  fi
+
+  # Use global variables to pass the return values as a limitation of Bash.
+  result_buf="${result}"
+  return "${exit_status}"
+}
+
 # Print system info.
 cat /proc/cpuinfo
 cat /proc/meminfo
@@ -58,40 +91,50 @@ pip3 install meson==0.55.0
 
 # Run test.
 
-# Customized constants.
+# Configuration
 #
 # If the value is true, the CI returns the exit status zero even if the tests
 # fail as a compromised way.
 IGNORE_EXIT_STATUS=
-# Set true if you want to skip specific tests to save total running time in all
-# the CPU cases.
-SKIP_ALL_GCC_DEFAULT=
-SKIP_ALL_GCC_O2=
-SKIP_ALL_GCC_RPM=true
-SKIP_ALL_CLANG_DEFAULT=true
-SKIP_ALL_CLANG_O2=true
-SKIP_ALL_CLANG_RPM=true
-# Set true if you want to skip specific tests in the specific CPU cases.
-# The host machine CPU name is used in the constant names.
-#
-# Skip the test as it fails, and the i686 case takes longer running time.
-SKIP_i686_GCC_DEFAULT=true
 
-# Generate the current CPU specific skip flags.
-SKIP_CPU_GCC_DEFAULT=$(eval echo "\${SKIP_${HOST_CPU}_GCC_DEFAULT:-}")
-SKIP_CPU_GCC_O2=$(eval echo "\${SKIP_${HOST_CPU}_GCC_O2:-}")
-SKIP_CPU_GCC_RPM=$(eval echo "\${SKIP_${HOST_CPU}_GCC_RPM:-}")
-SKIP_CPU_CLANG_DEFAULT=$(eval echo "\${SKIP_${HOST_CPU}_CLANG_DEFAULT:-}")
-SKIP_CPU_CLANG_O2=$(eval echo "\${SKIP_${HOST_CPU}_CLANG_O2:-}")
-SKIP_CPU_CLANG_RPM=$(eval echo "\${SKIP_${HOST_CPU}_CLANG_RPM:-}")
+# Define the testing matrix.
+# "include": Include the test in the matrix. Run the test.
+# "exclude": Exclude the test. The test is not executed.
+#            It can be used to save the total running time in CI.
+# "pend"   : Run the test, but if the test fails, it passes as exit status zero.
+#            If the test passes unexpectedly, it fails as exit status non-zero.
+#
+# Set the default behavior for each test.
+MATRIX_DEFAULT_GCC_DEFAULT="include"
+MATRIX_DEFAULT_GCC_O2="include"
+MATRIX_DEFAULT_GCC_RPM="exclude"
+MATRIX_DEFAULT_CLANG_DEFAULT="exclude"
+MATRIX_DEFAULT_CLANG_O2="exclude"
+MATRIX_DEFAULT_CLANG_RPM="exclude"
+# Set the CPU specific behavior for each test optionally.
+# This configuration is prioritized than the default behavior.
+MATRIX_i686_GCC_DEFAULT="pend"
+
+# End of configuration
+
+# Generate the current CPU specific test conditions.
+# If there is no CPU specific variable, set the default value.
+TEST_COND_GCC_DEFAULT=$(eval echo \
+  "\${MATRIX_${HOST_CPU}_GCC_DEFAULT:-${MATRIX_DEFAULT_GCC_DEFAULT}}")
+TEST_COND_GCC_O2=$(eval echo \
+  "\${MATRIX_${HOST_CPU}_GCC_O2:-${MATRIX_DEFAULT_GCC_O2}}")
+TEST_COND_GCC_RPM=$(eval echo \
+  "\${MATRIX_${HOST_CPU}_GCC_RPM:-${MATRIX_DEFAULT_GCC_RPM}}")
+TEST_COND_CLANG_DEFAULT=$(eval echo \
+  "\${MATRIX_${HOST_CPU}_CLANG_DEFAULT:-${MATRIX_DEFAULT_CLANG_DEFAULT}}")
+TEST_COND_CLANG_O2=$(eval echo \
+  "\${MATRIX_${HOST_CPU}_CLANG_O2:-${MATRIX_DEFAULT_CLANG_O2}}")
+TEST_COND_CLANG_RPM=$(eval echo \
+  "\${MATRIX_${HOST_CPU}_CLANG_RPM:-${MATRIX_DEFAULT_CLANG_RPM}}")
 
 exit_status=0
-result_gcc="skipped"
-result_gcc_O2="skipped"
-result_gcc_rpm="skipped"
-result_clang="skipped"
-result_clang_O2="skipped"
-result_clang_rpm="skipped"
+# A temporary buffer to store the return value from a function.
+result_buf=
 
 # Print compiler versions.
 gcc --version
@@ -100,89 +143,65 @@ clang --version
 clang++ --version
 
 echo "== Tests on gcc in a default status =="
-if [ "${SKIP_ALL_GCC_DEFAULT}" != true ] && \
-  [ "${SKIP_CPU_GCC_DEFAULT}" != true ]; then
-  result_gcc="ok"
-  if ! BUILD_DIR="build/gcc" CC="gcc" CXX="g++" \
-    _run_test; then
-    exit_status=1
-    result_gcc="not ok"
-  fi
+if ! BUILD_DIR="build/gcc" CC="gcc" CXX="g++" \
+  _run_test_and_get_result "${TEST_COND_GCC_DEFAULT}"; then
+  exit_status=1
 fi
+result_gcc="${result_buf}"
 
 echo "== Tests on clang in a default status =="
-if [ "${SKIP_ALL_CLANG_DEFAULT}" != true ] && \
-  [ "${SKIP_CPU_CLANG_DEFAULT}" != true ]; then
-  result_clang="ok"
-  if ! BUILD_DIR="build/clang" CC="clang" CXX="clang++" \
-    _run_test; then
-    exit_status=1
-    result_clang="not ok"
-  fi
+if ! BUILD_DIR="build/clang" CC="clang" CXX="clang++" \
+  _run_test_and_get_result "${TEST_COND_CLANG_DEFAULT}"; then
+  exit_status=1
 fi
+result_clang="${result_buf}"
 
 echo "== Tests on gcc with O2 flag =="
-if [ "${SKIP_ALL_GCC_O2}" != true ] && \
-  [ "${SKIP_CPU_GCC_O2}" != true ]; then
-  result_gcc_O2="ok"
-  if ! BUILD_DIR="build/gcc-O2" CC="gcc" CXX="g++" \
-    CFLAGS="-O2" CXXFLAGS="-O2" \
-    _run_test; then
-    exit_status=1
-    result_gcc_O2="not ok"
-  fi
+if ! BUILD_DIR="build/gcc-O2" CC="gcc" CXX="g++" \
+  CFLAGS="-O2" CXXFLAGS="-O2" \
+  _run_test_and_get_result "${TEST_COND_GCC_O2}"; then
+  exit_status=1
 fi
+result_gcc_O2="${result_buf}"
 
 echo "== Tests on clang with O2 flag =="
-if [ "${SKIP_ALL_CLANG_O2}" != true ] && \
-  [ "${SKIP_CPU_CLANG_O2}" != true ]; then
-  result_clang_O2="ok"
-  if ! BUILD_DIR="build/clang-O2" CC="clang" CXX="clang++" \
-    CFLAGS="-O2" CXXFLAGS="-O2" \
-    _run_test; then
-    exit_status=1
-    result_clang_O2="not ok"
-  fi
+if ! BUILD_DIR="build/clang-O2" CC="clang" CXX="clang++" \
+  CFLAGS="-O2" CXXFLAGS="-O2" \
+  _run_test_and_get_result "${TEST_COND_CLANG_O2}"; then
+  exit_status=1
 fi
+result_clang_O2="${result_buf}"
 
 # This is an advanced test.
 echo "== Tests on gcc with flags used in RPM package build =="
-if [ "${SKIP_ALL_GCC_RPM}" != true ] && \
-  [ "${SKIP_CPU_GCC_RPM}" != true ]; then
-  result_gcc_rpm="ok"
-  if ! BUILD_DIR="build/gcc-rpm" CC="gcc" CXX="g++" \
-    CFLAGS="${CI_GCC_RPM_CFLAGS}" CXXFLAGS="${CI_GCC_RPM_CXXFLAGS}" \
-    LDFLAGS="${CI_GCC_RPM_LDFLAGS}" \
-    _run_test; then
-    exit_status=1
-    result_gcc_rpm="not ok"
-  fi
+if ! BUILD_DIR="build/gcc-rpm" CC="gcc" CXX="g++" \
+  CFLAGS="${CI_GCC_RPM_CFLAGS-}" CXXFLAGS="${CI_GCC_RPM_CXXFLAGS-}" \
+  LDFLAGS="${CI_GCC_RPM_LDFLAGS-}" \
+  _run_test_and_get_result "${TEST_COND_GCC_RPM}"; then
+  exit_status=1
 fi
+result_gcc_rpm="${result_buf}"
 
 # This is an advanced test.
 echo "== Tests on clang with flags used in RPM package build =="
-if [ "${SKIP_ALL_CLANG_RPM}" != true ] && \
-  [ "${SKIP_CPU_CLANG_RPM}" != true ]; then
-  result_clang_rpm="ok"
-  if ! BUILD_DIR="build/clang-rpm" CC="clang" CXX="clang++" \
-    CFLAGS="${CI_CLANG_RPM_CFLAGS}" CXXFLAGS="${CI_CLANG_RPM_CXXFLAGS}" \
-    LDFLAGS="${CI_CLANG_RPM_LDFLAGS}" \
-    _run_test; then
-    exit_status=1
-    result_clang_rpm="not ok"
-  fi
+if ! BUILD_DIR="build/clang-rpm" CC="clang" CXX="clang++" \
+  CFLAGS="${CI_CLANG_RPM_CFLAGS-}" CXXFLAGS="${CI_CLANG_RPM_CXXFLAGS-}" \
+  LDFLAGS="${CI_CLANG_RPM_LDFLAGS-}" \
+  _run_test_and_get_result "${TEST_COND_CLANG_RPM}"; then
+  exit_status=1
 fi
+result_clang_rpm="${result_buf}"
 
 # Print results.
 cat <<EOF
 == Results ==
 Exit status: ${exit_status}
-${result_gcc} gcc without flags
-${result_gcc_O2} gcc with -O2 flag
-${result_gcc_rpm} gcc with RPM build flags
-${result_clang} clang without flags
-${result_clang_O2} clang with -O2 flag
-${result_clang_rpm} clang with RPM build flags
+${result_gcc}: gcc without flags
+${result_gcc_O2}: gcc with -O2 flag
+${result_gcc_rpm}: gcc with RPM build flags
+${result_clang}: clang without flags
+${result_clang_O2}: clang with -O2 flag
+${result_clang_rpm}: clang with RPM build flags
 EOF
 
 if [ "${IGNORE_EXIT_STATUS}" = true ]; then


### PR DESCRIPTION
This PR is for this feature. https://github.com/simd-everywhere/simde/pull/1044#issuecomment-1589615177

I considered a kind of GitHub Action's matrix feature.

My test in my forked repository:
CI result: https://copr.fedorainfracloud.org/coprs/packit/junaruga-simde-wip-ci-packit-matrix-pend/build/6083205/

My test with fully executed tests in my forked repository:

I changed the configuration like this for the test.

```
diff --git a/.packit/ci.sh b/.packit/ci.sh
index 49e4f040..d90d4a09 100755
--- a/.packit/ci.sh
+++ b/.packit/ci.sh
@@ -107,13 +107,16 @@ IGNORE_EXIT_STATUS=
 # Set the default behavior for each test.
 MATRIX_DEFAULT_GCC_DEFAULT="include"
 MATRIX_DEFAULT_GCC_O2="include"
-MATRIX_DEFAULT_GCC_RPM="exclude"
-MATRIX_DEFAULT_CLANG_DEFAULT="exclude"
-MATRIX_DEFAULT_CLANG_O2="exclude"
-MATRIX_DEFAULT_CLANG_RPM="exclude"
+MATRIX_DEFAULT_GCC_RPM="include"
+MATRIX_DEFAULT_CLANG_DEFAULT="include"
+MATRIX_DEFAULT_CLANG_O2="pend"
+MATRIX_DEFAULT_CLANG_RPM="pend"
 # Set the CPU specific behavior for each test optionally.
 # This configuration is prioritized than the default behavior.
 MATRIX_i686_GCC_DEFAULT="pend"
+MATRIX_i686_GCC_RPM="pend"
+MATRIX_i686_CLANG_DEFAULT="pend"
+MATRIX_s390x_CLANG_DEFAULT="pend"
 
 # End of configuration
```

CI result: https://copr.fedorainfracloud.org/coprs/packit/junaruga-simde-wip-ci-packit-matrix-pend-debug/build/6084882/
