### PR TITLE
Packit: README: Fix typo.

### DIFF
--- a/.packit/README.md
+++ b/.packit/README.md
@@ -15,7 +15,7 @@ We want to keep [Fedora rawhide](https://docs.fedoraproject.org/en-US/releases/r
 1. Enable Packit CI for your forked simde repository. See the [onboarding guide](https://packit.dev/docs/guide/).
 2. When you push branches to your repository, the CI is triggered. Go to the [Pipelines](https://dashboard.packit.dev/pipelines) page to see your pipeline.
 3. Do browser-search by "simde".
-4. Click a "fedora-*-*" button on the Jobs to go to the job detailed page.
+4. Click a "fedora-\*-\*" button on the Jobs to go to the job detailed page.
 5. You can see 3 links below. You can check the Build Logs first, and the SRPM Logs second if it is necessary.
     * **SRPM Logs**: A log of the preparation of the test such as installing the used RPM packages to test. This is a log that the system creates Source RPM (SRPM) from the RPM spec file.
     * **Web URL**: Go to the jobs page in Fedora Copr web system used to run the RPM.


### PR DESCRIPTION
I noticed a small typo. We need to escape the special character "*" to print it.

[Here](https://github.com/junaruga/simde/blob/wip/ci-packit-readme/.packit/README.md) is the modified README.