### PR TITLE
Update simde-detect-clang.h for clang 17 detection

### DIFF
--- a/simde/simde-detect-clang.h
+++ b/simde/simde-detect-clang.h
@@ -60,7 +60,9 @@
  */
 
 #if defined(__clang__) && !defined(SIMDE_DETECT_CLANG_VERSION)
-#  if __has_attribute(nouwtable)  // no new warnings in 16.0
+#  if __has_attribute(unsafe_buffer_usage)  // no new warnings in 17.0
+#    define SIMDE_DETECT_CLANG_VERSION 170000
+#  elif __has_attribute(nouwtable)  // no new warnings in 16.0
 #    define SIMDE_DETECT_CLANG_VERSION 160000
 #  elif __has_warning("-Warray-parameter")
 #    define SIMDE_DETECT_CLANG_VERSION 150000


### PR DESCRIPTION
Verified with godbolt:

- when using clang 17, it's 170000: https://godbolt.org/z/MTzb8va48
- when using clang 16, it's 160000: https://godbolt.org/z/8avxvq7rj