### PR TITLE
Improve performance of simde_mm512_add_epi32

### DIFF
--- a/simde/x86/avx512/add.h
+++ b/simde/x86/avx512/add.h
@@ -402,23 +402,7 @@ simde_mm512_add_epi32 (simde__m512i a, simde__m512i b) {
       a_ = simde__m512i_to_private(a),
       b_ = simde__m512i_to_private(b);
 
-    #if defined(SIMDE_ARM_SVE_NATIVE)
-      const size_t n = sizeof(a_.i32) / sizeof(a_.i32[0]);
-      size_t i = 0;
-      svbool_t pg = svwhilelt_b32(i, n);
-      do {
-        svint32_t
-          va = svld1_s32(pg, &(a_.i32[i])),
-          vb = svld1_s32(pg, &(b_.i32[i]));
-        svst1_s32(pg, &(r_.i32[i]), svadd_s32_x(pg, va, vb));
-        i += svcntw();
-        pg = svwhilelt_b32(i, n);
-      } while (svptest_any(svptrue_b32(), pg));
-    #elif SIMDE_NATURAL_VECTOR_SIZE_LE(256)
-      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
-        r_.m256i[i] = simde_mm256_add_epi32(a_.m256i[i], b_.m256i[i]);
-      }
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.i32 = a_.i32 + b_.i32;
     #else
       SIMDE_VECTORIZE


### PR DESCRIPTION
Improve and simplify implementation of `simde_mm512_add_epi32` as follows:

1. Remove the explicit SVE implementation. For SVE vector lengths of VL={128, 256}, this explicit vector length agnostic (VLA) SVE loop performs significantly worse than the Neon equivalent, which can be executed using fewer instructions. This sequence of SVE intrinsics is also malformed according to clang, so it fails to compile altogether.

2. Preferentially use GCC's vector extension if available, instead of repeated calls to `simde_mm256_add_epi32`. There are a couple of reasons for this:

    1. The added indirection results in worse code generation. See the code generation attached to commit message for an example with GCC 13.

    2. GCC's vector extension is an easier optimization target for compilers, allowing them to appropriately output performant code generation depending on their own internal cost & tuning models. See the snippets attached to commit message for an example of improved code-gen in a vector length specific (VLS) context.

This brings the implementation of `simde_mm512_add_epi32` back in line with other similar AVX512 intrinsics, such as `simde_mm512_sub_epi32` and `simde_mm512_mul_ps`.

Fixes #980.