### PR TITLE
Packit: Refactoring: Unset unused environment variables in a simpler way, and update the README.

### DIFF
--- a/.packit/simde.spec
+++ b/.packit/simde.spec
@@ -1,3 +1,8 @@
+# Disable the automatically set build flags to the environment variables such
+# as CC, CFLAGS, and etc.
+# See <https://src.fedoraproject.org/rpms/redhat-rpm-config/blob/rawhide/f/macros>.
+%undefine _auto_set_build_flags
+
 Name: simde
 Version: 1
 Release: 1%{?dist}
@@ -60,21 +65,6 @@ export CI_CLANG_RPM_LDFLAGS="%{build_ldflags}"
 export CI_GCC_RPM_CFLAGS="%{build_cflags}"
 export CI_GCC_RPM_CXXFLAGS="%{build_cxxflags}"
 export CI_GCC_RPM_LDFLAGS="%{build_ldflags}"
-
-# Unset unused environment variables to prevent the `meson setup` from reading
-# unintentionally in the in the CI script.
-# See <https://src.fedoraproject.org/rpms/redhat-rpm-config/blob/rawhide/f/macros>
-# - set_build_flags macro to check the set environment variables.
-unset CC
-unset CFLAGS
-unset CXX
-unset CXXFLAGS
-unset LDFLAGS
-# Unset other environment variables not used in the `meson setup` too.
-unset FFLAGS
-unset FCFLAGS
-unset VALAFLAGS
-unset RUSTFLAGS
 
 echo "Running the CI script %{SOURCE1}."
 /bin/time -f '=> [%E]' "%{SOURCE1}"

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ make sense since they will always be green, but here are the links:
 * [Azure Pipelines](https://dev.azure.com/simd-everywhere/SIMDe/_build)
 * [Drone CI](https://cloud.drone.io/simd-everywhere/simde/)
 * [Travis CI](https://app.travis-ci.com/github/simd-everywhere/simde/)
+* [Packit CI](https://dashboard.packit.dev/pipelines)
 
 If you're adding a new build I suggest Cirrus CI, which is where we
 currently have the most room given the number of builds currently on


### PR DESCRIPTION
This PR has 2 commits below for refactoring. The CI result on my forked repository is [here](https://copr.fedorainfracloud.org/coprs/packit/junaruga-simde-wip-ci-packet-refactoring/build/6096104/).

* Add Packit CI to the README. The updated README is [here](https://github.com/junaruga/simde/blob/wip/ci-packet-refactoring/README.md).
  Note that the linked page is a common history page including other open source projects. It seems the CI doesn't have the project specific history page.
* Packit: Unset unused environment variables in a simpler way.
  I found the way[1].

## References

* [1] https://src.fedoraproject.org/rpms/redhat-rpm-config/blob/rawhide/f/macros#_101
  > Automatically use set_build_flags macro for build, check, and
  > install phases.
  > Use "%undefine _auto_set_build_flags" to disable"
