### PR TITLE
GitHub Actions emscripten: use older release for now

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*build*
+docker/build*
+sde*
+.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,6 +547,7 @@ jobs:
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo add-apt-repository ppa:savoury1/build-tools
         sudo add-apt-repository ppa:savoury1/display
+        sudo add-apt-repository ppa:savoury1/llvm-defaults-16
         sudo apt-get update
         sudo apt-get -yq install gcovr ninja-build python3-pip clang-${{ matrix.version }}
         sudo python3 -m pip install meson==0.55.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,8 +168,8 @@ jobs:
       run: |
         git clone https://github.com/emscripten-core/emsdk.git /opt/emsdk
         cd /opt/emsdk
-        ./emsdk install tot
-        ./emsdk activate tot
+        ./emsdk install 4e7eadf19c76c143e522b535254eb99a9b34fd6d
+        ./emsdk activate 4e7eadf19c76c143e522b535254eb99a9b34fd6d
         source emsdk_env.sh
     - name: Install v8
       run: |


### PR DESCRIPTION
- docker: ignore common build paths
- gh-actions emscripten: use older release while we wait for https://github.com/emscripten-core/emscripten/issues/21368
