### PR TITLE
arm neon clang: skip vrnd native before clang v18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,6 +657,7 @@ jobs:
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md#xcode
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#xcode
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
         # https://trac.macports.org/wiki/XcodeVersionInfo
         include:
           - xcode: "11.7"
@@ -673,6 +674,10 @@ jobs:
             os: macos-12
           - xcode: "14.2"
             os: macos-13
+          - xcode: "14.3.1"
+            os: macos-14  # arm64
+          - xcode: "15.2"
+            os: macos-14  # arm64
     runs-on: ${{ matrix.os }}
     env:
       DEVELOPER_DIR:  /Applications/Xcode_${{ matrix.xcode }}.app

--- a/simde/arm/neon/rnd32x.h
+++ b/simde/arm/neon/rnd32x.h
@@ -67,7 +67,7 @@ simde_vrnd32x_f32(simde_float32x2_t a) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float64x1_t
 simde_vrnd32x_f64(simde_float64x1_t a) {
-  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_FRINT)
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_FRINT) && (!defined(__clang__) || SIMDE_DETECT_CLANG_VERSION_CHECK(18, 0, 0))
     return vrnd32x_f64(a);
   #else
     simde_float64x1_private
@@ -127,7 +127,7 @@ simde_vrnd32xq_f32(simde_float32x4_t a) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float64x2_t
 simde_vrnd32xq_f64(simde_float64x2_t a) {
-  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_FRINT)
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_FRINT) && (!defined(__clang__) || SIMDE_DETECT_CLANG_VERSION_CHECK(18, 0, 0))
     return vrnd32xq_f64(a);
   #else
     simde_float64x2_private

--- a/simde/arm/neon/rnd32z.h
+++ b/simde/arm/neon/rnd32z.h
@@ -67,7 +67,7 @@ simde_vrnd32z_f32(simde_float32x2_t a) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float64x1_t
 simde_vrnd32z_f64(simde_float64x1_t a) {
-  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_FRINT)
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_FRINT) && (!defined(__clang__) || SIMDE_DETECT_CLANG_VERSION_CHECK(18, 0, 0))
     return vrnd32z_f64(a);
   #else
     simde_float64x1_private
@@ -127,7 +127,7 @@ simde_vrnd32zq_f32(simde_float32x4_t a) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float64x2_t
 simde_vrnd32zq_f64(simde_float64x2_t a) {
-  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_FRINT)
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_FRINT) && (!defined(__clang__) || SIMDE_DETECT_CLANG_VERSION_CHECK(18, 0, 0))
     return vrnd32zq_f64(a);
   #else
     simde_float64x2_private

--- a/simde/arm/neon/rnd64x.h
+++ b/simde/arm/neon/rnd64x.h
@@ -67,7 +67,7 @@ simde_vrnd64x_f32(simde_float32x2_t a) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float64x1_t
 simde_vrnd64x_f64(simde_float64x1_t a) {
-  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_FRINT)
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_FRINT) && (!defined(__clang__) || SIMDE_DETECT_CLANG_VERSION_CHECK(18, 0, 0))
     return vrnd64x_f64(a);
   #else
     simde_float64x1_private
@@ -127,7 +127,7 @@ simde_vrnd64xq_f32(simde_float32x4_t a) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float64x2_t
 simde_vrnd64xq_f64(simde_float64x2_t a) {
-  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_FRINT)
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_FRINT) && (!defined(__clang__) || SIMDE_DETECT_CLANG_VERSION_CHECK(18, 0, 0))
     return vrnd64xq_f64(a);
   #else
     simde_float64x2_private

--- a/simde/arm/neon/rnd64z.h
+++ b/simde/arm/neon/rnd64z.h
@@ -67,7 +67,7 @@ simde_vrnd64z_f32(simde_float32x2_t a) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float64x1_t
 simde_vrnd64z_f64(simde_float64x1_t a) {
-  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_FRINT)
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_FRINT) && (!defined(__clang__) || SIMDE_DETECT_CLANG_VERSION_CHECK(18, 0, 0))
     return vrnd64z_f64(a);
   #else
     simde_float64x1_private
@@ -127,7 +127,7 @@ simde_vrnd64zq_f32(simde_float32x4_t a) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde_float64x2_t
 simde_vrnd64zq_f64(simde_float64x2_t a) {
-  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_FRINT)
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_FRINT) && (!defined(__clang__) || SIMDE_DETECT_CLANG_VERSION_CHECK(18, 0, 0))
     return vrnd64zq_f64(a);
   #else
     simde_float64x2_private

--- a/simde/simde-detect-clang.h
+++ b/simde/simde-detect-clang.h
@@ -60,7 +60,11 @@
  */
 
 #if defined(__clang__) && !defined(SIMDE_DETECT_CLANG_VERSION)
-#  if __has_attribute(unsafe_buffer_usage)  // no new warnings in 17.0
+#  if __has_warning("-Wmissing-designated-field-initializers")
+#    define SIMDE_DETECT_CLANG_VERSION 190000
+#  elif __has_warning("-woverriding-option")
+#    define simde_detect_clang_version 180000
+#  elif __has_attribute(unsafe_buffer_usage)  // no new warnings in 17.0
 #    define SIMDE_DETECT_CLANG_VERSION 170000
 #  elif __has_attribute(nouwtable)  // no new warnings in 16.0
 #    define SIMDE_DETECT_CLANG_VERSION 160000


### PR DESCRIPTION
- clang: detect versions 18 & 19
- arm neon clang: skip vrnd native before clang v18
- gh-actions: test Mac arm64
