### PR TITLE
x86/sse: Fix type convert error for LSX.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -881,40 +881,23 @@ jobs:
 
   linux-gcc-loongarch64:
     runs-on: ubuntu-24.04
+    container: amd64/ubuntu:24.10
     steps:
     - uses: actions/checkout@v4
     - name: CPU Information
       run: cat /proc/cpuinfo
     - name: Install APT Dependencies
       run: |
-        sudo apt-get install -y ninja-build ninja-build meson qemu-user-static
-    - name: Download and install loongarch64-toolchain
-      run: |
-        wget https://github.com/loongson/build-tools/releases/download/2022.09.06/loongarch64-clfs-7.3-cross-tools-gcc-glibc.tar.xz
-        tar -xf loongarch64-clfs-7.3-cross-tools-gcc-glibc.tar.xz -C /opt
+        apt-get update && apt-get install -y --no-install-recommends \
+          ninja-build ninja-build meson qemu-user-static binfmt-support \
+          libc6-loong64-cross libstdc++-14-dev-loong64-cross \
+          gcc-14-loongarch64-linux-gnu g++-14-loongarch64-linux-gnu
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
-        key: ${{ github.job }}-loongarch64-gcc-13
-    - name: set env
-      run: |
-        echo "LD_LIBRARY_PATH=/opt/cross-tools/target/usr/lib64:/opt/cross-tools/loongarch64-unknown-linux-gnu/lib64:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        echo "PATH=$GITHUB_WORKSPACE:/opt/cross-tools/bin:$PATH" >> $GITHUB_ENV
-    - name: Disable SVML tests
-      run: |
-        sed -i "/svml/d" test/x86/meson.build
-        rm test/x86/svml.c
-        echo "Due to the qemu versions 7.2 through 8.0 causing timeouts in four sets of test cases,"
-        echo "the SVML tests have been temporarily disabled."
-    - name: Disable RND*X tests
-      run: |
-        sed -i "/rndx/d" meson.build
-        sed -i "/rnd..x/d" meson.build
-        rm test/arm/neon/rndx.c test/arm/neon/rnd32x.c test/arm/neon/rnd64x.c
-        echo "Due to the qemu versions 7.2 through 8.0 causing timeouts in four sets of test cases,"
-        echo "the RNDX, RND32X, and RND64X tests have been temporarily disabled."
+        key: ${{ github.job }}-gcc-14
     - name: Configure
-      run: meson setup build --cross-file=docker/cross-files/loongarch64-gcc-13-ccache.cross
+      run: meson setup build --cross-file=docker/cross-files/loongarch64-gcc-14-ccache.cross || (cat build/meson-logs/meson-log.txt ; false)
     - name: Build
       run: meson compile -C build -v
     - name: Test

--- a/docker/cross-files/loongarch64-gcc-14-ccache.cross
+++ b/docker/cross-files/loongarch64-gcc-14-ccache.cross
@@ -1,0 +1,20 @@
+[binaries]
+c = ['ccache', 'loongarch64-linux-gnu-gcc-14']
+cpp = ['ccache', 'loongarch64-linux-gnu-g++-14']
+ar = 'loongarch64-linux-gnu-gcc-ar-14'
+strip = 'loongarch64-linux-gnu-strip'
+objcopy = 'loongarch64-linux-gnu-objcopy'
+ld = 'loongarch64-linux-gnu-ld'
+exe_wrapper = ['qemu-loongarch64-static', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
+
+[properties]
+c_args = ['-march=loongarch64', '-Wextra', '-Werror', '-mlsx']
+cpp_args = ['-march=loongarch64', '-Wextra', '-Werror', '-mlsx']
+#c_args = ['-march=la464', '-Wextra', '-Werror']
+#cpp_args = ['-march=la464', '-Wextra', '-Werror']
+
+[host_machine]
+system = 'linux'
+cpu_family = 'loongarch64'
+cpu = 'loongarch64'
+endian = 'little'

--- a/simde/x86/sse.h
+++ b/simde/x86/sse.h
@@ -674,7 +674,7 @@ simde_x_mm_round_ps (simde__m128 a, int rounding, int lax_rounding)
       #elif defined(SIMDE_ARM_NEON_A32V8_NATIVE)
         r_.neon_f32 = vrndnq_f32(a_.neon_f32);
       #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
-        r_.lsx_i64 = __lsx_vfrintrne_s(a_.lsx_f32);
+        r_.lsx_f32 = __lsx_vfrintrne_s(a_.lsx_f32);
       #elif defined(SIMDE_WASM_SIMD128_NATIVE)
         r_.wasm_v128 = wasm_f32x4_nearest(a_.wasm_v128);
       #elif defined(simde_math_roundevenf)
@@ -693,7 +693,7 @@ simde_x_mm_round_ps (simde__m128 a, int rounding, int lax_rounding)
       #elif defined(SIMDE_ARM_NEON_A32V8_NATIVE)
         r_.neon_f32 = vrndmq_f32(a_.neon_f32);
       #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
-        r_.lsx_i64 = __lsx_vfrintrm_s(a_.lsx_f32);
+        r_.lsx_f32 = __lsx_vfrintrm_s(a_.lsx_f32);
       #elif defined(SIMDE_WASM_SIMD128_NATIVE)
         r_.wasm_v128 = wasm_f32x4_floor(a_.wasm_v128);
       #elif defined(simde_math_floorf)
@@ -712,7 +712,7 @@ simde_x_mm_round_ps (simde__m128 a, int rounding, int lax_rounding)
       #elif defined(SIMDE_ARM_NEON_A32V8_NATIVE)
         r_.neon_f32 = vrndpq_f32(a_.neon_f32);
       #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
-        r_.lsx_i64 = __lsx_vfrintrp_s(a_.lsx_f32);
+        r_.lsx_f32 = __lsx_vfrintrp_s(a_.lsx_f32);
       #elif defined(SIMDE_WASM_SIMD128_NATIVE)
         r_.wasm_v128 = wasm_f32x4_ceil(a_.wasm_v128);
       #elif defined(simde_math_ceilf)
@@ -731,7 +731,7 @@ simde_x_mm_round_ps (simde__m128 a, int rounding, int lax_rounding)
       #elif defined(SIMDE_ARM_NEON_A32V8_NATIVE)
         r_.neon_f32 = vrndq_f32(a_.neon_f32);
       #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
-        r_.lsx_i64 = __lsx_vfrintrz_s(a_.lsx_f32);
+        r_.lsx_f32 = __lsx_vfrintrz_s(a_.lsx_f32);
       #elif defined(SIMDE_WASM_SIMD128_NATIVE)
         r_.wasm_v128 = wasm_f32x4_trunc(a_.wasm_v128);
       #elif defined(simde_math_truncf)


### PR DESCRIPTION
When compile webkitgtk-2.45.92, failed with following error:
webkitgtk-2.45.92/Source/WTF/wtf/simde/arm/neon.h:92893:38: 错误：cannot convert ‘__m128’ to ‘v2i64’ in assignment
92893 |         r_.lsx_i64 = __lsx_vfrintrm_s(a_.lsx_f32);
      |                      ~~~~~~~~~~~~~~~~^~~~~~~~~~~~
      |                                      |
      |                                      __m128