### PR TITLE
wasm NEON and AltiVec: add u16x8 and u8x16 avgr translations

### DIFF
--- a/simde/wasm/simd128.h
+++ b/simde/wasm/simd128.h
@@ -5785,6 +5785,8 @@ simde_wasm_u8x16_avgr (simde_v128_t a, simde_v128_t b) {
 
     #if defined(SIMDE_X86_SSE2_NATIVE)
       r_.sse_m128i = _mm_avg_epu8(a_.sse_m128i, b_.sse_m128i);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vrhaddq_u8(a_.neon_u8, b_.neon_u8);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
@@ -5812,6 +5814,8 @@ simde_wasm_u16x8_avgr (simde_v128_t a, simde_v128_t b) {
 
     #if defined(SIMDE_X86_SSE2_NATIVE)
       r_.sse_m128i = _mm_avg_epu16(a_.sse_m128i, b_.sse_m128i);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vrhaddq_u16(a_.neon_u16, b_.neon_u16);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {

--- a/simde/wasm/simd128.h
+++ b/simde/wasm/simd128.h
@@ -5787,6 +5787,8 @@ simde_wasm_u8x16_avgr (simde_v128_t a, simde_v128_t b) {
       r_.sse_m128i = _mm_avg_epu8(a_.sse_m128i, b_.sse_m128i);
     #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_u8 = vrhaddq_u8(a_.neon_u8, b_.neon_u8);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_u8 = vec_avg(a_.altivec_u8, b_.altivec_u8);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
@@ -5816,6 +5818,8 @@ simde_wasm_u16x8_avgr (simde_v128_t a, simde_v128_t b) {
       r_.sse_m128i = _mm_avg_epu16(a_.sse_m128i, b_.sse_m128i);
     #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_u16 = vrhaddq_u16(a_.neon_u16, b_.neon_u16);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_u16 = vec_avg(a_.altivec_u16, b_.altivec_u16);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {


### PR DESCRIPTION
This PR provides WASM to NEON translations from `wasm_u16x8_avgr` to `vrhaddq_u16` and `wasm_u8x16_avgr` to `vrhaddq_u8`. 

I also tested these locally on a Mac Mini M1. 

Something worth noting here is that the AltiVec translation may also work, but I haven't tested it on a physical device.
Here is what that change looks like: https://github.com/wrv/simde/commit/ff4e85ac47e538aff820514ff728ca3fa6382a9a
And the GH Actions result on that change: https://github.com/wrv/simde/actions/runs/10461140123  

If that looks alright, I can add it to this PR.