### PR TITLE
avx: fix _mm256_shuffle_pd impl

### DIFF
--- a/simde/x86/avx.h
+++ b/simde/x86/avx.h
@@ -5136,8 +5136,8 @@ simde_mm256_shuffle_pd (simde__m256d a, simde__m256d b, const int imm8)
 #elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
   #define simde_mm256_shuffle_pd(a, b, imm8) \
       simde_mm256_set_m128d( \
-          simde_mm_shuffle_pd(simde_mm256_extractf128_pd(a, 1), simde_mm256_extractf128_pd(b, 1), (imm8 >> 0) & 3), \
-          simde_mm_shuffle_pd(simde_mm256_extractf128_pd(a, 0), simde_mm256_extractf128_pd(b, 0), (imm8 >> 2) & 3))
+          simde_mm_shuffle_pd(simde_mm256_extractf128_pd(a, 1), simde_mm256_extractf128_pd(b, 1), (imm8 >> 2) & 3), \
+          simde_mm_shuffle_pd(simde_mm256_extractf128_pd(a, 0), simde_mm256_extractf128_pd(b, 0), (imm8 >> 0) & 3))
 #elif defined(SIMDE_SHUFFLE_VECTOR_)
   #define simde_mm256_shuffle_pd(a, b, imm8) \
     SIMDE_SHUFFLE_VECTOR_(64, 32, a, b, \

--- a/test/x86/avx.c
+++ b/test/x86/avx.c
@@ -13795,9 +13795,12 @@ test_simde_mm256_shuffle_pd(SIMDE_MUNIT_TEST_ARGS) {
       simde_mm256_set_pd(SIMDE_FLOAT64_C( -365.57), SIMDE_FLOAT64_C(  918.52),
                          SIMDE_FLOAT64_C(  333.70), SIMDE_FLOAT64_C(   26.68)) }
   };
+  uint64_t a[] = {1, 0, 0, 0};
+  uint64_t b[] = {0, 0, 1, 0};
+  int64_t target[4] = {INT64_C(1),  INT64_C(0),  INT64_C(0),  INT64_C(0) };
+  simde__m256d r, tmp_0_yd, tmp_1_yd;
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
-    simde__m256d r;
 
     r = simde_mm256_shuffle_pd(test_vec[i].a, test_vec[i].b, 0x5);
     simde_assert_m256d_close(r, test_vec[i].r1, 1);
@@ -13805,6 +13808,14 @@ test_simde_mm256_shuffle_pd(SIMDE_MUNIT_TEST_ARGS) {
     r = simde_mm256_shuffle_pd(test_vec[i].a, test_vec[i].b, 0xa);
     simde_assert_m256d_close(r, test_vec[i].r2, 1);
   }
+
+  tmp_0_yd = simde_mm256_loadu_pd(HEDLEY_REINTERPRET_CAST(double*, a));
+  tmp_1_yd = simde_mm256_loadu_pd(HEDLEY_REINTERPRET_CAST(double*, b));
+  r = simde_mm256_shuffle_pd(tmp_0_yd, tmp_1_yd, 0xc); // 0b1100
+
+  simde_test_x86_assert_equal_i64x4(simde_mm256_castpd_si256(r), simde_mm256_loadu_epi64(target));
+
+  //simde_test_x86_write_i64x4(2, simde_mm256_castpd_si256(r), SIMDE_TEST_VEC_POS_LAST);
 
   return 0;
 }


### PR DESCRIPTION
- add test from #926
- avx: simde_mm256_shuffle_pd fix for natural vector size < 128

Fixes: #926 