### PR TITLE
[Patch] Modified simde_float16 to simde_float16_t (issue#1099)

### DIFF
--- a/simde/arm/neon/add.h
+++ b/simde/arm/neon/add.h
@@ -35,7 +35,7 @@ SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16
-simde_vaddh_f16(simde_float16 a, simde_float16 b) {
+simde_vaddh_f16(simde_float16_t a, simde_float16_t b) {
   #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vaddh_f16(a, b);
   #else

--- a/simde/arm/neon/ceqz.h
+++ b/simde/arm/neon/ceqz.h
@@ -375,7 +375,7 @@ simde_vceqzd_u64(uint64_t a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 uint16_t
-simde_vceqzh_f16(simde_float16 a) {
+simde_vceqzh_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vceqzh_f16(a);
   #else

--- a/simde/arm/neon/cvt.h
+++ b/simde/arm/neon/cvt.h
@@ -141,7 +141,7 @@ simde_vcvt_f64_f32(simde_float32x2_t a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 int16_t
-simde_vcvth_s16_f16(simde_float16 a) {
+simde_vcvth_s16_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvth_s16_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -167,7 +167,7 @@ simde_vcvth_s16_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 uint16_t
-simde_vcvth_u16_f16(simde_float16 a) {
+simde_vcvth_u16_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvth_u16_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -193,7 +193,7 @@ simde_vcvth_u16_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 int32_t
-simde_vcvth_s32_f16(simde_float16 a) {
+simde_vcvth_s32_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvth_s32_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -219,7 +219,7 @@ simde_vcvth_s32_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 uint32_t
-simde_vcvth_u32_f16(simde_float16 a) {
+simde_vcvth_u32_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvth_u32_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -245,7 +245,7 @@ simde_vcvth_u32_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 int64_t
-simde_vcvth_s64_f16(simde_float16 a) {
+simde_vcvth_s64_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvth_s64_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -271,7 +271,7 @@ simde_vcvth_s64_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 uint64_t
-simde_vcvth_u64_f16(simde_float16 a) {
+simde_vcvth_u64_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvth_u64_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -1385,7 +1385,7 @@ simde_vcvtq_f64_u64(simde_uint64x2_t a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 int16_t
-simde_vcvtah_s16_f16(simde_float16 a) {
+simde_vcvtah_s16_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtah_s16_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -1411,7 +1411,7 @@ simde_vcvtah_s16_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 uint16_t
-simde_vcvtah_u16_f16(simde_float16 a) {
+simde_vcvtah_u16_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && !defined(SIMDE_BUG_CLANG_46844) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtah_u16_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -1437,7 +1437,7 @@ simde_vcvtah_u16_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 int32_t
-simde_vcvtah_s32_f16(simde_float16 a) {
+simde_vcvtah_s32_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtah_s32_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -1463,7 +1463,7 @@ simde_vcvtah_s32_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 uint32_t
-simde_vcvtah_u32_f16(simde_float16 a) {
+simde_vcvtah_u32_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && !defined(SIMDE_BUG_CLANG_46844) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtah_u32_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -1489,7 +1489,7 @@ simde_vcvtah_u32_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 int64_t
-simde_vcvtah_s64_f16(simde_float16 a) {
+simde_vcvtah_s64_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtah_s64_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -1515,7 +1515,7 @@ simde_vcvtah_s64_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 uint64_t
-simde_vcvtah_u64_f16(simde_float16 a) {
+simde_vcvtah_u64_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && !defined(SIMDE_BUG_CLANG_46844) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtah_u64_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)

--- a/simde/arm/neon/cvtm.h
+++ b/simde/arm/neon/cvtm.h
@@ -36,7 +36,7 @@ SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
 int64_t
-simde_vcvtmh_s64_f16(simde_float16 a) {
+simde_vcvtmh_s64_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtmh_s64_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -63,7 +63,7 @@ simde_vcvtmh_s64_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 int32_t
-simde_vcvtmh_s32_f16(simde_float16 a) {
+simde_vcvtmh_s32_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtmh_s32_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -90,7 +90,7 @@ simde_vcvtmh_s32_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 int16_t
-simde_vcvtmh_s16_f16(simde_float16 a) {
+simde_vcvtmh_s16_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtmh_s16_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -117,7 +117,7 @@ simde_vcvtmh_s16_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 uint64_t
-simde_vcvtmh_u64_f16(simde_float16 a) {
+simde_vcvtmh_u64_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtmh_u64_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -144,7 +144,7 @@ simde_vcvtmh_u64_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 uint32_t
-simde_vcvtmh_u32_f16(simde_float16 a) {
+simde_vcvtmh_u32_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtmh_u32_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -171,7 +171,7 @@ simde_vcvtmh_u32_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 uint16_t
-simde_vcvtmh_u16_f16(simde_float16 a) {
+simde_vcvtmh_u16_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtmh_u16_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)

--- a/simde/arm/neon/cvtn.h
+++ b/simde/arm/neon/cvtn.h
@@ -105,7 +105,7 @@ simde_vcvtnq_s64_f64(simde_float64x2_t a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 int64_t
-simde_vcvtnh_s64_f16(simde_float16 a) {
+simde_vcvtnh_s64_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtnh_s64_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -130,7 +130,7 @@ simde_vcvtnh_s64_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 int32_t
-simde_vcvtnh_s32_f16(simde_float16 a) {
+simde_vcvtnh_s32_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtnh_s32_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -155,7 +155,7 @@ simde_vcvtnh_s32_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 int16_t
-simde_vcvtnh_s16_f16(simde_float16 a) {
+simde_vcvtnh_s16_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtnh_s16_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -180,7 +180,7 @@ simde_vcvtnh_s16_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 uint64_t
-simde_vcvtnh_u64_f16(simde_float16 a) {
+simde_vcvtnh_u64_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtnh_u64_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -205,7 +205,7 @@ simde_vcvtnh_u64_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 uint32_t
-simde_vcvtnh_u32_f16(simde_float16 a) {
+simde_vcvtnh_u32_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtnh_u32_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -230,7 +230,7 @@ simde_vcvtnh_u32_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 uint16_t
-simde_vcvtnh_u16_f16(simde_float16 a) {
+simde_vcvtnh_u16_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtnh_u16_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)

--- a/simde/arm/neon/cvtp.h
+++ b/simde/arm/neon/cvtp.h
@@ -36,7 +36,7 @@ SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
 int64_t
-simde_vcvtph_s64_f16(simde_float16 a) {
+simde_vcvtph_s64_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtph_s64_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -63,7 +63,7 @@ simde_vcvtph_s64_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 int32_t
-simde_vcvtph_s32_f16(simde_float16 a) {
+simde_vcvtph_s32_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtph_s32_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -90,7 +90,7 @@ simde_vcvtph_s32_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 int16_t
-simde_vcvtph_s16_f16(simde_float16 a) {
+simde_vcvtph_s16_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtph_s16_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -117,7 +117,7 @@ simde_vcvtph_s16_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 uint64_t
-simde_vcvtph_u64_f16(simde_float16 a) {
+simde_vcvtph_u64_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtph_u64_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -144,7 +144,7 @@ simde_vcvtph_u64_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 uint32_t
-simde_vcvtph_u32_f16(simde_float16 a) {
+simde_vcvtph_u32_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtph_u32_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -171,7 +171,7 @@ simde_vcvtph_u32_f16(simde_float16 a) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 uint16_t
-simde_vcvtph_u16_f16(simde_float16 a) {
+simde_vcvtph_u16_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vcvtph_u16_f16(a);
   #elif defined(SIMDE_FAST_CONVERSION_RANGE)

--- a/simde/arm/neon/dup_n.h
+++ b/simde/arm/neon/dup_n.h
@@ -36,7 +36,7 @@ SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x4_t
-simde_vdup_n_f16(simde_float16 value) {
+simde_vdup_n_f16(simde_float16_t value) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vdup_n_f16(value);
   #else
@@ -324,7 +324,7 @@ simde_vdup_n_u64(uint64_t value) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x8_t
-simde_vdupq_n_f16(simde_float16 value) {
+simde_vdupq_n_f16(simde_float16_t value) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vdupq_n_f16(value);
   #else

--- a/simde/arm/neon/ld1.h
+++ b/simde/arm/neon/ld1.h
@@ -36,7 +36,7 @@ SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x4_t
-simde_vld1_f16(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(4)]) {
+simde_vld1_f16(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vld1_f16(ptr);
   #else
@@ -212,7 +212,7 @@ simde_vld1_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(1)]) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x8_t
-simde_vld1q_f16(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(8)]) {
+simde_vld1q_f16(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vld1q_f16(ptr);
   #else

--- a/simde/arm/neon/ld1_dup.h
+++ b/simde/arm/neon/ld1_dup.h
@@ -38,7 +38,7 @@ SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x4_t
-simde_vld1_dup_f16(simde_float16 const * ptr) {
+simde_vld1_dup_f16(simde_float16_t const * ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vld1_dup_f16(ptr);
   #else
@@ -194,7 +194,7 @@ simde_vld1_dup_u64(uint64_t const * ptr) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x8_t
-simde_vld1q_dup_f16(simde_float16 const * ptr) {
+simde_vld1q_dup_f16(simde_float16_t const * ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vld1q_dup_f16(ptr);
   #else

--- a/simde/arm/neon/ld1_x2.h
+++ b/simde/arm/neon/ld1_x2.h
@@ -43,7 +43,7 @@ SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x4x2_t
-simde_vld1_f16_x2(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(8)]) {
+simde_vld1_f16_x2(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if \
       defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16) && \
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE))) && \

--- a/simde/arm/neon/ld1_x3.h
+++ b/simde/arm/neon/ld1_x3.h
@@ -42,7 +42,7 @@ SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x4x3_t
-simde_vld1_f16_x3(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(12)]) {
+simde_vld1_f16_x3(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(12)]) {
   #if \
       defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16) && \
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE))) && \

--- a/simde/arm/neon/ld1_x4.h
+++ b/simde/arm/neon/ld1_x4.h
@@ -43,7 +43,7 @@ SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x4x4_t
-simde_vld1_f16_x4(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(16)]) {
+simde_vld1_f16_x4(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
   #if \
       defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16) && \
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE))) && \

--- a/simde/arm/neon/ld1q_x2.h
+++ b/simde/arm/neon/ld1q_x2.h
@@ -43,7 +43,7 @@ SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x8x2_t
-simde_vld1q_f16_x2(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(16)]) {
+simde_vld1q_f16_x2(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
   #if \
       defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16) && \
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE))) && \

--- a/simde/arm/neon/ld1q_x3.h
+++ b/simde/arm/neon/ld1q_x3.h
@@ -42,7 +42,7 @@ SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x8x3_t
-simde_vld1q_f16_x3(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(24)]) {
+simde_vld1q_f16_x3(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(24)]) {
   #if \
       defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16) && \
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE))) && \

--- a/simde/arm/neon/ld1q_x4.h
+++ b/simde/arm/neon/ld1q_x4.h
@@ -43,7 +43,7 @@ SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x8x4_t
-simde_vld1q_f16_x4(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(32)]) {
+simde_vld1q_f16_x4(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
   #if \
       defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16) && \
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE))) && \

--- a/simde/arm/neon/ld2_dup.h
+++ b/simde/arm/neon/ld2_dup.h
@@ -245,7 +245,7 @@ simde_vld2_dup_u64(uint64_t const * ptr) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x8x2_t
-simde_vld2q_dup_f16(simde_float16 const * ptr) {
+simde_vld2q_dup_f16(simde_float16_t const * ptr) {
   #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vld2q_dup_f16(ptr);
   #else

--- a/simde/arm/neon/ld3.h
+++ b/simde/arm/neon/ld3.h
@@ -43,7 +43,7 @@ SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x4x3_t
-simde_vld3_f16(simde_float16 const *ptr) {
+simde_vld3_f16(simde_float16_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vld3_f16(ptr);
   #else
@@ -351,7 +351,7 @@ simde_vld3_u64(uint64_t const *ptr) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x8x3_t
-simde_vld3q_f16(simde_float16 const *ptr) {
+simde_vld3q_f16(simde_float16_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vld3q_f16(ptr);
   #else

--- a/simde/arm/neon/ld3_dup.h
+++ b/simde/arm/neon/ld3_dup.h
@@ -245,7 +245,7 @@ simde_vld3_dup_u64(uint64_t const * ptr) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x8x3_t
-simde_vld3q_dup_f16(simde_float16 const * ptr) {
+simde_vld3q_dup_f16(simde_float16_t const * ptr) {
   #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vld3q_dup_f16(ptr);
   #else

--- a/simde/arm/neon/ld4.h
+++ b/simde/arm/neon/ld4.h
@@ -42,7 +42,7 @@ SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x4x4_t
-simde_vld4_f16(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(16)]) {
+simde_vld4_f16(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vld4_f16(ptr);
   #else
@@ -262,7 +262,7 @@ simde_vld4_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x8x4_t
-simde_vld4q_f16(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(32)]) {
+simde_vld4q_f16(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vld4q_f16(ptr);
   #else

--- a/simde/arm/neon/ld4_dup.h
+++ b/simde/arm/neon/ld4_dup.h
@@ -245,7 +245,7 @@ simde_vld4_dup_u64(uint64_t const * ptr) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x8x4_t
-simde_vld4q_dup_f16(simde_float16 const * ptr) {
+simde_vld4q_dup_f16(simde_float16_t const * ptr) {
   #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vld4q_dup_f16(ptr);
   #else

--- a/simde/arm/neon/mul_n.h
+++ b/simde/arm/neon/mul_n.h
@@ -39,7 +39,7 @@ SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x4_t
-simde_vmul_n_f16(simde_float16x4_t a, simde_float16 b) {
+simde_vmul_n_f16(simde_float16x4_t a, simde_float16_t b) {
   #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vmul_n_f16(a, b);
   #else
@@ -137,7 +137,7 @@ simde_vmul_n_u32(simde_uint32x2_t a, uint32_t b) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x8_t
-simde_vmulq_n_f16(simde_float16x8_t a, simde_float16 b) {
+simde_vmulq_n_f16(simde_float16x8_t a, simde_float16_t b) {
   #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vmulq_n_f16(a, b);
   #else

--- a/simde/arm/neon/sqrt.h
+++ b/simde/arm/neon/sqrt.h
@@ -35,7 +35,7 @@ SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16
-simde_vsqrth_f16(simde_float16 a) {
+simde_vsqrth_f16(simde_float16_t a) {
   #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vsqrth_f16(a);
   #elif defined(simde_math_sqrtf)

--- a/simde/arm/neon/sub.h
+++ b/simde/arm/neon/sub.h
@@ -36,7 +36,7 @@ SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float16
-simde_vsubh_f16(simde_float16 a, simde_float16 b) {
+simde_vsubh_f16(simde_float16_t a, simde_float16_t b) {
   #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vsubh_f16(a, b);
   #else

--- a/test/arm/neon/abd.c
+++ b/test/arm/neon/abd.c
@@ -12,9 +12,9 @@ static int
 test_simde_vabdh_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
-    simde_float16 b;
-    simde_float16 r;
+    simde_float16_t a;
+    simde_float16_t b;
+    simde_float16_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_NANS)
     {            SIMDE_NANHF,
@@ -216,9 +216,9 @@ static int
 test_simde_vabd_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { {  SIMDE_FLOAT16_VALUE(  12.132), SIMDE_FLOAT16_VALUE( -  13.736), SIMDE_FLOAT16_VALUE( -  15.777),  SIMDE_FLOAT16_VALUE(  27.640) },
       { SIMDE_FLOAT16_VALUE( -  15.705),  SIMDE_FLOAT16_VALUE(  17.382), SIMDE_FLOAT16_VALUE( -  21.155), SIMDE_FLOAT16_VALUE( -  29.967) },
@@ -744,9 +744,9 @@ static int
 test_simde_vabdq_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE( -   8.295),  SIMDE_FLOAT16_VALUE(   4.995),  SIMDE_FLOAT16_VALUE(  22.222),  SIMDE_FLOAT16_VALUE(   0.992),
         SIMDE_FLOAT16_VALUE( -   2.210),  SIMDE_FLOAT16_VALUE(  12.462),  SIMDE_FLOAT16_VALUE(  20.310),  SIMDE_FLOAT16_VALUE(  23.937) },

--- a/test/arm/neon/abs.c
+++ b/test/arm/neon/abs.c
@@ -7,8 +7,8 @@ static int
 test_simde_vabsh_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
-    simde_float16 r;
+    simde_float16_t a;
+    simde_float16_t r;
   } test_vec[] = {
     { SIMDE_FLOAT16_VALUE( -  24.786),
        SIMDE_FLOAT16_VALUE(  24.786) },
@@ -98,8 +98,8 @@ static int
 test_simde_vabs_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(-0.70), SIMDE_FLOAT16_VALUE(-8.20), SIMDE_FLOAT16_VALUE(-4.90), SIMDE_FLOAT16_VALUE(-5.20) },
       { SIMDE_FLOAT16_VALUE(0.70), SIMDE_FLOAT16_VALUE(8.20), SIMDE_FLOAT16_VALUE(4.90), SIMDE_FLOAT16_VALUE(5.20) } },
@@ -431,8 +431,8 @@ static int
 test_simde_vabsq_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(-6.20), SIMDE_FLOAT16_VALUE(-7.50), SIMDE_FLOAT16_VALUE(-1.70), SIMDE_FLOAT16_VALUE(3.30), SIMDE_FLOAT16_VALUE(1.30), SIMDE_FLOAT16_VALUE(-9.30), SIMDE_FLOAT16_VALUE(7.80), SIMDE_FLOAT16_VALUE(3.00) },
       { SIMDE_FLOAT16_VALUE(6.20), SIMDE_FLOAT16_VALUE(7.50), SIMDE_FLOAT16_VALUE(1.70), SIMDE_FLOAT16_VALUE(3.30), SIMDE_FLOAT16_VALUE(1.30), SIMDE_FLOAT16_VALUE(9.30), SIMDE_FLOAT16_VALUE(7.80), SIMDE_FLOAT16_VALUE(3.00) } },

--- a/test/arm/neon/add.c
+++ b/test/arm/neon/add.c
@@ -7,9 +7,9 @@ static int
 test_simde_vaddh_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
-    simde_float16 b;
-    simde_float16 r;
+    simde_float16_t a;
+    simde_float16_t b;
+    simde_float16_t r;
   } test_vec[] = {
     { SIMDE_FLOAT16_VALUE(   167.25),
       SIMDE_FLOAT16_VALUE(  -952.00),
@@ -38,7 +38,7 @@ test_simde_vaddh_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 r = simde_vaddh_f16(test_vec[i].a, test_vec[i].b);
+    simde_float16_t r = simde_vaddh_f16(test_vec[i].a, test_vec[i].b);
 
     simde_assert_equal_f16(r, test_vec[i].r, 1);
   }
@@ -47,9 +47,9 @@ test_simde_vaddh_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #else
   fputc('\n', stdout);
   for (int i = 0 ; i < 8 ; i++) {
-    simde_float16 a = simde_test_codegen_random_f16(-1000.0f, 1000.0f);
-    simde_float16 b = simde_test_codegen_random_f16(-1000.0f, 1000.0f);
-    simde_float16 r = simde_vaddh_f16(a, b);
+    simde_float16_t a = simde_test_codegen_random_f16(-1000.0f, 1000.0f);
+    simde_float16_t b = simde_test_codegen_random_f16(-1000.0f, 1000.0f);
+    simde_float16_t r = simde_vaddh_f16(a, b);
 
     simde_test_codegen_write_f16(2, a, SIMDE_TEST_VEC_POS_FIRST);
     simde_test_codegen_write_f16(2, b, SIMDE_TEST_VEC_POS_MIDDLE);
@@ -175,9 +175,9 @@ static int
 test_simde_vadd_f16 (SIMDE_MUNIT_TEST_ARGS) {
   #if 1
     struct {
-      simde_float16 a[4];
-      simde_float16 b[4];
-      simde_float16 r[4];
+      simde_float16_t a[4];
+      simde_float16_t b[4];
+      simde_float16_t r[4];
     } test_vec[] = {
       { { SIMDE_FLOAT16_VALUE(   -49.28), SIMDE_FLOAT16_VALUE(  -109.00), SIMDE_FLOAT16_VALUE(  -626.50), SIMDE_FLOAT16_VALUE(  -567.00) },
       { SIMDE_FLOAT16_VALUE(  -178.88), SIMDE_FLOAT16_VALUE(    10.22), SIMDE_FLOAT16_VALUE(   976.50), SIMDE_FLOAT16_VALUE(   -31.19) },
@@ -674,9 +674,9 @@ static int
 test_simde_vaddq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   #if 1
     struct {
-      simde_float16 a[8];
-      simde_float16 b[8];
-      simde_float16 r[8];
+      simde_float16_t a[8];
+      simde_float16_t b[8];
+      simde_float16_t r[8];
     } test_vec[] = {
       { { SIMDE_FLOAT16_VALUE(   441.00), SIMDE_FLOAT16_VALUE(   861.50), SIMDE_FLOAT16_VALUE(    98.06), SIMDE_FLOAT16_VALUE(   896.00),
         SIMDE_FLOAT16_VALUE(  -918.50), SIMDE_FLOAT16_VALUE(  -717.00), SIMDE_FLOAT16_VALUE(  -823.00), SIMDE_FLOAT16_VALUE(  -581.00) },

--- a/test/arm/neon/bsl.c
+++ b/test/arm/neon/bsl.c
@@ -8,9 +8,9 @@ test_simde_vbsl_f16 (SIMDE_MUNIT_TEST_ARGS) {
   #if 1
     struct {
       uint16_t a[4];
-      simde_float16 b[4];
-      simde_float16 c[4];
-      simde_float16 r[4];
+      simde_float16_t b[4];
+      simde_float16_t c[4];
+      simde_float16_t r[4];
     } test_vec[] = {
     #if !defined(SIMDE_FAST_MATH) && defined(SIMDE_FLOAT16_IS_SCALAR)
     { { UINT16_C(18704), UINT16_C(47545), UINT16_C( 6410), UINT16_C(57433) },
@@ -616,9 +616,9 @@ static int
 test_simde_vbslq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
     uint16_t a[8];
-    simde_float16 b[8];
-    simde_float16 c[8];
-    simde_float16 r[8];
+    simde_float16_t b[8];
+    simde_float16_t c[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { { UINT16_C(37688), UINT16_C(35401), UINT16_C(27742), UINT16_C(58401), UINT16_C(50272), UINT16_C(49953), UINT16_C(15249), UINT16_C(43869) },
       { SIMDE_FLOAT16_VALUE(  -660.00), SIMDE_FLOAT16_VALUE(  -281.00), SIMDE_FLOAT16_VALUE(  -589.00), SIMDE_FLOAT16_VALUE(  -492.25),

--- a/test/arm/neon/cage.c
+++ b/test/arm/neon/cage.c
@@ -199,8 +199,8 @@ static int
 test_simde_vcage_f16 (SIMDE_MUNIT_TEST_ARGS) {
   #if 1
     struct {
-      simde_float16 a[4];
-      simde_float16 b[4];
+      simde_float16_t a[4];
+      simde_float16_t b[4];
       uint16_t r[4];
     } test_vec[] = {
       { { SIMDE_FLOAT16_VALUE(   506.50), SIMDE_FLOAT16_VALUE(   580.50), SIMDE_FLOAT16_VALUE(   209.88), SIMDE_FLOAT16_VALUE(  -273.25) },
@@ -345,8 +345,8 @@ static int
 test_simde_vcageq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   #if 1
     struct {
-      simde_float16 a[8];
-      simde_float16 b[8];
+      simde_float16_t a[8];
+      simde_float16_t b[8];
       uint16_t r[8];
     } test_vec[] = {
       { { SIMDE_FLOAT16_VALUE(   476.50), SIMDE_FLOAT16_VALUE(   975.50), SIMDE_FLOAT16_VALUE(   915.00), SIMDE_FLOAT16_VALUE(  -632.50),

--- a/test/arm/neon/cagt.c
+++ b/test/arm/neon/cagt.c
@@ -7,8 +7,8 @@ static int
 test_simde_vcagth_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
-    simde_float16 b;
+    simde_float16_t a;
+    simde_float16_t b;
     uint16_t r;
   } test_vec[] = {
     { SIMDE_FLOAT16_VALUE(  -774.00),
@@ -199,8 +199,8 @@ static int
 test_simde_vcagt_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
     uint16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   930.50), SIMDE_FLOAT16_VALUE(  -703.50), SIMDE_FLOAT16_VALUE(  -125.12), SIMDE_FLOAT16_VALUE(   783.00) },
@@ -346,8 +346,8 @@ static int
 test_simde_vcagtq_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
     uint16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   131.50), SIMDE_FLOAT16_VALUE(  -289.00), SIMDE_FLOAT16_VALUE(  -100.88), SIMDE_FLOAT16_VALUE(  -881.00),

--- a/test/arm/neon/cale.c
+++ b/test/arm/neon/cale.c
@@ -199,8 +199,8 @@ static int
 test_simde_vcale_f16 (SIMDE_MUNIT_TEST_ARGS) {
   #if 1
     struct {
-      simde_float16 b[4];
-      simde_float16 a[4];
+      simde_float16_t b[4];
+      simde_float16_t a[4];
       uint16_t r[4];
     } test_vec[] = {
       { { SIMDE_FLOAT16_VALUE(   506.50), SIMDE_FLOAT16_VALUE(   580.50), SIMDE_FLOAT16_VALUE(   209.88), SIMDE_FLOAT16_VALUE(  -273.25) },
@@ -345,8 +345,8 @@ static int
 test_simde_vcaleq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   #if 1
     struct {
-      simde_float16 b[8];
-      simde_float16 a[8];
+      simde_float16_t b[8];
+      simde_float16_t a[8];
       uint16_t r[8];
     } test_vec[] = {
       { { SIMDE_FLOAT16_VALUE(   476.50), SIMDE_FLOAT16_VALUE(   975.50), SIMDE_FLOAT16_VALUE(   915.00), SIMDE_FLOAT16_VALUE(  -632.50),

--- a/test/arm/neon/calt.c
+++ b/test/arm/neon/calt.c
@@ -7,8 +7,8 @@ static int
 test_simde_vcalth_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 b;
-    simde_float16 a;
+    simde_float16_t b;
+    simde_float16_t a;
     uint16_t r;
   } test_vec[] = {
     { SIMDE_FLOAT16_VALUE(  -774.00),
@@ -199,8 +199,8 @@ static int
 test_simde_vcalt_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 b[4];
-    simde_float16 a[4];
+    simde_float16_t b[4];
+    simde_float16_t a[4];
     uint16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   930.50), SIMDE_FLOAT16_VALUE(  -703.50), SIMDE_FLOAT16_VALUE(  -125.12), SIMDE_FLOAT16_VALUE(   783.00) },
@@ -346,8 +346,8 @@ static int
 test_simde_vcaltq_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 b[8];
-    simde_float16 a[8];
+    simde_float16_t b[8];
+    simde_float16_t a[8];
     uint16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   131.50), SIMDE_FLOAT16_VALUE(  -289.00), SIMDE_FLOAT16_VALUE(  -100.88), SIMDE_FLOAT16_VALUE(  -881.00),

--- a/test/arm/neon/ceq.c
+++ b/test/arm/neon/ceq.c
@@ -255,8 +255,8 @@ static int
 test_simde_vceq_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
     uint16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(  -304.25), SIMDE_FLOAT16_VALUE(  -310.25), SIMDE_FLOAT16_VALUE(  -816.50), SIMDE_FLOAT16_VALUE(  -947.50) },
@@ -297,7 +297,7 @@ test_simde_vceq_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #else
   fputc('\n', stdout);
   for (int i = 0 ; i < 8 ; i++) {
-    simde_float16 a_[4], b_[4];
+    simde_float16_t a_[4], b_[4];
     simde_test_codegen_random_vf16(sizeof(a_) / sizeof(a_[0]), a_, -1000.0, 1000.0);
     simde_test_codegen_random_vf16(sizeof(b_) / sizeof(b_[0]), b_, -1000.0, 1000.0);
     for (size_t j = 0 ; j < (sizeof(a_) / sizeof(a_[0])) ; j++) {
@@ -956,8 +956,8 @@ static int
 test_simde_vceqq_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
     uint16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(  -258.75), SIMDE_FLOAT16_VALUE(   657.50), SIMDE_FLOAT16_VALUE(  -817.50), SIMDE_FLOAT16_VALUE(   764.00),
@@ -1013,7 +1013,7 @@ test_simde_vceqq_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #else
   fputc('\n', stdout);
   for (int i = 0 ; i < 8 ; i++) {
-    simde_float16 a_[8], b_[8];
+    simde_float16_t a_[8], b_[8];
     simde_test_codegen_random_vf16(sizeof(a_) / sizeof(a_[0]), a_, -1000.0, 1000.0);
     simde_test_codegen_random_vf16(sizeof(b_) / sizeof(b_[0]), b_, -1000.0, 1000.0);
     for (size_t j = 0 ; j < (sizeof(a_) / sizeof(a_[0])) ; j++) {

--- a/test/arm/neon/ceqz.c
+++ b/test/arm/neon/ceqz.c
@@ -8,7 +8,7 @@ static int
 test_simde_vceqz_f16 (SIMDE_MUNIT_TEST_ARGS) {
   #if 1
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
     uint16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   288.00), SIMDE_FLOAT16_VALUE(   217.88), SIMDE_FLOAT16_VALUE(   992.00), SIMDE_FLOAT16_VALUE(  -163.88) },
@@ -391,7 +391,7 @@ static int
 test_simde_vceqzq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   #if 1
     struct {
-      simde_float16 a[8];
+      simde_float16_t a[8];
       uint16_t r[8];
     } test_vec[] = {
       { { SIMDE_FLOAT16_VALUE(   732.00), SIMDE_FLOAT16_VALUE(  -455.50), SIMDE_FLOAT16_VALUE(   260.75), SIMDE_FLOAT16_VALUE(   765.00),

--- a/test/arm/neon/cge.c
+++ b/test/arm/neon/cge.c
@@ -13,8 +13,8 @@ static int
 test_simde_vcge_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
     uint16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(  -632.50), SIMDE_FLOAT16_VALUE(   581.50), SIMDE_FLOAT16_VALUE(  -412.25), SIMDE_FLOAT16_VALUE(  -375.00) },
@@ -750,8 +750,8 @@ static int
 test_simde_vcgeq_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
     uint16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   489.75), SIMDE_FLOAT16_VALUE(  -920.50), SIMDE_FLOAT16_VALUE(   574.50), SIMDE_FLOAT16_VALUE(  -427.25),

--- a/test/arm/neon/cgez.c
+++ b/test/arm/neon/cgez.c
@@ -13,7 +13,7 @@ static int
 test_simde_vcgez_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
     uint16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE( -29.138), SIMDE_FLOAT16_VALUE( -21.302),  SIMDE_FLOAT16_VALUE( 9.731),  SIMDE_FLOAT16_VALUE( 7.200) },
@@ -384,7 +384,7 @@ static int
 test_simde_vcgezq_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
     uint16_t r[8];
   } test_vec[] = {
     { {  SIMDE_FLOAT16_VALUE( 4.672), SIMDE_FLOAT16_VALUE( - 4.393), SIMDE_FLOAT16_VALUE( - 2.459),  SIMDE_FLOAT16_VALUE(17.741),

--- a/test/arm/neon/cgt.c
+++ b/test/arm/neon/cgt.c
@@ -12,8 +12,8 @@
 static int
 test_simde_vcgt_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
     uint16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   -49.28), SIMDE_FLOAT16_VALUE(  -109.00), SIMDE_FLOAT16_VALUE(  -626.50), SIMDE_FLOAT16_VALUE(  -567.00) },
@@ -720,8 +720,8 @@ test_simde_vcgt_u64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vcgtq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
     uint16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(  -259.46), SIMDE_FLOAT16_VALUE(  -774.65), SIMDE_FLOAT16_VALUE(   628.16), SIMDE_FLOAT16_VALUE(  -992.75),

--- a/test/arm/neon/cgtz.c
+++ b/test/arm/neon/cgtz.c
@@ -13,7 +13,7 @@ static int
 test_simde_vcgtz_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
     uint16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE( - 9.473), SIMDE_FLOAT16_VALUE( -14.640), SIMDE_FLOAT16_VALUE( - 7.967), SIMDE_FLOAT16_VALUE( -23.200) },
@@ -384,7 +384,7 @@ static int
 test_simde_vcgtzq_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
     uint16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE( - 6.928),  SIMDE_FLOAT16_VALUE(11.681),  SIMDE_FLOAT16_VALUE( 8.633), SIMDE_FLOAT16_VALUE( - 5.431),

--- a/test/arm/neon/cle.c
+++ b/test/arm/neon/cle.c
@@ -13,8 +13,8 @@ static int
 test_simde_vcle_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
     uint16_t r[4];
   } test_vec[] = {
     { {  SIMDE_FLOAT16_VALUE( 8.447), SIMDE_FLOAT16_VALUE( - 8.659), SIMDE_FLOAT16_VALUE( - 2.615),  SIMDE_FLOAT16_VALUE(11.602) },
@@ -742,8 +742,8 @@ static int
 test_simde_vcleq_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
     uint16_t r[8];
   } test_vec[] = {
     { {  SIMDE_FLOAT16_VALUE( 6.052), SIMDE_FLOAT16_VALUE( -21.631), SIMDE_FLOAT16_VALUE( -16.927),  SIMDE_FLOAT16_VALUE(20.755),

--- a/test/arm/neon/clez.c
+++ b/test/arm/neon/clez.c
@@ -12,7 +12,7 @@
 static int
 test_simde_vclez_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
     uint16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   259.46), SIMDE_FLOAT16_VALUE(   774.65), SIMDE_FLOAT16_VALUE(   628.16), SIMDE_FLOAT16_VALUE(   707.60)},
@@ -362,7 +362,7 @@ test_simde_vclez_s64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vclezq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
     uint16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   259.46), SIMDE_FLOAT16_VALUE(   774.65), SIMDE_FLOAT16_VALUE(   628.16), SIMDE_FLOAT16_VALUE(   707.60),

--- a/test/arm/neon/clt.c
+++ b/test/arm/neon/clt.c
@@ -12,8 +12,8 @@
 static int
 test_simde_vclt_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
     uint16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(  -259.46), SIMDE_FLOAT16_VALUE(  -774.65), SIMDE_FLOAT16_VALUE(   628.16), SIMDE_FLOAT16_VALUE(  -707.60) },
@@ -714,8 +714,8 @@ test_simde_vclt_u64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vcltq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
     uint16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(  -259.46), SIMDE_FLOAT16_VALUE(  -774.65), SIMDE_FLOAT16_VALUE(   628.16), SIMDE_FLOAT16_VALUE(  -707.60),

--- a/test/arm/neon/cltz.c
+++ b/test/arm/neon/cltz.c
@@ -8,7 +8,7 @@ static int
 test_simde_vcltz_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
     uint16_t r[4];
   } test_vec[] = {
     { {  SIMDE_FLOAT16_VALUE( 9.414), SIMDE_FLOAT16_VALUE( -22.697), SIMDE_FLOAT16_VALUE( - 2.044),  SIMDE_FLOAT16_VALUE(10.309) },
@@ -337,7 +337,7 @@ static int
 test_simde_vcltzq_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
     uint16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE( - 1.527), SIMDE_FLOAT16_VALUE( - 7.156),  SIMDE_FLOAT16_VALUE( 0.644),  SIMDE_FLOAT16_VALUE( 5.397),

--- a/test/arm/neon/combine.c
+++ b/test/arm/neon/combine.c
@@ -6,9 +6,9 @@
 static int
 test_simde_vcombine_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 r[8];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   -49.28), SIMDE_FLOAT16_VALUE(  -109.00), SIMDE_FLOAT16_VALUE(  -626.50), SIMDE_FLOAT16_VALUE(  -567.00) },
       { SIMDE_FLOAT16_VALUE(  -178.88), SIMDE_FLOAT16_VALUE(    10.22), SIMDE_FLOAT16_VALUE(   976.50), SIMDE_FLOAT16_VALUE(   -31.19) },

--- a/test/arm/neon/cvt.c
+++ b/test/arm/neon/cvt.c
@@ -7,7 +7,7 @@ static int
 test_simde_vcvth_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     int16_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -66,7 +66,7 @@ static int
 test_simde_vcvth_s32_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     int32_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -125,7 +125,7 @@ static int
 test_simde_vcvth_s64_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     int64_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -182,7 +182,7 @@ static int
 test_simde_vcvth_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     uint16_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -233,7 +233,7 @@ static int
 test_simde_vcvth_u32_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     uint32_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -284,7 +284,7 @@ static int
 test_simde_vcvth_u64_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     uint64_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -338,7 +338,7 @@ test_simde_vcvth_f16_s32 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
     int32_t a;
-    simde_float16 r;
+    simde_float16_t r;
   } test_vec[] = {
     { -INT32_C(  1589103087),
           SIMDE_NINFINITYHF },
@@ -359,7 +359,7 @@ test_simde_vcvth_f16_s32 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 r = simde_vcvth_f16_s32(test_vec[i].a);
+    simde_float16_t r = simde_vcvth_f16_s32(test_vec[i].a);
 
     simde_assert_equal_f16(r, test_vec[i].r, 1);
   }
@@ -369,7 +369,7 @@ test_simde_vcvth_f16_s32 (SIMDE_MUNIT_TEST_ARGS) {
   fputc('\n', stdout);
   for (int i = 0 ; i < 8 ; i++) {
     int32_t a = simde_test_codegen_random_i32();
-    simde_float16 r = simde_vcvth_f16_s32(a);
+    simde_float16_t r = simde_vcvth_f16_s32(a);
 
     simde_test_codegen_write_i32(2, a, SIMDE_TEST_VEC_POS_FIRST);
     simde_test_codegen_write_f16(2, r, SIMDE_TEST_VEC_POS_LAST);
@@ -383,7 +383,7 @@ test_simde_vcvth_f16_s64 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
     int64_t a;
-    simde_float16 r;
+    simde_float16_t r;
   } test_vec[] = {
     {  INT64_C( 7162937251746498287),
            SIMDE_INFINITYHF },
@@ -404,7 +404,7 @@ test_simde_vcvth_f16_s64 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 r = simde_vcvth_f16_s64(test_vec[i].a);
+    simde_float16_t r = simde_vcvth_f16_s64(test_vec[i].a);
 
     simde_assert_equal_f16(r, test_vec[i].r, 1);
   }
@@ -414,7 +414,7 @@ test_simde_vcvth_f16_s64 (SIMDE_MUNIT_TEST_ARGS) {
   fputc('\n', stdout);
   for (int i = 0 ; i < 8 ; i++) {
     int64_t a = simde_test_codegen_random_i64();
-    simde_float16 r = simde_vcvth_f16_s64(a);
+    simde_float16_t r = simde_vcvth_f16_s64(a);
 
     simde_test_codegen_write_i64(2, a, SIMDE_TEST_VEC_POS_FIRST);
     simde_test_codegen_write_f16(2, r, SIMDE_TEST_VEC_POS_LAST);
@@ -428,7 +428,7 @@ test_simde_vcvth_f16_u32 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
     uint32_t a;
-    simde_float16 r;
+    simde_float16_t r;
   } test_vec[] = {
     { UINT32_C( 320056621),
            SIMDE_INFINITYHF },
@@ -449,7 +449,7 @@ test_simde_vcvth_f16_u32 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 r = simde_vcvth_f16_u32(test_vec[i].a);
+    simde_float16_t r = simde_vcvth_f16_u32(test_vec[i].a);
 
     simde_assert_equal_f16(r, test_vec[i].r, 1);
   }
@@ -459,7 +459,7 @@ test_simde_vcvth_f16_u32 (SIMDE_MUNIT_TEST_ARGS) {
   fputc('\n', stdout);
   for (int i = 0 ; i < 8 ; i++) {
     uint32_t a = simde_test_codegen_random_u32();
-    simde_float16 r = simde_vcvth_f16_u32(a);
+    simde_float16_t r = simde_vcvth_f16_u32(a);
 
     simde_test_codegen_write_u32(2, a, SIMDE_TEST_VEC_POS_FIRST);
     simde_test_codegen_write_f16(2, r, SIMDE_TEST_VEC_POS_LAST);
@@ -473,7 +473,7 @@ test_simde_vcvth_f16_u64 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
     uint64_t a;
-    simde_float16 r;
+    simde_float16_t r;
   } test_vec[] = {
     { UINT64_C(17434679020164388305),
            SIMDE_INFINITYHF },
@@ -494,7 +494,7 @@ test_simde_vcvth_f16_u64 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 r = simde_vcvth_f16_u64(test_vec[i].a);
+    simde_float16_t r = simde_vcvth_f16_u64(test_vec[i].a);
 
     simde_assert_equal_f16(r, test_vec[i].r, 1);
   }
@@ -504,7 +504,7 @@ test_simde_vcvth_f16_u64 (SIMDE_MUNIT_TEST_ARGS) {
   fputc('\n', stdout);
   for (int i = 0 ; i < 8 ; i++) {
     uint64_t a = simde_test_codegen_random_u64();
-    simde_float16 r = simde_vcvth_f16_u64(a);
+    simde_float16_t r = simde_vcvth_f16_u64(a);
 
     simde_test_codegen_write_u64(2, a, SIMDE_TEST_VEC_POS_FIRST);
     simde_test_codegen_write_f16(2, r, SIMDE_TEST_VEC_POS_LAST);
@@ -733,7 +733,7 @@ static int
 test_simde_vcvt_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
     int16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(  -567.00), SIMDE_FLOAT16_VALUE(   429.00), SIMDE_FLOAT16_VALUE(   629.50), SIMDE_FLOAT16_VALUE(  -509.25) },
@@ -886,7 +886,7 @@ static int
 test_simde_vcvt_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
     uint16_t r[4];
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -1047,7 +1047,7 @@ static int
 test_simde_vcvtq_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
     int16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   309.00), SIMDE_FLOAT16_VALUE(   886.50), SIMDE_FLOAT16_VALUE(  -319.25), SIMDE_FLOAT16_VALUE(   953.50),
@@ -1198,7 +1198,7 @@ static int
 test_simde_vcvtq_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
     uint16_t r[8];
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -1363,7 +1363,7 @@ test_simde_vcvt_f16_s16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
     int16_t a[4];
-    simde_float16 r[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { -INT16_C( 31359), -INT16_C(  6060), -INT16_C(  9227),  INT16_C(  4133) },
       { SIMDE_FLOAT16_VALUE(-31360.00), SIMDE_FLOAT16_VALUE( -6060.00), SIMDE_FLOAT16_VALUE( -9224.00), SIMDE_FLOAT16_VALUE(  4132.00) } },
@@ -1501,7 +1501,7 @@ test_simde_vcvt_f16_u16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
     uint16_t a[4];
-    simde_float16 r[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { UINT16_C(62438), UINT16_C(34514), UINT16_C(11502), UINT16_C(61024) },
       { SIMDE_FLOAT16_VALUE( 62432.00), SIMDE_FLOAT16_VALUE( 34528.00), SIMDE_FLOAT16_VALUE( 11504.00), SIMDE_FLOAT16_VALUE( 61024.00) } },
@@ -1639,7 +1639,7 @@ test_simde_vcvtq_f16_s16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
     int16_t a[8];
-    simde_float16 r[8];
+    simde_float16_t r[8];
   } test_vec[] = {
      { {  INT16_C( 30695),  INT16_C(  2044), -INT16_C( 17659), -INT16_C( 13466), -INT16_C(  7782), -INT16_C( 26595),  INT16_C( 28844),  INT16_C(  8813) },
       { SIMDE_FLOAT16_VALUE( 30688.00), SIMDE_FLOAT16_VALUE(  2044.00), SIMDE_FLOAT16_VALUE(-17664.00), SIMDE_FLOAT16_VALUE(-13464.00),
@@ -1785,7 +1785,7 @@ test_simde_vcvtq_f16_u16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
     uint16_t a[8];
-    simde_float16 r[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { { UINT16_C(31719), UINT16_C(40615), UINT16_C(25989), UINT16_C(34272), UINT16_C(12352), UINT16_C(55680), UINT16_C(60433), UINT16_C(10783) },
       { SIMDE_FLOAT16_VALUE( 31712.00), SIMDE_FLOAT16_VALUE( 40608.00), SIMDE_FLOAT16_VALUE( 25984.00), SIMDE_FLOAT16_VALUE( 34272.00),
@@ -1931,7 +1931,7 @@ test_simde_vcvt_f16_f32 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
     simde_float32 a[4];
-    simde_float16 r[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT32_C(  -746.01), SIMDE_FLOAT32_C(    46.71), SIMDE_FLOAT32_C(   209.49), SIMDE_FLOAT32_C(  -407.21) },
       { SIMDE_FLOAT16_VALUE(  -746.00), SIMDE_FLOAT16_VALUE(    46.72), SIMDE_FLOAT16_VALUE(   209.50), SIMDE_FLOAT16_VALUE(  -407.25) } },
@@ -2066,7 +2066,7 @@ static int
 test_simde_vcvtah_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     int16_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -2100,7 +2100,7 @@ test_simde_vcvtah_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     int16_t r = simde_vcvtah_s16_f16(a);
 
     simde_assert_equal_i16(r, test_vec[i].r);
@@ -2125,7 +2125,7 @@ static int
 test_simde_vcvtah_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     uint16_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -2151,7 +2151,7 @@ test_simde_vcvtah_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     uint16_t r = simde_vcvtah_u16_f16(a);
 
     simde_assert_equal_u16(r, test_vec[i].r);
@@ -2176,7 +2176,7 @@ static int
 test_simde_vcvtah_s32_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     int32_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -2212,7 +2212,7 @@ test_simde_vcvtah_s32_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     int32_t r = simde_vcvtah_s32_f16(a);
 
     simde_assert_equal_i32(r, test_vec[i].r);
@@ -2237,7 +2237,7 @@ static int
 test_simde_vcvtah_u32_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     uint32_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -2261,7 +2261,7 @@ test_simde_vcvtah_u32_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     uint32_t r = simde_vcvtah_u32_f16(a);
 
     simde_assert_equal_u32(r, test_vec[i].r);
@@ -2286,7 +2286,7 @@ static int
 test_simde_vcvtah_s64_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     int64_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -2318,7 +2318,7 @@ test_simde_vcvtah_s64_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     int64_t r = simde_vcvtah_s64_f16(a);
 
     simde_assert_equal_i64(r, test_vec[i].r);
@@ -2343,7 +2343,7 @@ static int
 test_simde_vcvtah_u64_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     uint64_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -2365,7 +2365,7 @@ test_simde_vcvtah_u64_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     uint64_t r = simde_vcvtah_u64_f16(a);
 
     simde_assert_equal_u64(r, test_vec[i].r);
@@ -2623,7 +2623,7 @@ static int
 test_simde_vcvta_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
     int16_t r[4];
   } test_vec[] = {
     { {  SIMDE_FLOAT16_VALUE(   5.484), SIMDE_FLOAT16_VALUE( -   6.295), SIMDE_FLOAT16_VALUE( -   5.132),  SIMDE_FLOAT16_VALUE(  12.566) },
@@ -2670,7 +2670,7 @@ static int
 test_simde_vcvta_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
     uint16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(    91.88), SIMDE_FLOAT16_VALUE(    32.12), SIMDE_FLOAT16_VALUE(    15.08), SIMDE_FLOAT16_VALUE(    33.19) },
@@ -2921,7 +2921,7 @@ static int
 test_simde_vcvtaq_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
     int16_t r[8];
   } test_vec[] = {
     { {  SIMDE_FLOAT16_VALUE(  26.678),  SIMDE_FLOAT16_VALUE(  11.961), SIMDE_FLOAT16_VALUE( -   5.477),  SIMDE_FLOAT16_VALUE(   2.192),
@@ -2983,7 +2983,7 @@ static int
 test_simde_vcvtaq_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
     uint16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(    34.44), SIMDE_FLOAT16_VALUE(    55.34), SIMDE_FLOAT16_VALUE(    18.20), SIMDE_FLOAT16_VALUE(    10.84),
@@ -3237,9 +3237,9 @@ static int
 test_simde_vcvt_high_f16_f32 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 buf[4];
+    simde_float16_t buf[4];
     simde_float32 a[4];
-    simde_float16 r[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE( -  24.372),  SIMDE_FLOAT16_VALUE(  23.118), SIMDE_FLOAT16_VALUE( -  23.874), SIMDE_FLOAT16_VALUE( -  17.046) },
       { -SIMDE_FLOAT32_C(7209.161), -SIMDE_FLOAT32_C(3427.483),  SIMDE_FLOAT32_C(4040.883), -SIMDE_FLOAT32_C(2098.786) },
@@ -3363,7 +3363,7 @@ static int
 test_simde_vcvt_high_f32_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
     simde_float32 r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE( - 3.844),  SIMDE_FLOAT16_VALUE(22.261),  SIMDE_FLOAT16_VALUE(21.633),  SIMDE_FLOAT16_VALUE(21.815),

--- a/test/arm/neon/cvt_n.c
+++ b/test/arm/neon/cvt_n.c
@@ -8,7 +8,7 @@ static int
 test_simde_vcvth_n_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[1];
+    simde_float16_t a[1];
     int16_t r3[1];
     int16_t r6[1];
     int16_t r10[1];
@@ -111,7 +111,7 @@ static int
 test_simde_vcvth_n_s32_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     int32_t r3;
     int32_t r6;
     int32_t r10;
@@ -213,7 +213,7 @@ static int
 test_simde_vcvth_n_s64_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     int64_t r3;
     int64_t r6;
     int64_t r10;
@@ -315,7 +315,7 @@ static int
 test_simde_vcvth_n_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[1];
+    simde_float16_t a[1];
     uint16_t r3[1];
     uint16_t r6[1];
     uint16_t r10[1];
@@ -376,7 +376,7 @@ static int
 test_simde_vcvth_n_u32_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     uint32_t r3;
     uint32_t r6;
     uint32_t r10;
@@ -466,7 +466,7 @@ static int
 test_simde_vcvth_n_u64_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     uint64_t r3;
     uint64_t r6;
     uint64_t r10;
@@ -1757,7 +1757,7 @@ static int
 test_simde_vcvt_n_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
     int16_t r3[4];
     int16_t r6[4];
     int16_t r10[4];
@@ -1953,7 +1953,7 @@ static int
 test_simde_vcvt_n_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
     uint16_t r3[4];
     uint16_t r6[4];
     uint16_t r10[4];
@@ -2149,7 +2149,7 @@ static int
 test_simde_vcvtq_n_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
     int16_t r3[8];
     int16_t r6[8];
     int16_t r10[8];
@@ -2338,7 +2338,7 @@ static int
 test_simde_vcvtq_n_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
     uint16_t r3[8];
     uint16_t r6[8];
     uint16_t r10[8];

--- a/test/arm/neon/cvtm.c
+++ b/test/arm/neon/cvtm.c
@@ -99,7 +99,7 @@ static int
 test_simde_vcvtmh_s64_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     int64_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -131,7 +131,7 @@ test_simde_vcvtmh_s64_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     int64_t r = simde_vcvtmh_s64_f16(a);
     simde_assert_equal_i64(r, test_vec[i].r);
   }
@@ -155,7 +155,7 @@ static int
 test_simde_vcvtmh_s32_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     int32_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -191,7 +191,7 @@ test_simde_vcvtmh_s32_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     int32_t r = simde_vcvtmh_s32_f16(a);
     simde_assert_equal_i32(r, test_vec[i].r);
   }
@@ -215,7 +215,7 @@ static int
 test_simde_vcvtmh_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     int16_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -251,7 +251,7 @@ test_simde_vcvtmh_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     int16_t r = simde_vcvtmh_s16_f16(a);
     simde_assert_equal_i16(r, test_vec[i].r);
   }
@@ -335,7 +335,7 @@ static int
 test_simde_vcvtmh_u64_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     uint64_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -357,7 +357,7 @@ test_simde_vcvtmh_u64_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     uint64_t r = simde_vcvtmh_u64_f16(a);
     simde_assert_equal_u64(r, test_vec[i].r);
   }
@@ -381,7 +381,7 @@ static int
 test_simde_vcvtmh_u32_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     uint32_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -409,7 +409,7 @@ test_simde_vcvtmh_u32_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     uint32_t r = simde_vcvtmh_u32_f16(a);
     simde_assert_equal_u32(r, test_vec[i].r);
   }
@@ -433,7 +433,7 @@ static int
 test_simde_vcvtmh_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     uint16_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -459,7 +459,7 @@ test_simde_vcvtmh_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     uint16_t r = simde_vcvtmh_u16_f16(a);
     simde_assert_equal_u16(r, test_vec[i].r);
   }
@@ -742,7 +742,7 @@ static int
 test_simde_vcvtmq_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
     int16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE( -     8.496),  SIMDE_FLOAT16_VALUE(    18.975), SIMDE_FLOAT16_VALUE( -     2.199), SIMDE_FLOAT16_VALUE( -    20.493),
@@ -804,7 +804,7 @@ static int
 test_simde_vcvtm_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
     int16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE( -    14.252), SIMDE_FLOAT16_VALUE( -     8.932), SIMDE_FLOAT16_VALUE( -    10.075),  SIMDE_FLOAT16_VALUE(     2.645) },
@@ -850,7 +850,7 @@ static int
 test_simde_vcvtmq_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
     uint16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   348.25), SIMDE_FLOAT16_VALUE(   859.50), SIMDE_FLOAT16_VALUE(   629.50), SIMDE_FLOAT16_VALUE(   746.50),
@@ -903,7 +903,7 @@ static int
 test_simde_vcvtm_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
     uint16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   340.75), SIMDE_FLOAT16_VALUE(   489.00), SIMDE_FLOAT16_VALUE(   996.00), SIMDE_FLOAT16_VALUE(   399.75) },

--- a/test/arm/neon/cvtn.c
+++ b/test/arm/neon/cvtn.c
@@ -96,7 +96,7 @@ test_simde_vcvtnq_s64_f64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vcvtnh_s64_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     int64_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -126,7 +126,7 @@ test_simde_vcvtnh_s64_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     int64_t r = simde_vcvtnh_s64_f16(a);
     simde_assert_equal_i64(r, test_vec[i].r);
   }
@@ -137,7 +137,7 @@ test_simde_vcvtnh_s64_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vcvtnh_s32_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     int32_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -167,7 +167,7 @@ test_simde_vcvtnh_s32_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     int32_t r = simde_vcvtnh_s32_f16(a);
     simde_assert_equal_i32(r, test_vec[i].r);
   }
@@ -178,7 +178,7 @@ test_simde_vcvtnh_s32_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vcvtnh_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     int16_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -208,7 +208,7 @@ test_simde_vcvtnh_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     int16_t r = simde_vcvtnh_s16_f16(a);
     simde_assert_equal_i16(r, test_vec[i].r);
   }
@@ -260,7 +260,7 @@ test_simde_vcvtns_s32_f32 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vcvtnh_u64_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     uint64_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -290,7 +290,7 @@ test_simde_vcvtnh_u64_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     uint64_t r = simde_vcvtnh_u64_f16(a);
     simde_assert_equal_u64(r, test_vec[i].r);
   }
@@ -301,7 +301,7 @@ test_simde_vcvtnh_u64_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vcvtnh_u32_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     uint32_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -331,7 +331,7 @@ test_simde_vcvtnh_u32_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     uint32_t r = simde_vcvtnh_u32_f16(a);
     simde_assert_equal_u32(r, test_vec[i].r);
   }
@@ -342,7 +342,7 @@ test_simde_vcvtnh_u32_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vcvtnh_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     uint16_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -372,7 +372,7 @@ test_simde_vcvtnh_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     uint16_t r = simde_vcvtnh_u16_f16(a);
     simde_assert_equal_u16(r, test_vec[i].r);
   }
@@ -631,7 +631,7 @@ test_simde_vcvtnq_u64_f64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vcvtnq_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
     int16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(8.5), SIMDE_FLOAT16_VALUE(-2.4), SIMDE_FLOAT16_VALUE(6.5), SIMDE_FLOAT16_VALUE(3.3), SIMDE_FLOAT16_VALUE(-8.9), SIMDE_FLOAT16_VALUE(4.2), SIMDE_FLOAT16_VALUE(11.5), SIMDE_FLOAT16_VALUE(10.2) },
@@ -658,7 +658,7 @@ test_simde_vcvtnq_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vcvtn_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
     int16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(8.5), SIMDE_FLOAT16_VALUE(-2.4), SIMDE_FLOAT16_VALUE(6.5), SIMDE_FLOAT16_VALUE(3.3) },
@@ -695,7 +695,7 @@ test_simde_vcvtn_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vcvtnq_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
     uint16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(4.9), SIMDE_FLOAT16_VALUE(0.5), SIMDE_FLOAT16_VALUE(12.8), SIMDE_FLOAT16_VALUE(11.3), SIMDE_FLOAT16_VALUE(13.5), SIMDE_FLOAT16_VALUE(10.0), SIMDE_FLOAT16_VALUE(13.6), SIMDE_FLOAT16_VALUE(11.1) },
@@ -722,7 +722,7 @@ test_simde_vcvtnq_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vcvtn_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
     uint16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(4.9), SIMDE_FLOAT16_VALUE(0.5), SIMDE_FLOAT16_VALUE(12.8), SIMDE_FLOAT16_VALUE(11.3) },

--- a/test/arm/neon/cvtp.c
+++ b/test/arm/neon/cvtp.c
@@ -99,7 +99,7 @@ static int
 test_simde_vcvtph_s64_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     int64_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -131,7 +131,7 @@ test_simde_vcvtph_s64_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     int64_t r = simde_vcvtph_s64_f16(a);
     simde_assert_equal_i64(r, test_vec[i].r);
   }
@@ -155,7 +155,7 @@ static int
 test_simde_vcvtph_s32_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     int32_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -191,7 +191,7 @@ test_simde_vcvtph_s32_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     int32_t r = simde_vcvtph_s32_f16(a);
     simde_assert_equal_i32(r, test_vec[i].r);
   }
@@ -215,7 +215,7 @@ static int
 test_simde_vcvtph_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     int16_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -251,7 +251,7 @@ test_simde_vcvtph_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     int16_t r = simde_vcvtph_s16_f16(a);
     simde_assert_equal_i16(r, test_vec[i].r);
   }
@@ -335,7 +335,7 @@ static int
 test_simde_vcvtph_u64_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     uint64_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -357,7 +357,7 @@ test_simde_vcvtph_u64_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     uint64_t r = simde_vcvtph_u64_f16(a);
     simde_assert_equal_u64(r, test_vec[i].r);
   }
@@ -381,7 +381,7 @@ static int
 test_simde_vcvtph_u32_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     uint32_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -403,7 +403,7 @@ test_simde_vcvtph_u32_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     uint32_t r = simde_vcvtph_u32_f16(a);
     simde_assert_equal_u32(r, test_vec[i].r);
   }
@@ -427,7 +427,7 @@ static int
 test_simde_vcvtph_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a;
+    simde_float16_t a;
     uint16_t r;
   } test_vec[] = {
     #if !defined(SIMDE_FAST_CONVERSION_RANGE)
@@ -455,7 +455,7 @@ test_simde_vcvtph_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     uint16_t r = simde_vcvtph_u16_f16(a);
     simde_assert_equal_u16(r, test_vec[i].r);
   }
@@ -744,7 +744,7 @@ static int
 test_simde_vcvtpq_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
     int16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE( -    17.482),  SIMDE_FLOAT16_VALUE(    25.249), SIMDE_FLOAT16_VALUE( -    23.786),  SIMDE_FLOAT16_VALUE(    26.713),
@@ -806,7 +806,7 @@ static int
 test_simde_vcvtp_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
     int16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE( -    24.451), SIMDE_FLOAT16_VALUE( -    26.951),  SIMDE_FLOAT16_VALUE(     4.545), SIMDE_FLOAT16_VALUE( -    16.203) },
@@ -852,7 +852,7 @@ static int
 test_simde_vcvtpq_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
     uint16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(    14.36), SIMDE_FLOAT16_VALUE(    34.09), SIMDE_FLOAT16_VALUE(    69.00), SIMDE_FLOAT16_VALUE(     4.10),
@@ -906,7 +906,7 @@ static int
 test_simde_vcvtp_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
     uint16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(    92.38), SIMDE_FLOAT16_VALUE(    41.81), SIMDE_FLOAT16_VALUE(    12.00), SIMDE_FLOAT16_VALUE(    86.38) },

--- a/test/arm/neon/dup_lane.c
+++ b/test/arm/neon/dup_lane.c
@@ -10,9 +10,9 @@ SIMDE_DIAGNOSTIC_DISABLE_UNREACHABLE_
 static int
 test_simde_vdup_lane_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 vec[4];
+    simde_float16_t vec[4];
     int lane;
-    simde_float16 r[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(-7.6), SIMDE_FLOAT16_VALUE(11.4), SIMDE_FLOAT16_VALUE(10.7), SIMDE_FLOAT16_VALUE(-0.1) },
         INT8_C(2),
@@ -62,9 +62,9 @@ test_simde_vdup_lane_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vdupq_lane_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 vec[4];
+    simde_float16_t vec[4];
     int lane;
-    simde_float16 r[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(-3.4), SIMDE_FLOAT16_VALUE(6.4), SIMDE_FLOAT16_VALUE(-7.4), SIMDE_FLOAT16_VALUE(0.5) },
         INT8_C(0),

--- a/test/arm/neon/dup_n.c
+++ b/test/arm/neon/dup_n.c
@@ -7,8 +7,8 @@ static int
 test_simde_vdup_n_f16 (SIMDE_MUNIT_TEST_ARGS) {
   #if 1
     struct {
-      simde_float16 a;
-      simde_float16 r[4];
+      simde_float16_t a;
+      simde_float16_t r[4];
     } test_vec[] = {
       { SIMDE_FLOAT16_VALUE(  -930.50),
       { SIMDE_FLOAT16_VALUE(  -930.50), SIMDE_FLOAT16_VALUE(  -930.50), SIMDE_FLOAT16_VALUE(  -930.50), SIMDE_FLOAT16_VALUE(  -930.50) } },
@@ -29,7 +29,7 @@ test_simde_vdup_n_f16 (SIMDE_MUNIT_TEST_ARGS) {
     };
 
     for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-      simde_float16 a;
+      simde_float16_t a;
       simde_float16x4_t r;
 
       a = test_vec[i].a;
@@ -42,7 +42,7 @@ test_simde_vdup_n_f16 (SIMDE_MUNIT_TEST_ARGS) {
   #else
     fputc('\n', stdout);
     for (int i = 0 ; i < 8 ; i++) {
-      simde_float16 a = simde_test_codegen_random_f16(-1000.0f, 1000.0f);
+      simde_float16_t a = simde_test_codegen_random_f16(-1000.0f, 1000.0f);
       simde_float16x4_t r = simde_vdup_n_f16(a);
 
       simde_test_codegen_write_f16(2, a, SIMDE_TEST_VEC_POS_FIRST);
@@ -396,8 +396,8 @@ static int
 test_simde_vdupq_n_f16 (SIMDE_MUNIT_TEST_ARGS) {
   #if 1
     struct {
-      simde_float16 a;
-      simde_float16 r[8];
+      simde_float16_t a;
+      simde_float16_t r[8];
     } test_vec[] = {
       { SIMDE_FLOAT16_VALUE(   189.12),
       { SIMDE_FLOAT16_VALUE(   189.12), SIMDE_FLOAT16_VALUE(   189.12), SIMDE_FLOAT16_VALUE(   189.12), SIMDE_FLOAT16_VALUE(   189.12),
@@ -426,7 +426,7 @@ test_simde_vdupq_n_f16 (SIMDE_MUNIT_TEST_ARGS) {
     };
 
     for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-      simde_float16 a;
+      simde_float16_t a;
       simde_float16x8_t r;
 
       a = test_vec[i].a;
@@ -439,7 +439,7 @@ test_simde_vdupq_n_f16 (SIMDE_MUNIT_TEST_ARGS) {
   #else
     fputc('\n', stdout);
     for (int i = 0 ; i < 8 ; i++) {
-      simde_float16 a = simde_test_codegen_random_f16(-1000.0f, 1000.0f);
+      simde_float16_t a = simde_test_codegen_random_f16(-1000.0f, 1000.0f);
       simde_float16x8_t r = simde_vdupq_n_f16(a);
 
       simde_test_codegen_write_f16(2, a, SIMDE_TEST_VEC_POS_FIRST);

--- a/test/arm/neon/ext.c
+++ b/test/arm/neon/ext.c
@@ -9,10 +9,10 @@ SIMDE_DIAGNOSTIC_DISABLE_UNREACHABLE_
 static int
 test_simde_vext_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
     int n;
-    simde_float16 r[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(-13.7), SIMDE_FLOAT16_VALUE(-11.7), SIMDE_FLOAT16_VALUE(-14.2), SIMDE_FLOAT16_VALUE(-6.9) },
       { SIMDE_FLOAT16_VALUE(-1.5), SIMDE_FLOAT16_VALUE(-6.5), SIMDE_FLOAT16_VALUE(-12.9), SIMDE_FLOAT16_VALUE(7.6) },
@@ -753,10 +753,10 @@ test_simde_vext_u64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vextq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
     int n;
-    simde_float16 r[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   441.00), SIMDE_FLOAT16_VALUE(   861.50), SIMDE_FLOAT16_VALUE(    98.06), SIMDE_FLOAT16_VALUE(   896.00),
         SIMDE_FLOAT16_VALUE(  -918.50), SIMDE_FLOAT16_VALUE(  -717.00), SIMDE_FLOAT16_VALUE(  -823.00), SIMDE_FLOAT16_VALUE(  -581.00) },

--- a/test/arm/neon/fma.c
+++ b/test/arm/neon/fma.c
@@ -76,10 +76,10 @@ test_simde_vfma_f32 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vfmah_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a;
-    simde_float16 b;
-    simde_float16 c;
-    simde_float16 r;
+    simde_float16_t a;
+    simde_float16_t b;
+    simde_float16_t c;
+    simde_float16_t r;
   } test_vec[] = {
     { SIMDE_FLOAT16_VALUE(31.59),
       SIMDE_FLOAT16_VALUE(4.50),
@@ -134,10 +134,10 @@ test_simde_vfmah_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vfma_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 c[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t c[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(31.59), SIMDE_FLOAT16_VALUE(4.80), SIMDE_FLOAT16_VALUE(4.80), SIMDE_FLOAT16_VALUE(25.00) },
       { SIMDE_FLOAT16_VALUE(4.50), SIMDE_FLOAT16_VALUE(1.00), SIMDE_FLOAT16_VALUE(3.00), SIMDE_FLOAT16_VALUE(-2.20) } ,
@@ -195,10 +195,10 @@ test_simde_vfma_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vfmaq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 c[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t c[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(31.59), SIMDE_FLOAT16_VALUE(4.80), SIMDE_FLOAT16_VALUE(4.80), SIMDE_FLOAT16_VALUE(25.00), SIMDE_FLOAT16_VALUE(-8.30), SIMDE_FLOAT16_VALUE(23.00), SIMDE_FLOAT16_VALUE(-12.00), SIMDE_FLOAT16_VALUE(19.80) },
       { SIMDE_FLOAT16_VALUE(4.50), SIMDE_FLOAT16_VALUE(1.00), SIMDE_FLOAT16_VALUE(3.00), SIMDE_FLOAT16_VALUE(-2.20), SIMDE_FLOAT16_VALUE(0.60), SIMDE_FLOAT16_VALUE(-4.20), SIMDE_FLOAT16_VALUE(4.20), SIMDE_FLOAT16_VALUE(0.00) },

--- a/test/arm/neon/fma_n.c
+++ b/test/arm/neon/fma_n.c
@@ -6,10 +6,10 @@
 static int
 test_simde_vfma_n_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 c;
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t c;
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(3.1), SIMDE_FLOAT16_VALUE(0.5), SIMDE_FLOAT16_VALUE(-11.4), SIMDE_FLOAT16_VALUE(4.0) },
       { SIMDE_FLOAT16_VALUE(12.9), SIMDE_FLOAT16_VALUE(-2.2), SIMDE_FLOAT16_VALUE(6.4), SIMDE_FLOAT16_VALUE(-0.6) },
@@ -56,7 +56,7 @@ test_simde_vfma_n_f16 (SIMDE_MUNIT_TEST_ARGS) {
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
     simde_float16x4_t a = simde_vld1_f16(test_vec[i].a);
     simde_float16x4_t b = simde_vld1_f16(test_vec[i].b);
-    simde_float16 c = test_vec[i].c;
+    simde_float16_t c = test_vec[i].c;
     simde_float16x4_t r = simde_vfma_n_f16(a, b, c);
 
     simde_test_arm_neon_assert_equal_f16x4(r, simde_vld1_f16(test_vec[i].r), 1);
@@ -68,10 +68,10 @@ test_simde_vfma_n_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vfmaq_n_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 c;
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t c;
+    simde_float16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(-3.2), SIMDE_FLOAT16_VALUE(-1.5), SIMDE_FLOAT16_VALUE(-13.5), SIMDE_FLOAT16_VALUE(11.7),
         SIMDE_FLOAT16_VALUE(-0.3), SIMDE_FLOAT16_VALUE(-14.6), SIMDE_FLOAT16_VALUE(-13.6), SIMDE_FLOAT16_VALUE(-2.7) },
@@ -113,7 +113,7 @@ test_simde_vfmaq_n_f16 (SIMDE_MUNIT_TEST_ARGS) {
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
     simde_float16x8_t a = simde_vld1q_f16(test_vec[i].a);
     simde_float16x8_t b = simde_vld1q_f16(test_vec[i].b);
-    simde_float16 c = test_vec[i].c;
+    simde_float16_t c = test_vec[i].c;
     simde_float16x8_t r = simde_vfmaq_n_f16(a, b, c);
 
     simde_test_arm_neon_assert_equal_f16x8(r, simde_vld1q_f16(test_vec[i].r), 1);

--- a/test/arm/neon/fms.c
+++ b/test/arm/neon/fms.c
@@ -48,10 +48,10 @@ test_simde_vfms_f32 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vfmsh_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[1];
-    simde_float16 b[1];
-    simde_float16 c[1];
-    simde_float16 r[1];
+    simde_float16_t a[1];
+    simde_float16_t b[1];
+    simde_float16_t c[1];
+    simde_float16_t r[1];
   } test_vec[] = {
    { {  SIMDE_FLOAT16_VALUE(0.09) },
      {  SIMDE_FLOAT16_VALUE(6.34) },
@@ -86,10 +86,10 @@ test_simde_vfmsh_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vfms_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 c[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t c[4];
+    simde_float16_t r[4];
   } test_vec[] = {
    { {  SIMDE_FLOAT16_VALUE(-5.06), SIMDE_FLOAT16_VALUE(1.00), SIMDE_FLOAT16_VALUE(-5.98), SIMDE_FLOAT16_VALUE(-5.93) },
      {  SIMDE_FLOAT16_VALUE(7.00), SIMDE_FLOAT16_VALUE(-6.45), SIMDE_FLOAT16_VALUE(4.77), SIMDE_FLOAT16_VALUE(6.04) },
@@ -127,10 +127,10 @@ test_simde_vfms_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vfmsq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 c[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t c[8];
+    simde_float16_t r[8];
   } test_vec[] = {
    { {  SIMDE_FLOAT16_VALUE(-8.08), SIMDE_FLOAT16_VALUE(5.53), SIMDE_FLOAT16_VALUE(9.08), SIMDE_FLOAT16_VALUE(-8.83),
         SIMDE_FLOAT16_VALUE(-8.48), SIMDE_FLOAT16_VALUE(-0.88), SIMDE_FLOAT16_VALUE(0.79), SIMDE_FLOAT16_VALUE(2.97) },

--- a/test/arm/neon/fms_n.c
+++ b/test/arm/neon/fms_n.c
@@ -6,10 +6,10 @@
 static int
 test_simde_vfms_n_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 c;
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t c;
+    simde_float16_t r[4];
   } test_vec[] = {
    { {  SIMDE_FLOAT16_VALUE(-4.51), SIMDE_FLOAT16_VALUE(-3.15), SIMDE_FLOAT16_VALUE(4.65), SIMDE_FLOAT16_VALUE(-2.79) },
      {  SIMDE_FLOAT16_VALUE(1.88), SIMDE_FLOAT16_VALUE(2.18), SIMDE_FLOAT16_VALUE(-5.14), SIMDE_FLOAT16_VALUE(6.04) },
@@ -32,7 +32,7 @@ test_simde_vfms_n_f16 (SIMDE_MUNIT_TEST_ARGS) {
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
     simde_float16x4_t a = simde_vld1_f16(test_vec[i].a);
     simde_float16x4_t b = simde_vld1_f16(test_vec[i].b);
-    simde_float16 c = test_vec[i].c;
+    simde_float16_t c = test_vec[i].c;
     simde_float16x4_t r = simde_vfms_n_f16(a, b, c);
 
     simde_test_arm_neon_assert_equal_f16x4(r, simde_vld1_f16(test_vec[i].r), 1);
@@ -44,10 +44,10 @@ test_simde_vfms_n_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vfmsq_n_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 c;
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t c;
+    simde_float16_t r[8];
   } test_vec[] = {
    { {  SIMDE_FLOAT16_VALUE(-0.26), SIMDE_FLOAT16_VALUE(1.88), SIMDE_FLOAT16_VALUE(-3.00), SIMDE_FLOAT16_VALUE(-4.73),
         SIMDE_FLOAT16_VALUE(-5.26), SIMDE_FLOAT16_VALUE(3.81), SIMDE_FLOAT16_VALUE(5.67), SIMDE_FLOAT16_VALUE(8.36) },
@@ -89,7 +89,7 @@ test_simde_vfmsq_n_f16 (SIMDE_MUNIT_TEST_ARGS) {
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
     simde_float16x8_t a = simde_vld1q_f16(test_vec[i].a);
     simde_float16x8_t b = simde_vld1q_f16(test_vec[i].b);
-    simde_float16 c = test_vec[i].c;
+    simde_float16_t c = test_vec[i].c;
     simde_float16x8_t r = simde_vfmsq_n_f16(a, b, c);
 
     simde_test_arm_neon_assert_equal_f16x8(r, simde_vld1q_f16(test_vec[i].r), 1);

--- a/test/arm/neon/get_high.c
+++ b/test/arm/neon/get_high.c
@@ -6,8 +6,8 @@
 static int
 test_simde_vget_high_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 r[4];
+    simde_float16_t a[8];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   441.00), SIMDE_FLOAT16_VALUE(   861.50), SIMDE_FLOAT16_VALUE(    98.06), SIMDE_FLOAT16_VALUE(   896.00),
         SIMDE_FLOAT16_VALUE(  -918.50), SIMDE_FLOAT16_VALUE(  -717.00), SIMDE_FLOAT16_VALUE(  -823.00), SIMDE_FLOAT16_VALUE(  -581.00) },

--- a/test/arm/neon/get_lane.c
+++ b/test/arm/neon/get_lane.c
@@ -9,9 +9,9 @@ SIMDE_DIAGNOSTIC_DISABLE_UNREACHABLE_
 static int
 test_simde_vget_lane_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
     int b;
-    simde_float16 r;
+    simde_float16_t r;
   } test_vec[] = {
   { {SIMDE_FLOAT16_VALUE(-49.25), SIMDE_FLOAT16_VALUE(-109.00), SIMDE_FLOAT16_VALUE(-626.50), SIMDE_FLOAT16_VALUE(-567.00)},
        INT8_C(   0),
@@ -43,7 +43,7 @@ test_simde_vget_lane_f16 (SIMDE_MUNIT_TEST_ARGS) {
 
     simde_float16x4_t a = simde_vld1_f16(test_vec[i].a);
     int b = test_vec[i].b;
-    simde_float16 r;
+    simde_float16_t r;
     SIMDE_CONSTIFY_4_(simde_vget_lane_f16, r, (HEDLEY_UNREACHABLE(), SIMDE_FLOAT16_VALUE(0.0)), b, a);
 
     simde_assert_equal_f16(r, test_vec[i].r, 1);
@@ -480,9 +480,9 @@ test_simde_vget_lane_u64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vgetq_lane_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
     int b;
-    simde_float16 r;
+    simde_float16_t r;
   } test_vec[] = {
   { { SIMDE_FLOAT16_VALUE(   441.00), SIMDE_FLOAT16_VALUE(   861.50), SIMDE_FLOAT16_VALUE(    98.06), SIMDE_FLOAT16_VALUE(   896.00),
     SIMDE_FLOAT16_VALUE(  -918.50), SIMDE_FLOAT16_VALUE(  -717.00), SIMDE_FLOAT16_VALUE(  -823.00), SIMDE_FLOAT16_VALUE(  -581.00) },
@@ -522,7 +522,7 @@ test_simde_vgetq_lane_f16 (SIMDE_MUNIT_TEST_ARGS) {
 
     simde_float16x8_t a = simde_vld1q_f16(test_vec[i].a);
     int b = test_vec[i].b;
-    simde_float16 r;
+    simde_float16_t r;
     SIMDE_CONSTIFY_8_(simde_vgetq_lane_f16, r, (HEDLEY_UNREACHABLE(), SIMDE_FLOAT16_VALUE(0.0)), b, a);
 
     simde_assert_equal_f16(r, test_vec[i].r, 1);

--- a/test/arm/neon/get_low.c
+++ b/test/arm/neon/get_low.c
@@ -6,8 +6,8 @@
 static int
 test_simde_vget_low_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 r[4];
+    simde_float16_t a[8];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   441.00), SIMDE_FLOAT16_VALUE(   861.50), SIMDE_FLOAT16_VALUE(    98.06), SIMDE_FLOAT16_VALUE(   896.00),
         SIMDE_FLOAT16_VALUE(  -918.50), SIMDE_FLOAT16_VALUE(  -717.00), SIMDE_FLOAT16_VALUE(  -823.00), SIMDE_FLOAT16_VALUE(  -581.00) },

--- a/test/arm/neon/ld1_x2.c
+++ b/test/arm/neon/ld1_x2.c
@@ -9,8 +9,8 @@
 static int
 test_simde_vld1_f16_x2 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 buf[8];
-    simde_float16 expected[2][4];
+    simde_float16_t buf[8];
+    simde_float16_t expected[2][4];
   } test_vec[] = {
    { {  SIMDE_FLOAT16_VALUE(3.81), SIMDE_FLOAT16_VALUE(-2.59), SIMDE_FLOAT16_VALUE(-2.10), SIMDE_FLOAT16_VALUE(-4.19),
         SIMDE_FLOAT16_VALUE(-8.46), SIMDE_FLOAT16_VALUE(3.35), SIMDE_FLOAT16_VALUE(-0.60), SIMDE_FLOAT16_VALUE(-5.62) },

--- a/test/arm/neon/ld1_x3.c
+++ b/test/arm/neon/ld1_x3.c
@@ -9,8 +9,8 @@
 static int
 test_simde_vld1_f16_x3 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 buf[12];
-    simde_float16 expected[3][4];
+    simde_float16_t buf[12];
+    simde_float16_t expected[3][4];
   } test_vec[] = {
    { {  SIMDE_FLOAT16_VALUE(-5.79), SIMDE_FLOAT16_VALUE(4.80), SIMDE_FLOAT16_VALUE(9.66), SIMDE_FLOAT16_VALUE(-2.49),
         SIMDE_FLOAT16_VALUE(-3.48), SIMDE_FLOAT16_VALUE(2.38), SIMDE_FLOAT16_VALUE(-7.06), SIMDE_FLOAT16_VALUE(-9.89),

--- a/test/arm/neon/ld1_x4.c
+++ b/test/arm/neon/ld1_x4.c
@@ -9,8 +9,8 @@
 static int
 test_simde_vld1_f16_x4 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 buf[16];
-    simde_float16 expected[4][4];
+    simde_float16_t buf[16];
+    simde_float16_t expected[4][4];
   } test_vec[] = {
    { {  SIMDE_FLOAT16_VALUE(1.49), SIMDE_FLOAT16_VALUE(-9.73), SIMDE_FLOAT16_VALUE(7.36), SIMDE_FLOAT16_VALUE(3.11),
         SIMDE_FLOAT16_VALUE(7.22), SIMDE_FLOAT16_VALUE(-2.45), SIMDE_FLOAT16_VALUE(3.68), SIMDE_FLOAT16_VALUE(-1.35),

--- a/test/arm/neon/ld1q_x2.c
+++ b/test/arm/neon/ld1q_x2.c
@@ -9,8 +9,8 @@
 static int
 test_simde_vld1q_f16_x2 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 buf[16];
-    simde_float16 expected[2][8];
+    simde_float16_t buf[16];
+    simde_float16_t expected[2][8];
   } test_vec[] = {
    { {  SIMDE_FLOAT16_VALUE(8.77), SIMDE_FLOAT16_VALUE(-8.18), SIMDE_FLOAT16_VALUE(0.29), SIMDE_FLOAT16_VALUE(-5.13),
         SIMDE_FLOAT16_VALUE(-0.49), SIMDE_FLOAT16_VALUE(-5.46), SIMDE_FLOAT16_VALUE(-5.01), SIMDE_FLOAT16_VALUE(9.21),

--- a/test/arm/neon/ld1q_x3.c
+++ b/test/arm/neon/ld1q_x3.c
@@ -9,8 +9,8 @@
 static int
 test_simde_vld1q_f16_x3 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 buf[24];
-    simde_float16 expected[3][8];
+    simde_float16_t buf[24];
+    simde_float16_t expected[3][8];
   } test_vec[] = {
    { {  SIMDE_FLOAT16_VALUE(5.77), SIMDE_FLOAT16_VALUE(3.40), SIMDE_FLOAT16_VALUE(8.52), SIMDE_FLOAT16_VALUE(-8.12),
         SIMDE_FLOAT16_VALUE(9.75), SIMDE_FLOAT16_VALUE(4.58), SIMDE_FLOAT16_VALUE(-8.12), SIMDE_FLOAT16_VALUE(-0.21),

--- a/test/arm/neon/ld1q_x4.c
+++ b/test/arm/neon/ld1q_x4.c
@@ -9,8 +9,8 @@
 static int
 test_simde_vld1q_f16_x4 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 buf[32];
-    simde_float16 expected[4][8];
+    simde_float16_t buf[32];
+    simde_float16_t expected[4][8];
   } test_vec[] = {
    { {  SIMDE_FLOAT16_VALUE(0.77), SIMDE_FLOAT16_VALUE(-4.96), SIMDE_FLOAT16_VALUE(4.32), SIMDE_FLOAT16_VALUE(7.52),
         SIMDE_FLOAT16_VALUE(4.70), SIMDE_FLOAT16_VALUE(1.33), SIMDE_FLOAT16_VALUE(-9.47), SIMDE_FLOAT16_VALUE(7.32),

--- a/test/arm/neon/max.c
+++ b/test/arm/neon/max.c
@@ -6,9 +6,9 @@
 static int
 test_simde_vmax_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   441.00), SIMDE_FLOAT16_VALUE(   861.50), SIMDE_FLOAT16_VALUE(    98.06), SIMDE_FLOAT16_VALUE(   896.00) },
       { SIMDE_FLOAT16_VALUE(   684.00), SIMDE_FLOAT16_VALUE(   563.00), SIMDE_FLOAT16_VALUE(    15.31), SIMDE_FLOAT16_VALUE(  -786.50) },
@@ -541,9 +541,9 @@ test_simde_x_vmax_u64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vmaxq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   441.00), SIMDE_FLOAT16_VALUE(   861.50), SIMDE_FLOAT16_VALUE(    98.06), SIMDE_FLOAT16_VALUE(   896.00),
         SIMDE_FLOAT16_VALUE(  -918.50), SIMDE_FLOAT16_VALUE(  -717.00), SIMDE_FLOAT16_VALUE(  -823.00), SIMDE_FLOAT16_VALUE(  -581.00) },

--- a/test/arm/neon/min.c
+++ b/test/arm/neon/min.c
@@ -6,9 +6,9 @@
 static int
 test_simde_vmin_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(-7.60), SIMDE_FLOAT16_VALUE(5.20), SIMDE_FLOAT16_VALUE(7.20), SIMDE_FLOAT16_VALUE(-0.50) },
       { SIMDE_FLOAT16_VALUE(8.60), SIMDE_FLOAT16_VALUE(8.00), SIMDE_FLOAT16_VALUE(-9.00), SIMDE_FLOAT16_VALUE(2.40) },
@@ -544,9 +544,9 @@ test_simde_x_vmin_u64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vminq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(-2.70), SIMDE_FLOAT16_VALUE(-1.60), SIMDE_FLOAT16_VALUE(-8.90), SIMDE_FLOAT16_VALUE(-8.00), SIMDE_FLOAT16_VALUE(-8.60), SIMDE_FLOAT16_VALUE(5.20), SIMDE_FLOAT16_VALUE(9.80), SIMDE_FLOAT16_VALUE(-8.20) },
       { SIMDE_FLOAT16_VALUE(-9.40), SIMDE_FLOAT16_VALUE(-5.90), SIMDE_FLOAT16_VALUE(-0.20), SIMDE_FLOAT16_VALUE(-2.80), SIMDE_FLOAT16_VALUE(-7.30), SIMDE_FLOAT16_VALUE(7.50), SIMDE_FLOAT16_VALUE(7.20), SIMDE_FLOAT16_VALUE(8.30) },

--- a/test/arm/neon/mul.c
+++ b/test/arm/neon/mul.c
@@ -6,9 +6,9 @@
 static int
 test_simde_vmulh_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a;
-    simde_float16 b;
-    simde_float16 r;
+    simde_float16_t a;
+    simde_float16_t b;
+    simde_float16_t r;
   } test_vec[] = {
   { SIMDE_FLOAT16_VALUE( 147.875),
     SIMDE_FLOAT16_VALUE( 27.609375),
@@ -37,7 +37,7 @@ test_simde_vmulh_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 r = simde_vmulh_f16(test_vec[i].a, test_vec[i].b);
+    simde_float16_t r = simde_vmulh_f16(test_vec[i].a, test_vec[i].b);
 
     simde_assert_equal_f16(r, test_vec[i].r, 1);
   }
@@ -48,9 +48,9 @@ test_simde_vmulh_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vmul_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t r[4];
   } test_vec[] = {
   { { SIMDE_FLOAT16_VALUE( 147.875), SIMDE_FLOAT16_VALUE( 183.125),
       SIMDE_FLOAT16_VALUE( 250.125), SIMDE_FLOAT16_VALUE( 236.5), },
@@ -587,9 +587,9 @@ test_simde_x_vmul_u64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vmulq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t r[8];
   } test_vec[] = {
   { { SIMDE_FLOAT16_VALUE( 218.125), SIMDE_FLOAT16_VALUE( 147.75), SIMDE_FLOAT16_VALUE( 163.875), SIMDE_FLOAT16_VALUE( 3.16796875),
       SIMDE_FLOAT16_VALUE( 168.5), SIMDE_FLOAT16_VALUE( 4.4453125), SIMDE_FLOAT16_VALUE( 166.25), SIMDE_FLOAT16_VALUE( 95.0625), },

--- a/test/arm/neon/mul_lane.c
+++ b/test/arm/neon/mul_lane.c
@@ -10,10 +10,10 @@ SIMDE_DIAGNOSTIC_DISABLE_UNREACHABLE_
 static int
 test_simde_vmul_lane_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
     int lane;
-    simde_float16 r[4];
+    simde_float16_t r[4];
   } test_vec[] = {
    { {  SIMDE_FLOAT16_VALUE(-2.2), SIMDE_FLOAT16_VALUE(-6.4), SIMDE_FLOAT16_VALUE(-8.8), SIMDE_FLOAT16_VALUE(-3.0) },
      {  SIMDE_FLOAT16_VALUE(-6.1), SIMDE_FLOAT16_VALUE(-3.0), SIMDE_FLOAT16_VALUE(-6.1), SIMDE_FLOAT16_VALUE(6.2) },
@@ -768,10 +768,10 @@ test_simde_vmul_laneq_u32 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vmulq_lane_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 b[4];
+    simde_float16_t a[8];
+    simde_float16_t b[4];
     int lane;
-    simde_float16 r[8];
+    simde_float16_t r[8];
   } test_vec[] = {
   { { SIMDE_FLOAT16_VALUE( 218.125), SIMDE_FLOAT16_VALUE( 147.75), SIMDE_FLOAT16_VALUE( 163.875), SIMDE_FLOAT16_VALUE( 3.16796875),
       SIMDE_FLOAT16_VALUE( 168.5), SIMDE_FLOAT16_VALUE( 4.4453125), SIMDE_FLOAT16_VALUE( 166.25), SIMDE_FLOAT16_VALUE( 95.0625), },
@@ -1239,10 +1239,10 @@ test_simde_vmulq_lane_u32 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vmulq_laneq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
     int lane;
-    simde_float16 r[8];
+    simde_float16_t r[8];
   } test_vec[] = {
    { {  SIMDE_FLOAT16_VALUE(-4.6), SIMDE_FLOAT16_VALUE(0.6), SIMDE_FLOAT16_VALUE(5.9), SIMDE_FLOAT16_VALUE(-1.8),
         SIMDE_FLOAT16_VALUE(0.0), SIMDE_FLOAT16_VALUE(-2.4), SIMDE_FLOAT16_VALUE(-1.9), SIMDE_FLOAT16_VALUE(9.7) },
@@ -2103,10 +2103,10 @@ test_simde_vmuls_laneq_f32 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vmul_laneq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[8];
+    simde_float16_t a[4];
+    simde_float16_t b[8];
     int lane;
-    simde_float16 r[4];
+    simde_float16_t r[4];
   } test_vec[] = {
    { {  SIMDE_FLOAT16_VALUE(-2.3), SIMDE_FLOAT16_VALUE(-2.7), SIMDE_FLOAT16_VALUE(0.1), SIMDE_FLOAT16_VALUE(6.2) },
      {  SIMDE_FLOAT16_VALUE(-4.0), SIMDE_FLOAT16_VALUE(1.4), SIMDE_FLOAT16_VALUE(-5.2), SIMDE_FLOAT16_VALUE(6.9),

--- a/test/arm/neon/mul_n.c
+++ b/test/arm/neon/mul_n.c
@@ -6,9 +6,9 @@
 static int
 test_simde_vmul_n_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b;
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t b;
+    simde_float16_t r[4];
   } test_vec[] = {
   { { SIMDE_FLOAT16_VALUE( 218.125), SIMDE_FLOAT16_VALUE( 147.75), SIMDE_FLOAT16_VALUE( 163.875), SIMDE_FLOAT16_VALUE( 3.16796875) },
       SIMDE_FLOAT16_VALUE( 1.25),
@@ -26,7 +26,7 @@ test_simde_vmul_n_f16 (SIMDE_MUNIT_TEST_ARGS) {
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
     simde_float16x4_t a = simde_vld1_f16(test_vec[i].a);
-    simde_float16 b = test_vec[i].b;
+    simde_float16_t b = test_vec[i].b;
     simde_float16x4_t r = simde_vmul_n_f16(a, b);
 
     simde_test_arm_neon_assert_equal_f16x4(r, simde_vld1_f16(test_vec[i].r), 1);
@@ -390,9 +390,9 @@ test_simde_vmul_n_u32 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vmulq_n_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 b[1];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t b[1];
+    simde_float16_t r[8];
   } test_vec[] = {
   { { SIMDE_FLOAT16_VALUE( 12.0), SIMDE_FLOAT16_VALUE( 48.0), SIMDE_FLOAT16_VALUE( 22.5), SIMDE_FLOAT16_VALUE( 19.25),
       SIMDE_FLOAT16_VALUE( 8.5), SIMDE_FLOAT16_VALUE( 10.25), SIMDE_FLOAT16_VALUE( 4.625), SIMDE_FLOAT16_VALUE( 179.5) },

--- a/test/arm/neon/neg.c
+++ b/test/arm/neon/neg.c
@@ -6,8 +6,8 @@
 static int
 test_simde_vnegh_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a;
-    simde_float16 r;
+    simde_float16_t a;
+    simde_float16_t r;
   } test_vec[] = {
    { SIMDE_FLOAT16_VALUE(5.08),
      SIMDE_FLOAT16_VALUE(-5.08) },
@@ -39,8 +39,8 @@ test_simde_vnegh_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vneg_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t r[4];
   } test_vec[] = {
    { {  SIMDE_FLOAT16_VALUE(3.76), SIMDE_FLOAT16_VALUE(4.26), SIMDE_FLOAT16_VALUE(0.04), SIMDE_FLOAT16_VALUE(-1.27) },
      {  SIMDE_FLOAT16_VALUE(-3.76), SIMDE_FLOAT16_VALUE(-4.26), SIMDE_FLOAT16_VALUE(-0.04), SIMDE_FLOAT16_VALUE(1.27) } },
@@ -73,8 +73,8 @@ test_simde_vneg_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vnegq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t r[8];
   } test_vec[] = {
    { {  SIMDE_FLOAT16_VALUE(3.86), SIMDE_FLOAT16_VALUE(-7.04), SIMDE_FLOAT16_VALUE(-0.07), SIMDE_FLOAT16_VALUE(-5.19),
         SIMDE_FLOAT16_VALUE(-9.22), SIMDE_FLOAT16_VALUE(-9.12), SIMDE_FLOAT16_VALUE(7.75), SIMDE_FLOAT16_VALUE(5.97) },

--- a/test/arm/neon/padd.c
+++ b/test/arm/neon/padd.c
@@ -6,9 +6,9 @@
 static int
 test_simde_vpadd_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   -49.28), SIMDE_FLOAT16_VALUE(  -109.00), SIMDE_FLOAT16_VALUE(  -626.50), SIMDE_FLOAT16_VALUE(  -567.00) },
       { SIMDE_FLOAT16_VALUE(  -178.88), SIMDE_FLOAT16_VALUE(    10.22), SIMDE_FLOAT16_VALUE(   976.50), SIMDE_FLOAT16_VALUE(   -31.19) },

--- a/test/arm/neon/pmax.c
+++ b/test/arm/neon/pmax.c
@@ -6,9 +6,9 @@
 static int
 test_simde_vpmax_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   441.00), SIMDE_FLOAT16_VALUE(   684.00), SIMDE_FLOAT16_VALUE(   861.50), SIMDE_FLOAT16_VALUE(   563.00) },
       { SIMDE_FLOAT16_VALUE(    98.06), SIMDE_FLOAT16_VALUE(    15.31), SIMDE_FLOAT16_VALUE(   896.00), SIMDE_FLOAT16_VALUE(  -786.50) },

--- a/test/arm/neon/recpe.c
+++ b/test/arm/neon/recpe.c
@@ -100,8 +100,8 @@ test_simde_vrecped_f64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vrecpe_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(-3.50), SIMDE_FLOAT16_VALUE(-3.90), SIMDE_FLOAT16_VALUE(5.70), SIMDE_FLOAT16_VALUE(-7.70) },
       { SIMDE_FLOAT16_VALUE(-0.29), SIMDE_FLOAT16_VALUE(-0.26), SIMDE_FLOAT16_VALUE(0.18), SIMDE_FLOAT16_VALUE(-0.13) } },
@@ -325,8 +325,8 @@ test_simde_vrecpeq_f32 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vrecpeq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(7.50), SIMDE_FLOAT16_VALUE(-9.30), SIMDE_FLOAT16_VALUE(7.50), SIMDE_FLOAT16_VALUE(-3.10), SIMDE_FLOAT16_VALUE(5.00), SIMDE_FLOAT16_VALUE(-3.50), SIMDE_FLOAT16_VALUE(-3.70), SIMDE_FLOAT16_VALUE(9.10) },
       { SIMDE_FLOAT16_VALUE(0.13), SIMDE_FLOAT16_VALUE(-0.11), SIMDE_FLOAT16_VALUE(0.13), SIMDE_FLOAT16_VALUE(-0.32), SIMDE_FLOAT16_VALUE(0.20), SIMDE_FLOAT16_VALUE(-0.29), SIMDE_FLOAT16_VALUE(-0.27), SIMDE_FLOAT16_VALUE(0.11) } },

--- a/test/arm/neon/recps.c
+++ b/test/arm/neon/recps.c
@@ -239,9 +239,9 @@ test_simde_vrecps_f32 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vrecps_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(3.80), SIMDE_FLOAT16_VALUE(-1.40), SIMDE_FLOAT16_VALUE(1.60), SIMDE_FLOAT16_VALUE(4.40) },
       { SIMDE_FLOAT16_VALUE(0.50), SIMDE_FLOAT16_VALUE(4.60), SIMDE_FLOAT16_VALUE(-3.60), SIMDE_FLOAT16_VALUE(4.90) },
@@ -403,9 +403,9 @@ test_simde_vrecpsq_f32 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vrecpsq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(-3.10), SIMDE_FLOAT16_VALUE(-3.20), SIMDE_FLOAT16_VALUE(-4.50), SIMDE_FLOAT16_VALUE(-1.50), SIMDE_FLOAT16_VALUE(-3.30), SIMDE_FLOAT16_VALUE(-0.80), SIMDE_FLOAT16_VALUE(-0.60), SIMDE_FLOAT16_VALUE(4.10) },
       { SIMDE_FLOAT16_VALUE(-3.30), SIMDE_FLOAT16_VALUE(1.20), SIMDE_FLOAT16_VALUE(2.40), SIMDE_FLOAT16_VALUE(-4.90), SIMDE_FLOAT16_VALUE(-0.30), SIMDE_FLOAT16_VALUE(-1.90), SIMDE_FLOAT16_VALUE(-0.80), SIMDE_FLOAT16_VALUE(1.10) },

--- a/test/arm/neon/reinterpret.c
+++ b/test/arm/neon/reinterpret.c
@@ -5735,7 +5735,7 @@ test_simde_vreinterpret_u16_f32 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpret_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
   } test_vec[] = {
      {{ SIMDE_FLOAT16_VALUE(  -937.50), SIMDE_FLOAT16_VALUE(   311.75), SIMDE_FLOAT16_VALUE(   -23.30), SIMDE_FLOAT16_VALUE(   600.50) }},
      {{ SIMDE_FLOAT16_VALUE(   438.25), SIMDE_FLOAT16_VALUE(   -31.77), SIMDE_FLOAT16_VALUE(  -916.50), SIMDE_FLOAT16_VALUE(   172.62) }},
@@ -6090,7 +6090,7 @@ test_simde_vreinterpretq_u16_f32 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpretq_u16_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
   } test_vec[] = {
      { { SIMDE_FLOAT16_VALUE(   615.50), SIMDE_FLOAT16_VALUE(  -978.50), SIMDE_FLOAT16_VALUE(  -561.50), SIMDE_FLOAT16_VALUE(   508.50),
         SIMDE_FLOAT16_VALUE(  -968.00), SIMDE_FLOAT16_VALUE(  -316.25), SIMDE_FLOAT16_VALUE(  -961.50), SIMDE_FLOAT16_VALUE(   786.50) } },
@@ -7532,7 +7532,7 @@ test_simde_vreinterpretq_f16_f64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpret_f32_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   -49.28), SIMDE_FLOAT16_VALUE(  -109.00), SIMDE_FLOAT16_VALUE(  -626.50), SIMDE_FLOAT16_VALUE(  -567.00) } },
     { { SIMDE_FLOAT16_VALUE(  -178.88), SIMDE_FLOAT16_VALUE(    10.22), SIMDE_FLOAT16_VALUE(   976.50), SIMDE_FLOAT16_VALUE(   -31.19) } },
@@ -7560,7 +7560,7 @@ test_simde_vreinterpret_f32_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpretq_f32_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   615.50), SIMDE_FLOAT16_VALUE(  -978.50), SIMDE_FLOAT16_VALUE(  -561.50), SIMDE_FLOAT16_VALUE(   508.50),
         SIMDE_FLOAT16_VALUE(  -968.00), SIMDE_FLOAT16_VALUE(  -316.25), SIMDE_FLOAT16_VALUE(  -961.50), SIMDE_FLOAT16_VALUE(   786.50) } },
@@ -7595,7 +7595,7 @@ test_simde_vreinterpretq_f32_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpret_f64_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   -49.28), SIMDE_FLOAT16_VALUE(  -109.00), SIMDE_FLOAT16_VALUE(  -626.50), SIMDE_FLOAT16_VALUE(  -567.00) } },
     { { SIMDE_FLOAT16_VALUE(  -178.88), SIMDE_FLOAT16_VALUE(    10.22), SIMDE_FLOAT16_VALUE(   976.50), SIMDE_FLOAT16_VALUE(   -31.19) } },
@@ -7623,7 +7623,7 @@ test_simde_vreinterpret_f64_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpretq_f64_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   615.50), SIMDE_FLOAT16_VALUE(  -978.50), SIMDE_FLOAT16_VALUE(  -561.50), SIMDE_FLOAT16_VALUE(   508.50),
         SIMDE_FLOAT16_VALUE(  -968.00), SIMDE_FLOAT16_VALUE(  -316.25), SIMDE_FLOAT16_VALUE(  -961.50), SIMDE_FLOAT16_VALUE(   786.50) } },
@@ -7658,7 +7658,7 @@ test_simde_vreinterpretq_f64_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpret_s8_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   -49.28), SIMDE_FLOAT16_VALUE(  -109.00), SIMDE_FLOAT16_VALUE(  -626.50), SIMDE_FLOAT16_VALUE(  -567.00) } },
     { { SIMDE_FLOAT16_VALUE(  -178.88), SIMDE_FLOAT16_VALUE(    10.22), SIMDE_FLOAT16_VALUE(   976.50), SIMDE_FLOAT16_VALUE(   -31.19) } },
@@ -7686,7 +7686,7 @@ test_simde_vreinterpret_s8_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpretq_s8_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   615.50), SIMDE_FLOAT16_VALUE(  -978.50), SIMDE_FLOAT16_VALUE(  -561.50), SIMDE_FLOAT16_VALUE(   508.50),
         SIMDE_FLOAT16_VALUE(  -968.00), SIMDE_FLOAT16_VALUE(  -316.25), SIMDE_FLOAT16_VALUE(  -961.50), SIMDE_FLOAT16_VALUE(   786.50) } },
@@ -7721,7 +7721,7 @@ test_simde_vreinterpretq_s8_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpret_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   -49.28), SIMDE_FLOAT16_VALUE(  -109.00), SIMDE_FLOAT16_VALUE(  -626.50), SIMDE_FLOAT16_VALUE(  -567.00) } },
     { { SIMDE_FLOAT16_VALUE(  -178.88), SIMDE_FLOAT16_VALUE(    10.22), SIMDE_FLOAT16_VALUE(   976.50), SIMDE_FLOAT16_VALUE(   -31.19) } },
@@ -7749,7 +7749,7 @@ test_simde_vreinterpret_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpretq_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   615.50), SIMDE_FLOAT16_VALUE(  -978.50), SIMDE_FLOAT16_VALUE(  -561.50), SIMDE_FLOAT16_VALUE(   508.50),
         SIMDE_FLOAT16_VALUE(  -968.00), SIMDE_FLOAT16_VALUE(  -316.25), SIMDE_FLOAT16_VALUE(  -961.50), SIMDE_FLOAT16_VALUE(   786.50) } },
@@ -7784,7 +7784,7 @@ test_simde_vreinterpretq_s16_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpret_s32_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   -49.28), SIMDE_FLOAT16_VALUE(  -109.00), SIMDE_FLOAT16_VALUE(  -626.50), SIMDE_FLOAT16_VALUE(  -567.00) } },
     { { SIMDE_FLOAT16_VALUE(  -178.88), SIMDE_FLOAT16_VALUE(    10.22), SIMDE_FLOAT16_VALUE(   976.50), SIMDE_FLOAT16_VALUE(   -31.19) } },
@@ -7812,7 +7812,7 @@ test_simde_vreinterpret_s32_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpretq_s32_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   615.50), SIMDE_FLOAT16_VALUE(  -978.50), SIMDE_FLOAT16_VALUE(  -561.50), SIMDE_FLOAT16_VALUE(   508.50),
         SIMDE_FLOAT16_VALUE(  -968.00), SIMDE_FLOAT16_VALUE(  -316.25), SIMDE_FLOAT16_VALUE(  -961.50), SIMDE_FLOAT16_VALUE(   786.50) } },
@@ -7847,7 +7847,7 @@ test_simde_vreinterpretq_s32_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpret_s64_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   -49.28), SIMDE_FLOAT16_VALUE(  -109.00), SIMDE_FLOAT16_VALUE(  -626.50), SIMDE_FLOAT16_VALUE(  -567.00) } },
     { { SIMDE_FLOAT16_VALUE(  -178.88), SIMDE_FLOAT16_VALUE(    10.22), SIMDE_FLOAT16_VALUE(   976.50), SIMDE_FLOAT16_VALUE(   -31.19) } },
@@ -7875,7 +7875,7 @@ test_simde_vreinterpret_s64_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpretq_s64_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   615.50), SIMDE_FLOAT16_VALUE(  -978.50), SIMDE_FLOAT16_VALUE(  -561.50), SIMDE_FLOAT16_VALUE(   508.50),
         SIMDE_FLOAT16_VALUE(  -968.00), SIMDE_FLOAT16_VALUE(  -316.25), SIMDE_FLOAT16_VALUE(  -961.50), SIMDE_FLOAT16_VALUE(   786.50) } },
@@ -7910,7 +7910,7 @@ test_simde_vreinterpretq_s64_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpret_u8_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   -49.28), SIMDE_FLOAT16_VALUE(  -109.00), SIMDE_FLOAT16_VALUE(  -626.50), SIMDE_FLOAT16_VALUE(  -567.00) } },
     { { SIMDE_FLOAT16_VALUE(  -178.88), SIMDE_FLOAT16_VALUE(    10.22), SIMDE_FLOAT16_VALUE(   976.50), SIMDE_FLOAT16_VALUE(   -31.19) } },
@@ -7938,7 +7938,7 @@ test_simde_vreinterpret_u8_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpretq_u8_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   615.50), SIMDE_FLOAT16_VALUE(  -978.50), SIMDE_FLOAT16_VALUE(  -561.50), SIMDE_FLOAT16_VALUE(   508.50),
         SIMDE_FLOAT16_VALUE(  -968.00), SIMDE_FLOAT16_VALUE(  -316.25), SIMDE_FLOAT16_VALUE(  -961.50), SIMDE_FLOAT16_VALUE(   786.50) } },
@@ -7972,7 +7972,7 @@ test_simde_vreinterpretq_u8_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpret_u32_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   -49.28), SIMDE_FLOAT16_VALUE(  -109.00), SIMDE_FLOAT16_VALUE(  -626.50), SIMDE_FLOAT16_VALUE(  -567.00) } },
     { { SIMDE_FLOAT16_VALUE(  -178.88), SIMDE_FLOAT16_VALUE(    10.22), SIMDE_FLOAT16_VALUE(   976.50), SIMDE_FLOAT16_VALUE(   -31.19) } },
@@ -7999,7 +7999,7 @@ test_simde_vreinterpret_u32_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpretq_u32_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   615.50), SIMDE_FLOAT16_VALUE(  -978.50), SIMDE_FLOAT16_VALUE(  -561.50), SIMDE_FLOAT16_VALUE(   508.50),
         SIMDE_FLOAT16_VALUE(  -968.00), SIMDE_FLOAT16_VALUE(  -316.25), SIMDE_FLOAT16_VALUE(  -961.50), SIMDE_FLOAT16_VALUE(   786.50) } },
@@ -8033,7 +8033,7 @@ test_simde_vreinterpretq_u32_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpret_u64_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
+    simde_float16_t a[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   -49.28), SIMDE_FLOAT16_VALUE(  -109.00), SIMDE_FLOAT16_VALUE(  -626.50), SIMDE_FLOAT16_VALUE(  -567.00) } },
     { { SIMDE_FLOAT16_VALUE(  -178.88), SIMDE_FLOAT16_VALUE(    10.22), SIMDE_FLOAT16_VALUE(   976.50), SIMDE_FLOAT16_VALUE(   -31.19) } },
@@ -8060,7 +8060,7 @@ test_simde_vreinterpret_u64_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vreinterpretq_u64_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
+    simde_float16_t a[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   615.50), SIMDE_FLOAT16_VALUE(  -978.50), SIMDE_FLOAT16_VALUE(  -561.50), SIMDE_FLOAT16_VALUE(   508.50),
         SIMDE_FLOAT16_VALUE(  -968.00), SIMDE_FLOAT16_VALUE(  -316.25), SIMDE_FLOAT16_VALUE(  -961.50), SIMDE_FLOAT16_VALUE(   786.50) } },

--- a/test/arm/neon/rev64.c
+++ b/test/arm/neon/rev64.c
@@ -287,8 +287,8 @@ static int
 test_simde_vrev64_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE( - 73.456), SIMDE_FLOAT16_VALUE( - 25.018),  SIMDE_FLOAT16_VALUE( 37.020),  SIMDE_FLOAT16_VALUE( 60.928) },
       {  SIMDE_FLOAT16_VALUE( 60.928),  SIMDE_FLOAT16_VALUE( 37.020), SIMDE_FLOAT16_VALUE( - 25.018), SIMDE_FLOAT16_VALUE( - 73.456) } },
@@ -686,8 +686,8 @@ static int
 test_simde_vrev64q_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { {  SIMDE_FLOAT16_VALUE( 22.973),  SIMDE_FLOAT16_VALUE( 82.785), SIMDE_FLOAT16_VALUE( - 87.788),  SIMDE_FLOAT16_VALUE( 54.222),
         SIMDE_FLOAT16_VALUE( - 79.878),  SIMDE_FLOAT16_VALUE( 61.120), SIMDE_FLOAT16_VALUE( -  1.496),  SIMDE_FLOAT16_VALUE( 87.003) },

--- a/test/arm/neon/rndn.c
+++ b/test/arm/neon/rndn.c
@@ -45,8 +45,8 @@ test_simde_vrndnh_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vrndn_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     #if !defined(SIMDE_FAST_NANS)
       { {            SIMDE_NANHF,           SIMDE_NANHF,            SIMDE_NANHF,           SIMDE_NANHF },
@@ -191,8 +191,8 @@ test_simde_vrndn_f64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vrndnq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     #if !defined(SIMDE_FAST_NANS)
         { {            SIMDE_NANHF,           SIMDE_NANHF,            SIMDE_NANHF,           SIMDE_NANHF,            SIMDE_NANHF,           SIMDE_NANHF,            SIMDE_NANHF,           SIMDE_NANHF },

--- a/test/arm/neon/rsqrte.c
+++ b/test/arm/neon/rsqrte.c
@@ -7,8 +7,8 @@
 static int
 test_simde_vrsqrteh_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a;
-    simde_float16 r;
+    simde_float16_t a;
+    simde_float16_t r;
   } test_vec[] = {
     { SIMDE_FLOAT16_VALUE(5.50),
       SIMDE_FLOAT16_VALUE(0.43) },
@@ -137,8 +137,8 @@ test_simde_vrsqrted_f64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vrsqrte_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(0.27), SIMDE_FLOAT16_VALUE(15.80), SIMDE_FLOAT16_VALUE(5.01), SIMDE_FLOAT16_VALUE(5.52) },
       { SIMDE_FLOAT16_VALUE(1.92), SIMDE_FLOAT16_VALUE(0.25), SIMDE_FLOAT16_VALUE(0.45), SIMDE_FLOAT16_VALUE(0.43) } },
@@ -313,8 +313,8 @@ test_simde_vrsqrte_u32 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vrsqrteq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(3.00), SIMDE_FLOAT16_VALUE(13.00), SIMDE_FLOAT16_VALUE(17.80), SIMDE_FLOAT16_VALUE(3.50), SIMDE_FLOAT16_VALUE(13.20), SIMDE_FLOAT16_VALUE(3.80), SIMDE_FLOAT16_VALUE(9.30), SIMDE_FLOAT16_VALUE(12.70) },
       { SIMDE_FLOAT16_VALUE(0.58), SIMDE_FLOAT16_VALUE(0.28), SIMDE_FLOAT16_VALUE(0.24), SIMDE_FLOAT16_VALUE(0.53), SIMDE_FLOAT16_VALUE(0.28), SIMDE_FLOAT16_VALUE(0.51), SIMDE_FLOAT16_VALUE(0.33), SIMDE_FLOAT16_VALUE(0.28) } },

--- a/test/arm/neon/rsqrts.c
+++ b/test/arm/neon/rsqrts.c
@@ -6,9 +6,9 @@
 static int
 test_simde_vrsqrts_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(    -1.81), SIMDE_FLOAT16_VALUE(     6.08),
         SIMDE_FLOAT16_VALUE(     4.44), SIMDE_FLOAT16_VALUE(     6.63) },
@@ -166,9 +166,9 @@ test_simde_vrsqrts_f64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vrsqrtsq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(    -2.14), SIMDE_FLOAT16_VALUE(    -4.57), SIMDE_FLOAT16_VALUE(     6.16), SIMDE_FLOAT16_VALUE(    -7.69),
         SIMDE_FLOAT16_VALUE(    -5.58), SIMDE_FLOAT16_VALUE(     3.64), SIMDE_FLOAT16_VALUE(     5.46), SIMDE_FLOAT16_VALUE(    -2.76) },

--- a/test/arm/neon/set_lane.c
+++ b/test/arm/neon/set_lane.c
@@ -9,9 +9,9 @@ SIMDE_DIAGNOSTIC_DISABLE_UNREACHABLE_
 static int
 test_simde_vset_lane_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a;
-    simde_float16 v[4];
-    simde_float16 r[4];
+    simde_float16_t a;
+    simde_float16_t v[4];
+    simde_float16_t r[4];
     int lane;
   } test_vec[] = {
     { SIMDE_FLOAT16_VALUE(64.81),
@@ -57,7 +57,7 @@ test_simde_vset_lane_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     simde_float16x4_t v = simde_vld1_f16(test_vec[i].v);
     int lane = test_vec[i].lane;
     simde_float16x4_t r;
@@ -773,9 +773,9 @@ test_simde_vset_lane_u64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vsetq_lane_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a;
-    simde_float16 v[8];
-    simde_float16 r[8];
+    simde_float16_t a;
+    simde_float16_t v[8];
+    simde_float16_t r[8];
     int lane;
   } test_vec[] = {
     { SIMDE_FLOAT16_VALUE(    44.00),
@@ -829,7 +829,7 @@ test_simde_vsetq_lane_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 a = test_vec[i].a;
+    simde_float16_t a = test_vec[i].a;
     simde_float16x8_t v = simde_vld1q_f16(test_vec[i].v);
     int lane = test_vec[i].lane;
     simde_float16x8_t r;

--- a/test/arm/neon/sqrt.c
+++ b/test/arm/neon/sqrt.c
@@ -6,8 +6,8 @@
 static int
 test_simde_vsqrth_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a;
-    simde_float16 r;
+    simde_float16_t a;
+    simde_float16_t r;
   } test_vec[] = {
     { SIMDE_FLOAT16_VALUE(14.90),
       SIMDE_FLOAT16_VALUE(3.86)  },
@@ -32,7 +32,7 @@ test_simde_vsqrth_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 r = simde_vsqrth_f16(test_vec[i].a);
+    simde_float16_t r = simde_vsqrth_f16(test_vec[i].a);
 
     simde_assert_equal_f16(r, test_vec[i].r, 1);
   }
@@ -43,8 +43,8 @@ test_simde_vsqrth_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vsqrt_f16 (SIMDE_MUNIT_TEST_ARGS) {
     struct {
-      simde_float16 a[4];
-      simde_float16 r[4];
+      simde_float16_t a[4];
+      simde_float16_t r[4];
     } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(27.93), SIMDE_FLOAT16_VALUE(10.08), SIMDE_FLOAT16_VALUE(9.30), SIMDE_FLOAT16_VALUE(11.22) },
       { SIMDE_FLOAT16_VALUE(5.28), SIMDE_FLOAT16_VALUE(3.18), SIMDE_FLOAT16_VALUE(3.05), SIMDE_FLOAT16_VALUE(3.35) } },
@@ -161,8 +161,8 @@ test_simde_vsqrt_f64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vsqrtq_f16 (SIMDE_MUNIT_TEST_ARGS) {
     struct {
-      simde_float16 a[8];
-      simde_float16 r[8];
+      simde_float16_t a[8];
+      simde_float16_t r[8];
     } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(10.75), SIMDE_FLOAT16_VALUE(3.14), SIMDE_FLOAT16_VALUE(3.83), SIMDE_FLOAT16_VALUE(2.77), SIMDE_FLOAT16_VALUE(12.19), SIMDE_FLOAT16_VALUE(1.99), SIMDE_FLOAT16_VALUE(1.01), SIMDE_FLOAT16_VALUE(15.86) },
       { SIMDE_FLOAT16_VALUE(3.28), SIMDE_FLOAT16_VALUE(1.77), SIMDE_FLOAT16_VALUE(1.96), SIMDE_FLOAT16_VALUE(1.67), SIMDE_FLOAT16_VALUE(3.49), SIMDE_FLOAT16_VALUE(1.41), SIMDE_FLOAT16_VALUE(1.00), SIMDE_FLOAT16_VALUE(3.98) } },

--- a/test/arm/neon/st1_lane.c
+++ b/test/arm/neon/st1_lane.c
@@ -9,8 +9,8 @@ SIMDE_DIAGNOSTIC_DISABLE_UNREACHABLE_
 static int
 test_simde_vst1_lane_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a;
-    simde_float16 val[4];
+    simde_float16_t a;
+    simde_float16_t val[4];
     int lane;
   } test_vec[] = {
     {    SIMDE_FLOAT16_VALUE( 85.175),
@@ -41,7 +41,7 @@ test_simde_vst1_lane_f16 (SIMDE_MUNIT_TEST_ARGS) {
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
     simde_float16x4_t val = simde_vld1_f16(test_vec[i].val);
-    simde_float16 a;
+    simde_float16_t a;
     SIMDE_CONSTIFY_4_NO_RESULT_(simde_vst1_lane_f16, HEDLEY_UNREACHABLE(), test_vec[i].lane, &a, val);
 
     simde_assert_equal_f16(a, test_vec[i].a, 1);
@@ -625,8 +625,8 @@ test_simde_vst1_lane_u64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vst1q_lane_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a;
-    simde_float16 val[8];
+    simde_float16_t a;
+    simde_float16_t val[8];
     int lane;
   } test_vec[] = {
     {   SIMDE_FLOAT16_VALUE( - 64.026),
@@ -666,7 +666,7 @@ test_simde_vst1q_lane_f16 (SIMDE_MUNIT_TEST_ARGS) {
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
     simde_float16x8_t val = simde_vld1q_f16(test_vec[i].val);
-    simde_float16 a;
+    simde_float16_t a;
     SIMDE_CONSTIFY_8_NO_RESULT_(simde_vst1q_lane_f16, HEDLEY_UNREACHABLE(), test_vec[i].lane, &a, val);
     simde_assert_equal_f16(a, test_vec[i].a, 1);
   }

--- a/test/arm/neon/st1_x2.c
+++ b/test/arm/neon/st1_x2.c
@@ -9,8 +9,8 @@ static int
 test_simde_vst1_f16_x2 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 val[2][4];
-    simde_float16 r[8];
+    simde_float16_t val[2][4];
+    simde_float16_t r[8];
   } test_vec[] = {
   { { { SIMDE_FLOAT16_VALUE( -  49.565), SIMDE_FLOAT16_VALUE( -   3.779), SIMDE_FLOAT16_VALUE( -   4.526),  SIMDE_FLOAT16_VALUE(  54.137)  },
       {  SIMDE_FLOAT16_VALUE(  93.243),  SIMDE_FLOAT16_VALUE(  77.887),  SIMDE_FLOAT16_VALUE(  67.064), SIMDE_FLOAT16_VALUE( -  88.528)  } },
@@ -43,7 +43,7 @@ test_simde_vst1_f16_x2 (SIMDE_MUNIT_TEST_ARGS) {
         simde_vld1_f16(test_vec[i].val[0]),
         simde_vld1_f16(test_vec[i].val[1]),
     }};
-    simde_float16 r_[8];
+    simde_float16_t r_[8];
     simde_vst1_f16_x2(r_, val);
     simde_assert_equal_i(0, simde_memcmp(r_, test_vec[i].r, sizeof(test_vec[i].r)));
   }

--- a/test/arm/neon/st1_x3.c
+++ b/test/arm/neon/st1_x3.c
@@ -9,8 +9,8 @@ static int
 test_simde_vst1_f16_x3 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 val[3][4];
-    simde_float16 r[12];
+    simde_float16_t val[3][4];
+    simde_float16_t r[12];
   } test_vec[] = {
   { { {  SIMDE_FLOAT16_VALUE( 29.597), SIMDE_FLOAT16_VALUE( - 97.375), SIMDE_FLOAT16_VALUE( - 37.290),  SIMDE_FLOAT16_VALUE( 83.451)  },
       {  SIMDE_FLOAT16_VALUE( 58.071),  SIMDE_FLOAT16_VALUE(  9.615), SIMDE_FLOAT16_VALUE( - 92.703), SIMDE_FLOAT16_VALUE( - 13.746)  },
@@ -68,7 +68,7 @@ test_simde_vst1_f16_x3 (SIMDE_MUNIT_TEST_ARGS) {
         simde_vld1_f16(test_vec[i].val[1]),
         simde_vld1_f16(test_vec[i].val[2]),
     }};
-    simde_float16 r_[12];
+    simde_float16_t r_[12];
     simde_vst1_f16_x3(r_, val);
     simde_assert_equal_i(0, simde_memcmp(r_, test_vec[i].r, sizeof(test_vec[i].r)));
   }

--- a/test/arm/neon/st1_x4.c
+++ b/test/arm/neon/st1_x4.c
@@ -9,8 +9,8 @@ static int
 test_simde_vst1_f16_x4 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 val[4][4];
-    simde_float16 r[16];
+    simde_float16_t val[4][4];
+    simde_float16_t r[16];
   } test_vec[] = {
   { { {  SIMDE_FLOAT16_VALUE( 82.328),  SIMDE_FLOAT16_VALUE( 70.920), SIMDE_FLOAT16_VALUE( -  2.164),  SIMDE_FLOAT16_VALUE( 20.248)  },
       {  SIMDE_FLOAT16_VALUE( 17.827), SIMDE_FLOAT16_VALUE( - 14.465), SIMDE_FLOAT16_VALUE( - 88.806),  SIMDE_FLOAT16_VALUE( 79.077)  },
@@ -85,7 +85,7 @@ test_simde_vst1_f16_x4 (SIMDE_MUNIT_TEST_ARGS) {
         simde_vld1_f16(test_vec[i].val[2]),
         simde_vld1_f16(test_vec[i].val[3]),
     }};
-    simde_float16 r_[16];
+    simde_float16_t r_[16];
     simde_vst1_f16_x4(r_, val);
     simde_assert_equal_i(0, simde_memcmp(r_, test_vec[i].r, sizeof(test_vec[i].r)));
   }

--- a/test/arm/neon/st1q_x2.c
+++ b/test/arm/neon/st1q_x2.c
@@ -9,8 +9,8 @@ static int
 test_simde_vst1q_f16_x2 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 val[2][8];
-    simde_float16 r[16];
+    simde_float16_t val[2][8];
+    simde_float16_t r[16];
   } test_vec[] = {
   { { { SIMDE_FLOAT16_VALUE( - 20.956), SIMDE_FLOAT16_VALUE( - 58.964), SIMDE_FLOAT16_VALUE( - 74.395), SIMDE_FLOAT16_VALUE( - 58.069),
         SIMDE_FLOAT16_VALUE( - 73.918), SIMDE_FLOAT16_VALUE( - 88.889), SIMDE_FLOAT16_VALUE( - 89.387),  SIMDE_FLOAT16_VALUE( 26.229)  },
@@ -83,7 +83,7 @@ test_simde_vst1q_f16_x2 (SIMDE_MUNIT_TEST_ARGS) {
         simde_vld1q_f16(test_vec[i].val[0]),
         simde_vld1q_f16(test_vec[i].val[1]),
     }};
-    simde_float16 r_[16];
+    simde_float16_t r_[16];
     simde_vst1q_f16_x2(r_, val);
     simde_assert_equal_i(0, simde_memcmp(r_, test_vec[i].r, sizeof(test_vec[i].r)));
   }

--- a/test/arm/neon/st1q_x3.c
+++ b/test/arm/neon/st1q_x3.c
@@ -9,8 +9,8 @@ static int
 test_simde_vst1q_f16_x3 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 val[3][8];
-    simde_float16 r[24];
+    simde_float16_t val[3][8];
+    simde_float16_t r[24];
   } test_vec[] = {
   { { { SIMDE_FLOAT16_VALUE( - 78.006), SIMDE_FLOAT16_VALUE( - 86.214),  SIMDE_FLOAT16_VALUE( 79.768), SIMDE_FLOAT16_VALUE( - 58.640),
          SIMDE_FLOAT16_VALUE( 95.290), SIMDE_FLOAT16_VALUE( - 58.694), SIMDE_FLOAT16_VALUE( - 66.494),  SIMDE_FLOAT16_VALUE( 14.402)  },
@@ -116,7 +116,7 @@ test_simde_vst1q_f16_x3 (SIMDE_MUNIT_TEST_ARGS) {
         simde_vld1q_f16(test_vec[i].val[1]),
         simde_vld1q_f16(test_vec[i].val[2]),
     }};
-    simde_float16 r_[24];
+    simde_float16_t r_[24];
     simde_vst1q_f16_x3(r_, val);
     simde_assert_equal_i(0, simde_memcmp(r_, test_vec[i].r, sizeof(test_vec[i].r)));
   }

--- a/test/arm/neon/st1q_x4.c
+++ b/test/arm/neon/st1q_x4.c
@@ -9,8 +9,8 @@ static int
 test_simde_vst1q_f16_x4 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 val[4][8];
-    simde_float16 r[32];
+    simde_float16_t val[4][8];
+    simde_float16_t r[32];
   } test_vec[] = {
   { { { SIMDE_FLOAT16_VALUE( - 22.750),  SIMDE_FLOAT16_VALUE( 61.096),  SIMDE_FLOAT16_VALUE( 69.465),  SIMDE_FLOAT16_VALUE( 61.036),
          SIMDE_FLOAT16_VALUE( 97.235),  SIMDE_FLOAT16_VALUE( 49.615), SIMDE_FLOAT16_VALUE( - 97.607), SIMDE_FLOAT16_VALUE( - 78.562)  },
@@ -149,7 +149,7 @@ test_simde_vst1q_f16_x4 (SIMDE_MUNIT_TEST_ARGS) {
         simde_vld1q_f16(test_vec[i].val[2]),
         simde_vld1q_f16(test_vec[i].val[3]),
     }};
-    simde_float16 r_[32];
+    simde_float16_t r_[32];
     simde_vst1q_f16_x4(r_, val);
     simde_assert_equal_i(0, simde_memcmp(r_, test_vec[i].r, sizeof(test_vec[i].r)));
   }

--- a/test/arm/neon/st2.c
+++ b/test/arm/neon/st2.c
@@ -7,9 +7,9 @@
 static int
 test_simde_vst2_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 r0[4];
-    simde_float16 r1[4];
-    simde_float16 a[8];
+    simde_float16_t r0[4];
+    simde_float16_t r1[4];
+    simde_float16_t a[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(-4.40), SIMDE_FLOAT16_VALUE(6.50), SIMDE_FLOAT16_VALUE(-1.60), SIMDE_FLOAT16_VALUE(5.90) },
       { SIMDE_FLOAT16_VALUE(1.60), SIMDE_FLOAT16_VALUE(-0.50), SIMDE_FLOAT16_VALUE(0.90), SIMDE_FLOAT16_VALUE(-6.80) },
@@ -47,7 +47,7 @@ test_simde_vst2_f16 (SIMDE_MUNIT_TEST_ARGS) {
     simde_float16x4x2_t r_ = { { simde_vld1_f16(test_vec[i].r0),
                                  simde_vld1_f16(test_vec[i].r1) } };
 
-    simde_float16 a_[8];
+    simde_float16_t a_[8];
     simde_vst2_f16(a_, r_);
 
     simde_assert_equal_i(0, simde_memcmp(a_, test_vec[i].a, sizeof(test_vec[i].a)));
@@ -715,9 +715,9 @@ test_simde_vst2_u64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vst2q_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 r0[8];
-    simde_float16 r1[8];
-    simde_float16 a[16];
+    simde_float16_t r0[8];
+    simde_float16_t r1[8];
+    simde_float16_t a[16];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(1.20), SIMDE_FLOAT16_VALUE(-2.10), SIMDE_FLOAT16_VALUE(-5.20), SIMDE_FLOAT16_VALUE(6.00), SIMDE_FLOAT16_VALUE(-2.60), SIMDE_FLOAT16_VALUE(-7.50), SIMDE_FLOAT16_VALUE(-0.90), SIMDE_FLOAT16_VALUE(-2.10) },
       { SIMDE_FLOAT16_VALUE(-5.90), SIMDE_FLOAT16_VALUE(-2.10), SIMDE_FLOAT16_VALUE(6.50), SIMDE_FLOAT16_VALUE(9.60), SIMDE_FLOAT16_VALUE(4.80), SIMDE_FLOAT16_VALUE(-8.70), SIMDE_FLOAT16_VALUE(0.20), SIMDE_FLOAT16_VALUE(-5.80) },
@@ -755,7 +755,7 @@ test_simde_vst2q_f16 (SIMDE_MUNIT_TEST_ARGS) {
     simde_float16x8x2_t r_ = { { simde_vld1q_f16(test_vec[i].r0),
                                  simde_vld1q_f16(test_vec[i].r1) } };
 
-    simde_float16 a_[16];
+    simde_float16_t a_[16];
     simde_vst2q_f16(a_, r_);
 
     simde_assert_equal_i(0, simde_memcmp(a_, test_vec[i].a, sizeof(test_vec[i].a)));

--- a/test/arm/neon/st3.c
+++ b/test/arm/neon/st3.c
@@ -22,10 +22,10 @@ static int
 test_simde_vst3_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 r0[4];
-    simde_float16 r1[4];
-    simde_float16 r2[4];
-    simde_float16 a[12];
+    simde_float16_t r0[4];
+    simde_float16_t r1[4];
+    simde_float16_t r2[4];
+    simde_float16_t a[12];
   } test_vec[] = {
     { {  SIMDE_FLOAT16_VALUE( 96.588), SIMDE_FLOAT16_VALUE( -  1.777),  SIMDE_FLOAT16_VALUE( 46.463),  SIMDE_FLOAT16_VALUE( 56.300) },
       {  SIMDE_FLOAT16_VALUE( 56.067),  SIMDE_FLOAT16_VALUE( 76.113), SIMDE_FLOAT16_VALUE( - 80.190), SIMDE_FLOAT16_VALUE( - 59.487) },
@@ -82,7 +82,7 @@ test_simde_vst3_f16 (SIMDE_MUNIT_TEST_ARGS) {
                                  simde_vld1_f16(test_vec[i].r1),
                                  simde_vld1_f16(test_vec[i].r2), } };
 
-    simde_float16 a_[12];
+    simde_float16_t a_[12];
     simde_vst3_f16(a_, r_);
     simde_assert_equal_i(0, simde_memcmp(a_, test_vec[i].a, sizeof(test_vec[i].a)));
 
@@ -1896,10 +1896,10 @@ static int
 test_simde_vst3q_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 r0[8];
-    simde_float16 r1[8];
-    simde_float16 r2[8];
-    simde_float16 a[24];
+    simde_float16_t r0[8];
+    simde_float16_t r1[8];
+    simde_float16_t r2[8];
+    simde_float16_t a[24];
   } test_vec[] = {
     { {  SIMDE_FLOAT16_VALUE( 58.181), SIMDE_FLOAT16_VALUE( - 74.070),  SIMDE_FLOAT16_VALUE(  2.770),  SIMDE_FLOAT16_VALUE( 89.824),
         SIMDE_FLOAT16_VALUE( - 73.116),  SIMDE_FLOAT16_VALUE( 77.533), SIMDE_FLOAT16_VALUE( - 71.575),  SIMDE_FLOAT16_VALUE( 68.580) },
@@ -2004,7 +2004,7 @@ test_simde_vst3q_f16 (SIMDE_MUNIT_TEST_ARGS) {
                                  simde_vld1q_f16(test_vec[i].r1),
                                  simde_vld1q_f16(test_vec[i].r2), } };
 
-    simde_float16 a_[24];
+    simde_float16_t a_[24];
     simde_vst3q_f16(a_, r_);
     simde_assert_equal_i(0, simde_memcmp(a_, test_vec[i].a, sizeof(test_vec[i].a)));
 

--- a/test/arm/neon/st4.c
+++ b/test/arm/neon/st4.c
@@ -22,11 +22,11 @@ static int
 test_simde_vst4_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 r0[4];
-    simde_float16 r1[4];
-    simde_float16 r2[4];
-    simde_float16 r3[4];
-    simde_float16 a[16];
+    simde_float16_t r0[4];
+    simde_float16_t r1[4];
+    simde_float16_t r2[4];
+    simde_float16_t r3[4];
+    simde_float16_t a[16];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE( - 47.024),  SIMDE_FLOAT16_VALUE(  6.719),  SIMDE_FLOAT16_VALUE( 41.219),  SIMDE_FLOAT16_VALUE( 13.593) },
       { SIMDE_FLOAT16_VALUE( - 94.191),  SIMDE_FLOAT16_VALUE( 54.699),  SIMDE_FLOAT16_VALUE( 93.339), SIMDE_FLOAT16_VALUE( - 70.910) },
@@ -100,7 +100,7 @@ test_simde_vst4_f16 (SIMDE_MUNIT_TEST_ARGS) {
                                  simde_vld1_f16(test_vec[i].r2),
                                  simde_vld1_f16(test_vec[i].r3), } };
 
-    simde_float16 a_[16];
+    simde_float16_t a_[16];
     simde_vst4_f16(a_, r_);
     simde_assert_equal_i(0, simde_memcmp(a_, test_vec[i].a, sizeof(test_vec[i].a)));
 
@@ -2303,11 +2303,11 @@ static int
 test_simde_vst4q_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 r0[8];
-    simde_float16 r1[8];
-    simde_float16 r2[8];
-    simde_float16 r3[8];
-    simde_float16 a[32];
+    simde_float16_t r0[8];
+    simde_float16_t r1[8];
+    simde_float16_t r2[8];
+    simde_float16_t r3[8];
+    simde_float16_t a[32];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE( - 14.743),  SIMDE_FLOAT16_VALUE( 96.869),  SIMDE_FLOAT16_VALUE( 35.732), SIMDE_FLOAT16_VALUE( - 11.204),
         SIMDE_FLOAT16_VALUE( - 36.507), SIMDE_FLOAT16_VALUE( - 87.762), SIMDE_FLOAT16_VALUE( - 30.140),  SIMDE_FLOAT16_VALUE( 40.553) },
@@ -2445,7 +2445,7 @@ test_simde_vst4q_f16 (SIMDE_MUNIT_TEST_ARGS) {
                                  simde_vld1q_f16(test_vec[i].r2),
                                  simde_vld1q_f16(test_vec[i].r3), } };
 
-    simde_float16 a_[32];
+    simde_float16_t a_[32];
     simde_vst4q_f16(a_, r_);
     simde_assert_equal_i(0, simde_memcmp(a_, test_vec[i].a, sizeof(test_vec[i].a)));
 

--- a/test/arm/neon/sub.c
+++ b/test/arm/neon/sub.c
@@ -6,9 +6,9 @@
 static int
 test_simde_vsubh_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a;
-    simde_float16 b;
-    simde_float16 r;
+    simde_float16_t a;
+    simde_float16_t b;
+    simde_float16_t r;
   } test_vec[] = {
     { SIMDE_FLOAT16_VALUE(   167.25),
       SIMDE_FLOAT16_VALUE(   952.00),
@@ -37,7 +37,7 @@ test_simde_vsubh_f16 (SIMDE_MUNIT_TEST_ARGS) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
-    simde_float16 r = simde_vsubh_f16(test_vec[i].a, test_vec[i].b);
+    simde_float16_t r = simde_vsubh_f16(test_vec[i].a, test_vec[i].b);
 
     simde_assert_equal_f16(r, test_vec[i].r, 1);
   }
@@ -47,9 +47,9 @@ test_simde_vsubh_f16 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vsub_f16 (SIMDE_MUNIT_TEST_ARGS) {
     struct {
-      simde_float16 a[4];
-      simde_float16 b[4];
-      simde_float16 r[4];
+      simde_float16_t a[4];
+      simde_float16_t b[4];
+      simde_float16_t r[4];
     } test_vec[] = {
   { {SIMDE_FLOAT16_VALUE(-49.28), SIMDE_FLOAT16_VALUE(-109.00), SIMDE_FLOAT16_VALUE(-626.50), SIMDE_FLOAT16_VALUE(-567.00)},
     {SIMDE_FLOAT16_VALUE(178.88), SIMDE_FLOAT16_VALUE(-10.22), SIMDE_FLOAT16_VALUE(-976.50), SIMDE_FLOAT16_VALUE(31.19)},
@@ -530,9 +530,9 @@ test_simde_vsub_u64 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vsubq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t r[8];
   } test_vec[] = {
 
 { { SIMDE_FLOAT16_VALUE(   441.00), SIMDE_FLOAT16_VALUE(   861.50), SIMDE_FLOAT16_VALUE(    98.06), SIMDE_FLOAT16_VALUE(   896.00),

--- a/test/arm/neon/trn.c
+++ b/test/arm/neon/trn.c
@@ -9,9 +9,9 @@ static int
 test_simde_vtrn_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 r[2][4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t r[2][4];
   } test_vec[] = {
     { {  SIMDE_FLOAT16_VALUE( 66.320),  SIMDE_FLOAT16_VALUE( 36.495), SIMDE_FLOAT16_VALUE( - 89.790),  SIMDE_FLOAT16_VALUE( 71.726) },
       {  SIMDE_FLOAT16_VALUE(  5.106),  SIMDE_FLOAT16_VALUE( 19.453),  SIMDE_FLOAT16_VALUE( 93.337),  SIMDE_FLOAT16_VALUE( 76.081) },
@@ -726,9 +726,9 @@ static int
 test_simde_vtrnq_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 r[2][8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t r[2][8];
   } test_vec[] = {
     { {  SIMDE_FLOAT16_VALUE( 72.402), SIMDE_FLOAT16_VALUE( - 27.275), SIMDE_FLOAT16_VALUE( - 87.963), SIMDE_FLOAT16_VALUE( -  3.927),
          SIMDE_FLOAT16_VALUE( 27.751), SIMDE_FLOAT16_VALUE( - 91.569), SIMDE_FLOAT16_VALUE( - 72.494), SIMDE_FLOAT16_VALUE( - 63.937) },

--- a/test/arm/neon/trn1.c
+++ b/test/arm/neon/trn1.c
@@ -7,9 +7,9 @@ static int
 test_simde_vtrn1_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { {  SIMDE_FLOAT16_VALUE( 11.105), SIMDE_FLOAT16_VALUE( - 63.267), SIMDE_FLOAT16_VALUE( - 15.443), SIMDE_FLOAT16_VALUE( - 77.497) },
       {  SIMDE_FLOAT16_VALUE( 99.692), SIMDE_FLOAT16_VALUE( - 68.474), SIMDE_FLOAT16_VALUE( - 55.887), SIMDE_FLOAT16_VALUE( - 21.106) },
@@ -477,9 +477,9 @@ static int
 test_simde_vtrn1q_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE( - 50.625),  SIMDE_FLOAT16_VALUE( 30.747),  SIMDE_FLOAT16_VALUE( 18.487),  SIMDE_FLOAT16_VALUE( 57.491),
         SIMDE_FLOAT16_VALUE( - 21.129),  SIMDE_FLOAT16_VALUE( 15.440), SIMDE_FLOAT16_VALUE( - 52.593), SIMDE_FLOAT16_VALUE( -  4.727) },

--- a/test/arm/neon/trn2.c
+++ b/test/arm/neon/trn2.c
@@ -7,9 +7,9 @@ static int
 test_simde_vtrn2_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { {  SIMDE_FLOAT16_VALUE( 56.300), SIMDE_FLOAT16_VALUE( -  9.279), SIMDE_FLOAT16_VALUE( - 19.078),  SIMDE_FLOAT16_VALUE( 91.073) },
       {  SIMDE_FLOAT16_VALUE( 85.295),  SIMDE_FLOAT16_VALUE(  3.112), SIMDE_FLOAT16_VALUE( - 91.891),  SIMDE_FLOAT16_VALUE(  4.800) },
@@ -477,9 +477,9 @@ static int
 test_simde_vtrn2q_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { {  SIMDE_FLOAT16_VALUE( 72.335),  SIMDE_FLOAT16_VALUE(  7.554), SIMDE_FLOAT16_VALUE( - 33.008),  SIMDE_FLOAT16_VALUE( 90.304),
         SIMDE_FLOAT16_VALUE( - 99.993), SIMDE_FLOAT16_VALUE( - 50.693), SIMDE_FLOAT16_VALUE( - 79.762),  SIMDE_FLOAT16_VALUE(  7.872) },

--- a/test/arm/neon/uzp.c
+++ b/test/arm/neon/uzp.c
@@ -9,9 +9,9 @@ static int
 test_simde_vuzp_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 r[2][4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t r[2][4];
   } test_vec[] = {
     { {  SIMDE_FLOAT16_VALUE( 59.585), SIMDE_FLOAT16_VALUE( - 87.027), SIMDE_FLOAT16_VALUE( - 74.361), SIMDE_FLOAT16_VALUE( - 30.649) },
       {  SIMDE_FLOAT16_VALUE( 93.073), SIMDE_FLOAT16_VALUE( - 31.922),  SIMDE_FLOAT16_VALUE( 17.320), SIMDE_FLOAT16_VALUE( - 55.446) },
@@ -726,9 +726,9 @@ static int
 test_simde_vuzpq_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 r[2][8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t r[2][8];
   } test_vec[] = {
     { {  SIMDE_FLOAT16_VALUE( 73.721),  SIMDE_FLOAT16_VALUE( 46.339), SIMDE_FLOAT16_VALUE( - 10.427), SIMDE_FLOAT16_VALUE( - 38.234),
         SIMDE_FLOAT16_VALUE( - 26.097),  SIMDE_FLOAT16_VALUE( 16.887), SIMDE_FLOAT16_VALUE( - 35.759),  SIMDE_FLOAT16_VALUE( 44.147) },

--- a/test/arm/neon/uzp1.c
+++ b/test/arm/neon/uzp1.c
@@ -7,9 +7,9 @@ static int
 test_simde_vuzp1_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   -49.28), SIMDE_FLOAT16_VALUE(  -109.00), SIMDE_FLOAT16_VALUE(  -626.50), SIMDE_FLOAT16_VALUE(  -567.00) },
       { SIMDE_FLOAT16_VALUE(  -178.88), SIMDE_FLOAT16_VALUE(    10.22), SIMDE_FLOAT16_VALUE(   976.50), SIMDE_FLOAT16_VALUE(   -31.19) },
@@ -481,9 +481,9 @@ static int
 test_simde_vuzp1q_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE( - 97.687), SIMDE_FLOAT16_VALUE( - 79.004), SIMDE_FLOAT16_VALUE( - 89.890),  SIMDE_FLOAT16_VALUE( 40.738),
         SIMDE_FLOAT16_VALUE( - 65.793), SIMDE_FLOAT16_VALUE( - 23.168), SIMDE_FLOAT16_VALUE( -  5.072),  SIMDE_FLOAT16_VALUE( 43.484) },

--- a/test/arm/neon/uzp2.c
+++ b/test/arm/neon/uzp2.c
@@ -7,9 +7,9 @@ static int
 test_simde_vuzp2_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(   -49.28), SIMDE_FLOAT16_VALUE(  -109.00), SIMDE_FLOAT16_VALUE(  -626.50), SIMDE_FLOAT16_VALUE(  -567.00) },
       { SIMDE_FLOAT16_VALUE(  -178.88), SIMDE_FLOAT16_VALUE(    10.22), SIMDE_FLOAT16_VALUE(   976.50), SIMDE_FLOAT16_VALUE(   -31.19) },
@@ -469,9 +469,9 @@ static int
 test_simde_vuzp2q_f16 (SIMDE_MUNIT_TEST_ARGS) {
 #if 1
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { {  SIMDE_FLOAT16_VALUE( 90.452),  SIMDE_FLOAT16_VALUE( 17.701), SIMDE_FLOAT16_VALUE( - 49.009), SIMDE_FLOAT16_VALUE( - 88.786),
         SIMDE_FLOAT16_VALUE( - 29.009), SIMDE_FLOAT16_VALUE( - 37.203), SIMDE_FLOAT16_VALUE( - 58.225),  SIMDE_FLOAT16_VALUE( 98.368) },

--- a/test/arm/neon/zip.c
+++ b/test/arm/neon/zip.c
@@ -8,9 +8,9 @@
 static int
 test_simde_vzip_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 r[2][4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t r[2][4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(-3.80), SIMDE_FLOAT16_VALUE(-6.90), SIMDE_FLOAT16_VALUE(-3.70), SIMDE_FLOAT16_VALUE(-1.00) },
       { SIMDE_FLOAT16_VALUE(-5.20), SIMDE_FLOAT16_VALUE(0.50), SIMDE_FLOAT16_VALUE(-4.20), SIMDE_FLOAT16_VALUE(6.20) },
@@ -613,9 +613,9 @@ test_simde_vzip_u32 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vzipq_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 r[2][8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t r[2][8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(-0.70), SIMDE_FLOAT16_VALUE(-7.80), SIMDE_FLOAT16_VALUE(8.80), SIMDE_FLOAT16_VALUE(1.30), SIMDE_FLOAT16_VALUE(-8.00), SIMDE_FLOAT16_VALUE(-7.10), SIMDE_FLOAT16_VALUE(6.00), SIMDE_FLOAT16_VALUE(-0.60) },
       { SIMDE_FLOAT16_VALUE(3.70), SIMDE_FLOAT16_VALUE(2.20), SIMDE_FLOAT16_VALUE(7.00), SIMDE_FLOAT16_VALUE(7.50), SIMDE_FLOAT16_VALUE(10.00), SIMDE_FLOAT16_VALUE(9.70), SIMDE_FLOAT16_VALUE(-5.30), SIMDE_FLOAT16_VALUE(4.10) },

--- a/test/arm/neon/zip1.c
+++ b/test/arm/neon/zip1.c
@@ -6,9 +6,9 @@
 static int
 test_simde_vzip1_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(8.60), SIMDE_FLOAT16_VALUE(3.70), SIMDE_FLOAT16_VALUE(5.60), SIMDE_FLOAT16_VALUE(5.30) },
       { SIMDE_FLOAT16_VALUE(6.70), SIMDE_FLOAT16_VALUE(-8.40), SIMDE_FLOAT16_VALUE(-9.00), SIMDE_FLOAT16_VALUE(9.10) },
@@ -362,9 +362,9 @@ test_simde_vzip1_u32 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vzip1q_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(-3.60), SIMDE_FLOAT16_VALUE(-4.80), SIMDE_FLOAT16_VALUE(-9.90), SIMDE_FLOAT16_VALUE(9.50), SIMDE_FLOAT16_VALUE(3.20), SIMDE_FLOAT16_VALUE(-6.00), SIMDE_FLOAT16_VALUE(6.60), SIMDE_FLOAT16_VALUE(0.20) },
       { SIMDE_FLOAT16_VALUE(7.00), SIMDE_FLOAT16_VALUE(-1.50), SIMDE_FLOAT16_VALUE(7.00), SIMDE_FLOAT16_VALUE(5.70), SIMDE_FLOAT16_VALUE(9.60), SIMDE_FLOAT16_VALUE(3.50), SIMDE_FLOAT16_VALUE(4.20), SIMDE_FLOAT16_VALUE(-5.30) },

--- a/test/arm/neon/zip2.c
+++ b/test/arm/neon/zip2.c
@@ -6,9 +6,9 @@
 static int
 test_simde_vzip2_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[4];
-    simde_float16 b[4];
-    simde_float16 r[4];
+    simde_float16_t a[4];
+    simde_float16_t b[4];
+    simde_float16_t r[4];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(-7.80), SIMDE_FLOAT16_VALUE(3.70), SIMDE_FLOAT16_VALUE(4.10), SIMDE_FLOAT16_VALUE(5.50) },
       { SIMDE_FLOAT16_VALUE(-6.10), SIMDE_FLOAT16_VALUE(1.40), SIMDE_FLOAT16_VALUE(5.30), SIMDE_FLOAT16_VALUE(4.90) },
@@ -362,9 +362,9 @@ test_simde_vzip2_u32 (SIMDE_MUNIT_TEST_ARGS) {
 static int
 test_simde_vzip2q_f16 (SIMDE_MUNIT_TEST_ARGS) {
   struct {
-    simde_float16 a[8];
-    simde_float16 b[8];
-    simde_float16 r[8];
+    simde_float16_t a[8];
+    simde_float16_t b[8];
+    simde_float16_t r[8];
   } test_vec[] = {
     { { SIMDE_FLOAT16_VALUE(9.60), SIMDE_FLOAT16_VALUE(6.90), SIMDE_FLOAT16_VALUE(7.80), SIMDE_FLOAT16_VALUE(7.90), SIMDE_FLOAT16_VALUE(-5.80), SIMDE_FLOAT16_VALUE(1.70), SIMDE_FLOAT16_VALUE(-8.70), SIMDE_FLOAT16_VALUE(8.20) },
       { SIMDE_FLOAT16_VALUE(1.80), SIMDE_FLOAT16_VALUE(4.00), SIMDE_FLOAT16_VALUE(-1.80), SIMDE_FLOAT16_VALUE(9.70), SIMDE_FLOAT16_VALUE(7.10), SIMDE_FLOAT16_VALUE(4.80), SIMDE_FLOAT16_VALUE(6.70), SIMDE_FLOAT16_VALUE(-0.60) },


### PR DESCRIPTION
Hi there, this is Eric from Andes Technology Corporation.
This PR is to fix the compilation error in https://github.com/simd-everywhere/simde/issues/1099#issue-1968009653, which is caused by the different types `simde_float16` and `simde_float16_t`.