### PR TITLE
Use 128 bit fnmadd_pd to do 256 bit fnmadd_pd

### DIFF
--- a/simde/x86/fma.h
+++ b/simde/x86/fma.h
@@ -464,11 +464,16 @@ simde_mm256_fnmadd_pd (simde__m256d a, simde__m256d b, simde__m256d c) {
       b_ = simde__m256d_to_private(b),
       c_ = simde__m256d_to_private(c);
 
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-      r_.f64[i] = -(a_.f64[i] * b_.f64[i]) + c_.f64[i];
-    }
-
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_fnmadd_pd(a_.m128d[i], b_.m128d[i], c_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = -(a_.f64[i] * b_.f64[i]) + c_.f64[i];
+      }
+    #endif
     return simde__m256d_from_private(r_);
   #endif
 }


### PR DESCRIPTION
When building x86_64 intrinsics for arm64 (armv8.2) using gcc 10 and 11 with -O2, we observed poor performance in some math functions. One of the reasons turned out to be how `_mm256_fnmadd_pd` was being compiled. I made a simple test case for further evaluation:
```cpp
void fma_test(__m256d a, __m256d b, __m256d c, __m256d* d) { *d = _mm256_fnmadd_pd(a, b, c); }
```

With our default settings `-O2 -march=armv8.2-a` on gcc 10, this compiled to the following:
```
0000000000000000 <fma_test(double __vector(4), double __vector(4), double __vector(4), double __vector(4)*)>:
   0:   d102c3ff        sub     sp, sp, #0xb0
   4:   aa0103e6        mov     x6, x1
   8:   9100ffe5        add     x5, sp, #0x3f
   c:   d2800024        mov     x4, #0x1                        // #1
  10:   927be8a5        and     x5, x5, #0xffffffffffffffe0
  14:   910100a9        add     x9, x5, #0x40
  18:   910080a8        add     x8, x5, #0x20
  1c:   a9402c0a        ldp     x10, x11, [x0]
  20:   a9042caa        stp     x10, x11, [x5, #64]
  24:   910180a7        add     x7, x5, #0x60
  28:   a940342c        ldp     x12, x13, [x1]
  2c:   a90234ac        stp     x12, x13, [x5, #32]
  30:   a9402c4a        ldp     x10, x11, [x2]
  34:   a9002caa        stp     x10, x11, [x5]
  38:   a9410400        ldp     x0, x1, [x0, #16]
  3c:   a9010520        stp     x0, x1, [x9, #16]
  40:   a9412c4a        ldp     x10, x11, [x2, #16]
  44:   a9012caa        stp     x10, x11, [x5, #16]
  48:   a94104c0        ldp     x0, x1, [x6, #16]
  4c:   a9010500        stp     x0, x1, [x8, #16]
  50:   d37df080        lsl     x0, x4, #3
  54:   8b000126        add     x6, x9, x0
  58:   8b000102        add     x2, x8, x0
  5c:   8b0000a1        add     x1, x5, x0
  60:   8b0000e0        add     x0, x7, x0
  64:   91000484        add     x4, x4, #0x1
  68:   fc5f8041        ldur    d1, [x2, #-8]
  6c:   fc5f80c2        ldur    d2, [x6, #-8]
  70:   fc5f8020        ldur    d0, [x1, #-8]
  74:   1f418040        fmsub   d0, d2, d1, d0
  78:   fc1f8000        stur    d0, [x0, #-8]
  7c:   f100149f        cmp     x4, #0x5
  80:   54fffe81        b.ne    50 <fma_test(double __vector(4), double __vector(4), double __vector(4), double __vector(4)*)+0x50>  // b.any
  84:   a94004e0        ldp     x0, x1, [x7]
  88:   a9000460        stp     x0, x1, [x3]
  8c:   a94104e0        ldp     x0, x1, [x7, #16]
  90:   a9010460        stp     x0, x1, [x3, #16]
  94:   9102c3ff        add     sp, sp, #0xb0
  98:   d65f03c0        ret
```

With `-O3`, it compiles to this much simpler sequence
```
   0:   ad400c04        ldp     q4, q3, [x0]
   4:   d10143ff        sub     sp, sp, #0x50
   8:   ad400825        ldp     q5, q2, [x1]
   c:   9100ffe4        add     x4, sp, #0x3f
  10:   ad400041        ldp     q1, q0, [x2]
  14:   927be884        and     x4, x4, #0xffffffffffffffe0
  18:   4ee4cca1        fmls    v1.2d, v5.2d, v4.2d
  1c:   4ee2cc60        fmls    v0.2d, v3.2d, v2.2d
  20:   3d800061        str     q1, [x3]
  24:   3d800460        str     q0, [x3, #16]
  28:   ad000081        stp     q1, q0, [x4]
  2c:   910143ff        add     sp, sp, #0x50
  30:   d65f03c0        ret
```

This change produces the expected behavior with -O2 (other optimization levels not tested). I used the `_mm256_fmadd_ps` implementation as a reference for how to structure the code / `#if`'s. With this change, the disassembly looks almost exactly like the `-O3` version:
```
0000000000000000 <fma_test(double __vector(4), double __vector(4), double __vector(4), double __vector(4)*)>:
   0:   ad400c05        ldp     q5, q3, [x0]
   4:   d10143ff        sub     sp, sp, #0x50
   8:   ad400824        ldp     q4, q2, [x1]
   c:   9100ffe4        add     x4, sp, #0x3f
  10:   ad400041        ldp     q1, q0, [x2]
  14:   927be884        and     x4, x4, #0xffffffffffffffe0
  18:   4ee4cca1        fmls    v1.2d, v5.2d, v4.2d
  1c:   4ee2cc60        fmls    v0.2d, v3.2d, v2.2d
  20:   3d800061        str     q1, [x3]
  24:   3d800460        str     q0, [x3, #16]
  28:   ad000081        stp     q1, q0, [x4]
  2c:   910143ff        add     sp, sp, #0x50
  30:   d65f03c0        ret
```

## Other intrinsics
I looked at the behavior of `_mm256_fmadd_pd`, because it also doesn't directly use `_mm_fmadd_pd`. However, at least with `-O2`, my compiler still outputs the "efficient" version with no changes needed.

I haven't looked at `_mm256_fmsub_pd` or any others. If this approach / style is correct, I can test how those behave and make equivalent changes.