### PR TITLE
apply arm64 windows workaround only on older version msvc

### DIFF
--- a/simde/arm/neon/sqadd.h
+++ b/simde/arm/neon/sqadd.h
@@ -32,7 +32,8 @@
 
 // Workaround on ARM64 windows due to windows SDK bug
 // https://developercommunity.visualstudio.com/t/In-arm64_neonh-vsqaddb_u8-vsqaddh_u16/10271747?sort=newest
-#if (defined _MSC_VER) && (defined SIMDE_ARM_NEON_A64V8_NATIVE)
+#if (defined _MSC_VER) && (defined SIMDE_ARM_NEON_A64V8_NATIVE) && (_MSC_VER < 1938)
+#pragma message ("Due to msvc bug, current version of msvc is supported by workaround. Recommend to update msvc")
 #undef vsqaddb_u8
 #define vsqaddb_u8(src1, src2) neon_usqadds8(__uint8ToN8_v(src1), __int8ToN8_v(src2)).n8_u8[0]
 #undef vsqaddh_u16

--- a/simde/arm/neon/uqadd.h
+++ b/simde/arm/neon/uqadd.h
@@ -35,7 +35,8 @@ SIMDE_BEGIN_DECLS_
 
 // Workaround on ARM64 windows due to windows SDK bug
 // https://developercommunity.visualstudio.com/t/In-arm64_neonh-vsqaddb_u8-vsqaddh_u16/10271747?sort=newest
-#if (defined _MSC_VER) && (defined SIMDE_ARM_NEON_A64V8_NATIVE)
+#if (defined _MSC_VER) && (defined SIMDE_ARM_NEON_A64V8_NATIVE) && (_MSC_VER < 1938)
+#pragma message ("Due to msvc bug, current version of msvc is supported by workaround. Recommend to update msvc")
 #undef vuqaddh_s16
 #define vuqaddh_s16(src1, src2) neon_suqadds16(__int16ToN16_v(src1), __uint16ToN16_v(src2)).n16_i16[0]
 #undef vuqadds_s32


### PR DESCRIPTION
The arm_neo.h bug of msvc is fixed. So that the workaround is not needed on new msvc