### PR TITLE
ClangCl fixes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -69,6 +69,10 @@ cache:
 init:
   - pwsh: |
       $Env:APPVEYOR_SAVE_CACHE_ON_ERROR = 'true'
+
+on_failure:
+- appveyor PushArtifact build\meson-logs\meson-log.txt
+
 install:
   - cmd: set PATH=%PYTHON_DIR%;%PYTHON_DIR%\scripts;%PATH%
   - cmd: pip install --upgrade ninja meson

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -72,6 +72,7 @@ init:
 
 on_failure:
 - appveyor PushArtifact build\meson-logs\meson-log.txt
+- appveyor PushArtifact build\meson-logs\testlog.txt
 
 install:
   - cmd: set PATH=%PYTHON_DIR%;%PYTHON_DIR%\scripts;%PATH%

--- a/simde/simde-f16.h
+++ b/simde/simde-f16.h
@@ -66,6 +66,7 @@ SIMDE_BEGIN_DECLS_
  * welcome. */
 #if !defined(SIMDE_FLOAT16_API)
   #if !defined(__EMSCRIPTEN__) && !(defined(__clang__) && defined(SIMDE_ARCH_POWER)) && \
+    !(defined(HEDLEY_MSVC_VERSION) && defined(__clang__)) && \
     !(defined(__clang__) && defined(SIMDE_ARCH_RISCV64)) && ( \
       defined(SIMDE_X86_AVX512FP16_NATIVE) || \
       (defined(SIMDE_ARCH_X86_SSE2) && HEDLEY_GCC_VERSION_CHECK(12,0,0)) || \

--- a/simde/simde-features.h
+++ b/simde/simde-features.h
@@ -293,7 +293,7 @@
 #endif
 
 #if !defined(SIMDE_X86_SVML_NATIVE) && !defined(SIMDE_X86_SVML_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
-  #if defined(SIMDE_ARCH_X86) && (defined(__INTEL_COMPILER) || HEDLEY_MSVC_VERSION_CHECK(14, 20, 0))
+  #if defined(SIMDE_ARCH_X86) && (defined(__INTEL_COMPILER) || (HEDLEY_MSVC_VERSION_CHECK(14, 20, 0) && !defined(__clang__)))
     #define SIMDE_X86_SVML_NATIVE
   #endif
 #endif


### PR DESCRIPTION
- appveyor: save meson log on error
- appveyor: preserve test log
- fp16: don't use _Float16 on ClangCL if not supported
- svml: don't enable SIMDE_X86_SVML_NATIVE for ClangCl
