### PR TITLE
fix SIMDE_ARCH_X86_SSE4_2 define

### DIFF
--- a/simde/simde-arch.h
+++ b/simde/simde-arch.h
@@ -269,7 +269,7 @@
 #    if !defined(SIMDE_ARCH_X86_SSE4_1)
 #      define SIMDE_ARCH_X86_SSE4_1 1
 #    endif
-#    if !defined(SIMDE_ARCH_X86_SSE4_1)
+#    if !defined(SIMDE_ARCH_X86_SSE4_2)
 #      define SIMDE_ARCH_X86_SSE4_2 1
 #    endif
 #  endif


### PR DESCRIPTION
when using `/arch=AVX` or similar then SSE4.2 does not get activated (on MSVC at least, but should be similar on g++/clang)

This PR fixes this.