### PR TITLE
Packit: Drop i386 (i686) support.

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -19,7 +19,6 @@ jobs:
     # "Motivation and context" for details.
     targets:
       - fedora-rawhide-x86_64
-      - fedora-rawhide-i386
       - fedora-rawhide-aarch64
       - fedora-rawhide-ppc64le
       - fedora-rawhide-s390x

--- a/.packit/ci.sh
+++ b/.packit/ci.sh
@@ -116,7 +116,6 @@ MATRIX_DEFAULT_CLANG_O2="exclude"
 MATRIX_DEFAULT_CLANG_RPM="exclude"
 # Set the CPU specific behavior for each test optionally.
 # This configuration is prioritized than the default behavior.
-MATRIX_i686_GCC_DEFAULT="pend"
 
 # End of configuration
 


### PR DESCRIPTION
We don't maintain the i386 (i686) case on Packit CI any more due to a limitation of the human power.

Note that the i386 (i686) case is a kind of deprecated state in Fedora project. See the following links for details.

* https://fedoraproject.org/wiki/Changes/EncourageI686LeafRemoval
* https://fedoramagazine.org/in-fedora-31-32-bit-i686-is-86ed/