### PR TITLE
Update simde-detect-clang.h for clang 13 detection

### DIFF
--- a/simde/simde-detect-clang.h
+++ b/simde/simde-detect-clang.h
@@ -66,7 +66,7 @@
 #    define SIMDE_DETECT_CLANG_VERSION 150000
 #  elif __has_warning("-Wbitwise-instead-of-logical")
 #    define SIMDE_DETECT_CLANG_VERSION 140000
-#  elif __has_warning("-Wwaix-compat")
+#  elif __has_warning("-Waix-compat")
 #    define SIMDE_DETECT_CLANG_VERSION 130000
 #  elif __has_warning("-Wformat-insufficient-args")
 #    define SIMDE_DETECT_CLANG_VERSION 120000


### PR DESCRIPTION
https://releases.llvm.org/13.0.0/tools/clang/docs/DiagnosticsReference.html#waix-compat

seems to have been incorrectly written in 7bc774fc7087748b8abf2bd6586d2d87df72fe8b

verified working as expected for clang 13 with godbolt: https://godbolt.org/z/cr1YhKv6b