### PR TITLE
Packit: Set PATH for commands installed by `pip install`.

### DIFF
--- a/.packit/ci.sh
+++ b/.packit/ci.sh
@@ -86,6 +86,9 @@ function _run_test_and_get_result {
 cat /proc/cpuinfo
 cat /proc/meminfo
 
+# Set PATH for commands installed by `pip install`.
+PATH="${PATH}:${HOME}/.local/bin"
+
 # Install additional packages.
 pip3 install meson==0.55.0
 


### PR DESCRIPTION
This fixes the following issue found at https://github.com/simd-everywhere/simde/pull/1055#issuecomment-1683738127.

```
+ pip3 install meson==0.55.0
...
Installing collected packages: meson
  WARNING: The script meson is installed in '/builddir/.local/bin' which is not on PATH.
...
+ meson setup build/gcc
/builddir/build/SOURCES/ci.sh: line 15: meson: command not found
...
```