### PR TITLE
README.md - move CLMUL to partial, list more of the CI.yml architectures

### DIFF
--- a/.packit/simde.spec
+++ b/.packit/simde.spec
@@ -11,7 +11,7 @@ License: MIT
 URL: https://github.com/simd-everywhere/simde
 # This value is magically replaced with the archive tar.gz file created by
 # `git archive` in the process of the CI.
-# Set the exsiting file `README.md` in case of creating SRPM from this RPM spec
+# Set the existing file `README.md` in case of creating SRPM from this RPM spec
 # file on local for testing purpose.
 Source0: README.md
 # A path to the CI script.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ set extensions:
   * [F16C](https://en.wikipedia.org/wiki/F16C) [List](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#avxnewtechs=F16C)
   * [FMA](https://en.wikipedia.org/wiki/FMA_instruction_set) [List](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#avxnewtechs=FMA)
   * [GFNI](https://en.wikipedia.org/wiki/AVX-512#GFNI) [List](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#othertechs=GFNI)
-  * [CLMUL](https://en.wikipedia.org/wiki/CLMUL_instruction_set) [List](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=clmul&ig_expand=770&othertechs=PCLMULQDQ,VPCLMULQDQ)
   * [XOP](https://en.wikipedia.org/wiki/XOP_instruction_set)
   * [SVML](https://software.intel.com/content/www/us/en/develop/documentation/cpp-compiler-developer-guide-and-reference/top/compiler-reference/intrinsics/intrinsics-for-intel-advanced-vector-extensions-512-intel-avx-512-instructions/intrinsics-for-arithmetic-operations-1/intrinsics-for-short-vector-math-library-svml-operations.html) [List](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#ig_expand=770&techs=SVML)
   * [AVX512VPOPCNTDQ](https://en.wikipedia.org/wiki/AVX-512#VPOPCNTDQ_and_BITALG) [List](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#ig_expand=7131&avx512techs=AVX512VPOPCNTDQ)
@@ -92,7 +91,7 @@ set extensions:
 * WebAssembly
   * [SIMD128](https://github.com/WebAssembly/simd)
 
-As well as partial support for many others, including AES-ni, SSE4.2, SVE, [MSA](https://en.wikipedia.org/wiki/MIPS_architecture#Application-specific_extensions) in
+As well as partial support for many others, including AES-ni, [CLMUL](https://en.wikipedia.org/wiki/CLMUL_instruction_set), SSE4.2, SVE, [MSA](https://en.wikipedia.org/wiki/MIPS_architecture#Application-specific_extensions) in
 addition to several AVX-512 extensions.  See the
 [instruction-set-support](https://github.com/simd-everywhere/simde/issues?q=is%3Aissue+is%3Aopen+label%3Ainstruction-set-support+sort%3Aupdated-desc)
 label in the issue tracker for details on progress.  If you'd like to
@@ -276,13 +275,17 @@ isn't an option then other CI platforms can be added.
 
 The following architectures are tested in CI for every commit:
 
- * x86_64
+ * x86_64/amd64
  * x86
  * AArch64
  * ARMv8
- * ARMv7
+ * ARMv7 with VFPv3-D16 floating point
+ * ARMv5 EABI
  * PPC64
- * MIPS Loongson
+ * z/Architecture (with "-mzvector")
+ * MIPS Loongson 64
+ * RISC-V 64
+ * emscripten 32- & 64-bit; regular and relaxed
 
 We would love to add more, so patches are extremely welcome!
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,7 +15,7 @@ Once the container is ready it will drop you into a bash shell in
 `/opt/simde`; this is the build directory.
 
 This will bind the parent directory (the root of the SIMDe checkout)
-to `/usr/local/src/simde`; any changes to either will propogate to the
+to `/usr/local/src/simde`; any changes to either will propagate to the
 other, meaning you can continue using your normal development
 environment and just re-run ninja in the container to (re)build SIMDe.
 

--- a/simde/simde-align.h
+++ b/simde/simde-align.h
@@ -11,7 +11,7 @@
  **********************************************************************
  *
  * This is portability layer which should help iron out some
- * differences across various compilers, as well as various verisons of
+ * differences across various compilers, as well as various versions of
  * C and C++.
  *
  * It was originally developed for SIMD Everywhere
@@ -55,7 +55,7 @@
 #include "hedley.h"
 
 /* I know this seems a little silly, but some non-hosted compilers
- * don't have stddef.h, so we try to accomodate them. */
+ * don't have stddef.h, so we try to accommodate them. */
 #if !defined(SIMDE_ALIGN_SIZE_T_)
   #if defined(__SIZE_TYPE__)
     #define SIMDE_ALIGN_SIZE_T_ __SIZE_TYPE__
@@ -405,7 +405,7 @@
 
 /* SIMDE_ALIGN_ASSUME_LIKE(Pointer, Type)
  *
- * Tihs is similar to SIMDE_ALIGN_ASSUME_TO, except that it takes a
+ * This is similar to SIMDE_ALIGN_ASSUME_TO, except that it takes a
  * type instead of a numeric value. */
 #if defined(SIMDE_ALIGN_OF) && defined(SIMDE_ALIGN_ASSUME_TO)
   #define SIMDE_ALIGN_ASSUME_LIKE(Pointer, Type) SIMDE_ALIGN_ASSUME_TO(Pointer, SIMDE_ALIGN_OF(Type))

--- a/simde/simde-complex.h
+++ b/simde/simde-complex.h
@@ -26,7 +26,7 @@
 
 /* Support for complex math.
  *
- * We try to avoid inculding <complex> (in C++ mode) since it pulls in
+ * We try to avoid including <complex> (in C++ mode) since it pulls in
  * a *lot* of code.  Unfortunately this only works for GNU modes (i.e.,
  * -std=gnu++14 not -std=c++14) unless you pass -fext-numeric-literals,
  * but there is no way (AFAICT) to detect that flag so we have to rely

--- a/simde/simde-diagnostic.h
+++ b/simde/simde-diagnostic.h
@@ -272,7 +272,7 @@
   #define SIMDE_DIAGNOSTIC_DISABLE_CAST_FUNCTION_TYPE_
 #endif
 
-/* clang will emit this warning when we use C99 extensions whan not in
+/* clang will emit this warning when we use C99 extensions when not in
  * C99 mode, even though it does support this.  In such cases we check
  * the compiler and version first, so we know it's not a problem. */
 #if HEDLEY_HAS_WARNING("-Wc99-extensions")

--- a/simde/simde-f16.h
+++ b/simde/simde-f16.h
@@ -58,7 +58,7 @@ SIMDE_BEGIN_DECLS_
  * that on Arm since it would break compatibility with the NEON F16
  * functions. */
 #define SIMDE_FLOAT16_API_FP16_NO_ABI 3
-/* This is basically __fp16 as specified by Arm, where arugments and
+/* This is basically __fp16 as specified by Arm, where arguments and
  * return values are raw __fp16 values not structs. */
 #define SIMDE_FLOAT16_API_FP16 4
 

--- a/simde/x86/avx512/xorsign.h
+++ b/simde/x86/avx512/xorsign.h
@@ -26,7 +26,7 @@
  */
 
 /* This is a SIMDe extension which is not part of AVX-512.  It exists
- * because a lot of numerical methods in SIMDe have algoriths which do
+ * because a lot of numerical methods in SIMDe have algorithms which do
  * something like:
  *
  *   float sgn = input < 0 ? -1 : 1;

--- a/simde/x86/sse.h
+++ b/simde/x86/sse.h
@@ -804,7 +804,7 @@ simde_mm_move_ss (simde__m128 a, simde__m128 b) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128
 simde_x_mm_broadcastlow_ps(simde__m128 a) {
-  /* This function broadcasts the first element in the inpu vector to
+  /* This function broadcasts the first element in the input vector to
    * all lanes.  It is used to avoid generating spurious exceptions in
    * *_ss functions since there may be garbage in the upper lanes. */
 

--- a/test/x86/f16c.c
+++ b/test/x86/f16c.c
@@ -54,7 +54,7 @@ test_simde_mm_cvtps_ph (SIMDE_MUNIT_TEST_ARGS) {
       {  INT16_C( 25352),  INT16_C( 24774), -INT16_C(  8787),  INT16_C( 25507),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0) } },
 
     #if 0
-    // simde_mm_cvtps_ph doesn't handle the rounding paramter at all
+    // simde_mm_cvtps_ph doesn't handle the rounding parameter at all
     { { SIMDE_FLOAT32_C(  9204.05), SIMDE_FLOAT32_C( 86132.80), SIMDE_FLOAT32_C( 37121.74), SIMDE_FLOAT32_C( 68581.13) },
       {  INT16_C( 28799),  INT16_C( 31744),  INT16_C( 30856),  INT16_C( 31744),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0) },
       {  INT16_C( 28798),  INT16_C( 31743),  INT16_C( 30856),  INT16_C( 31743),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0),  INT16_C(     0) },


### PR DESCRIPTION
Per https://github.com/simd-everywhere/simde/pull/1152#issuecomment-2021047051

Should the following two architectures also be added?
- ARMv8 SVE - it's in [simde-features.h](https://github.com/simd-everywhere/simde/blob/b88a66de3a7de7a16099ab28019bc566e4468b82/simde/simde-features.h), but I couldn't find it in ci.yml
- z/Architecture **ZVECTOR** - it's in simde-features.h, but ci.yml just lists s390x, so unclear if ZVECTOR extensions are utilized