### PR TITLE
arm: enable more intrinsic function for armv7

### DIFF
--- a/simde/arm/neon/ld2_lane.h
+++ b/simde/arm/neon/ld2_lane.h
@@ -285,10 +285,10 @@ simde_int16x8x2_t simde_vld2q_lane_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(2)],
   }
   return r;
 }
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vld2q_lane_s16(ptr, src, lane) vld2q_lane_s16(ptr, src, lane)
 #endif
-#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld2q_lane_s16
   #define vld2q_lane_s16(ptr, src, lane) simde_vld2q_lane_s16((ptr), (src), (lane))
 #endif
@@ -365,10 +365,10 @@ simde_uint16x8x2_t simde_vld2q_lane_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(2)
   }
   return r;
 }
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vld2q_lane_u16(ptr, src, lane) vld2q_lane_u16(ptr, src, lane)
 #endif
-#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld2q_lane_u16
   #define vld2q_lane_u16(ptr, src, lane) simde_vld2q_lane_u16((ptr), (src), (lane))
 #endif
@@ -564,10 +564,10 @@ simde_poly16x8x2_t simde_vld2q_lane_p16(simde_poly16_t const ptr[HEDLEY_ARRAY_PA
   }
   return r;
 }
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vld2q_lane_p16(ptr, src, lane) vld2q_lane_p16(ptr, src, lane)
 #endif
-#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld2q_lane_p16
   #define vld2q_lane_p16(ptr, src, lane) simde_vld2q_lane_p16((ptr), (src), (lane))
 #endif

--- a/simde/arm/neon/ld3.h
+++ b/simde/arm/neon/ld3.h
@@ -268,7 +268,7 @@ simde_vld3_s64(int64_t const *ptr) {
     return r;
   #endif
 }
-#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld3_s64
   #define vld3_s64(a) simde_vld3_s64((a))
 #endif
@@ -400,7 +400,7 @@ simde_vld3_u64(uint64_t const *ptr) {
     return r;
   #endif
 }
-#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld3_u64
   #define vld3_u64(a) simde_vld3_u64((a))
 #endif

--- a/simde/arm/neon/ld3_lane.h
+++ b/simde/arm/neon/ld3_lane.h
@@ -285,10 +285,10 @@ simde_int16x8x3_t simde_vld3q_lane_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(3)],
   }
   return r;
 }
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vld3q_lane_s16(ptr, src, lane) vld3q_lane_s16(ptr, src, lane)
 #endif
-#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld3q_lane_s16
   #define vld3q_lane_s16(ptr, src, lane) simde_vld3q_lane_s16((ptr), (src), (lane))
 #endif
@@ -365,10 +365,10 @@ simde_uint16x8x3_t simde_vld3q_lane_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(3)
   }
   return r;
 }
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vld3q_lane_u16(ptr, src, lane) vld3q_lane_u16(ptr, src, lane)
 #endif
-#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld3q_lane_u16
   #define vld3q_lane_u16(ptr, src, lane) simde_vld3q_lane_u16((ptr), (src), (lane))
 #endif
@@ -564,10 +564,10 @@ simde_poly16x8x3_t simde_vld3q_lane_p16(simde_poly16_t const ptr[HEDLEY_ARRAY_PA
   }
   return r;
 }
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vld3q_lane_p16(ptr, src, lane) vld3q_lane_p16(ptr, src, lane)
 #endif
-#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld3q_lane_p16
   #define vld3q_lane_p16(ptr, src, lane) simde_vld3q_lane_p16((ptr), (src), (lane))
 #endif

--- a/simde/arm/neon/ld4.h
+++ b/simde/arm/neon/ld4.h
@@ -232,7 +232,7 @@ simde_vld4_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return s_;
   #endif
 }
-#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld4_s64
   #define vld4_s64(a) simde_vld4_s64((a))
 #endif
@@ -344,7 +344,7 @@ simde_vld4_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return s_;
   #endif
 }
-#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld4_u64
   #define vld4_u64(a) simde_vld4_u64((a))
 #endif

--- a/simde/arm/neon/st3.h
+++ b/simde/arm/neon/st3.h
@@ -283,7 +283,7 @@ simde_vst3_s64(int64_t ptr[HEDLEY_ARRAY_PARAM(3)], simde_int64x1x3_t val) {
     #endif
   #endif
 }
-#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vst3_s64
   #define vst3_s64(a, b) simde_vst3_s64((a), (b))
 #endif
@@ -440,7 +440,7 @@ simde_vst3_u64(uint64_t ptr[HEDLEY_ARRAY_PARAM(3)], simde_uint64x1x3_t val) {
     #endif
   #endif
 }
-#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vst3_u64
   #define vst3_u64(a, b) simde_vst3_u64((a), (b))
 #endif

--- a/simde/arm/neon/st4.h
+++ b/simde/arm/neon/st4.h
@@ -236,7 +236,7 @@ simde_vst4_s64(int64_t *ptr, simde_int64x1x4_t val) {
     #endif
   #endif
 }
-#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vst4_s64
   #define vst4_s64(a, b) simde_vst4_s64((a), (b))
 #endif
@@ -352,7 +352,7 @@ simde_vst4_u64(uint64_t *ptr, simde_uint64x1x4_t val) {
     #endif
   #endif
 }
-#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vst4_u64
   #define vst4_u64(a, b) simde_vst4_u64((a), (b))
 #endif

--- a/simde/arm/neon/types.h
+++ b/simde/arm/neon/types.h
@@ -1291,6 +1291,8 @@ typedef union {
 #endif
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   typedef   simde_float32_t     float32_t;
+  typedef     simde_poly8_t       poly8_t;
+  typedef    simde_poly16_t      poly16_t;
 
   typedef    simde_int8x8_t      int8x8_t;
   typedef   simde_int16x4_t     int16x4_t;


### PR DESCRIPTION
Hi, I run the arm-neon-tests (https://github.com/christophe-lyon/arm-neon-tests) for simde neon2rvv, and have set the flags `-DSIMDE_RISCV_V_NATIVE -DSIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES` to compiler. But I get some compiler reported errors as follow, it means that vld4_s6 is not supported  in simde neon2rvv.
```
ref_vldX.c:200:3: error: call to undeclared function 'vld4_s64'; ISO C99 and later do not support implicit function declarations 
```

As I know，vld4_s64 and the other intrinsic function which are mentioned in my patch are supported in armv7 platform.  But simde disable them in armv7 platform.  So I upload the patch to enable those intrinsic function in armv7 platform. Please help to review, thanks.
