### PR TITLE
Substitution for MemoryBarrier() to avoid including <windows.h>

### DIFF
--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -4776,7 +4776,7 @@ simde_mm_pause (void) {
     #endif
   #elif defined(SIMDE_ARCH_ARM_NEON)
     #if defined(_MSC_VER)
-      __isb(_ARM64_BARRIER_SY);
+      __isb(SIMDE_ARM64_BARRIER_SY);
     #else
       __asm__ __volatile__("isb\n");
     #endif


### PR DESCRIPTION
Preprocessor checks should probably be substituted with SIMDE_* alternatives, but I'm not very familiar with these, so it could use a review. #1193 