### PR TITLE
work around test compilation error with clang on aarch64

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -58,6 +58,10 @@ if cxx.get_id() == 'intel'
   simde_native_cxx_flags += '-DSIMDE_FAST_MATH'
 endif
 
+if target_machine.cpu_family() == 'aarch64' and cc.get_id() == 'clang'
+  simde_native_c_flags += '-mcrc'
+endif
+
 if not c_openmp_simd
   simde_deps += dependency('openmp', required: false)
 endif


### PR DESCRIPTION
Fixes #1200 :

```
In file included from ../../test/arm/neon/crc32.c:4:
../../test/arm/neon/../../../simde/arm/neon/crc32.h:59:12: error: always_inline function '__crc32b' requires target feature 'crc', but would
 be inlined into function 'simde___crc32b' that is compiled without support for 'crc'
```