### PR TITLE
gh-actions: emscripten use 3.1.45, not tot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,8 +170,8 @@ jobs:
       run: |
         git clone https://github.com/emscripten-core/emsdk.git /opt/emsdk
         cd /opt/emsdk
-        ./emsdk install tot
-        ./emsdk activate tot
+        ./emsdk install 3.1.45  # tot
+        ./emsdk activate 3.1.45  # tot
         source emsdk_env.sh
     - name: Install v8
       run: |


### PR DESCRIPTION
3.1.46+ fails: https://github.com/emscripten-core/emscripten/issues/20250
