### PR TITLE
loongarch float16: use a portable version to avoid compilation errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,6 +609,11 @@ jobs:
         #   arch_gnu: mips64el
         #   arch_gnu_abi: abi64
         #   distro: ubuntu-24.04
+        - version: 18
+          cross: loongarch64
+          arch_deb: loong64
+          arch_gnu: loongarch64
+          distro: ubuntu-24.04
     runs-on: ${{ matrix.distro }}
     steps:
     - uses: actions/checkout@v4
@@ -620,9 +625,10 @@ jobs:
     - name: Install APT Dependencies
       run: |
         sudo apt-get update -y
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa && \
         sudo apt-get -yq install ninja-build parallel \
           binfmt-support clang-${{ matrix.version }} clang++-${{ matrix.version }} \
-          qemu-user-static pipx libc6-${{ matrix.arch_deb }}-cross libstdc++-12-dev-${{ matrix.arch_deb }}-cross \
+          qemu-user-static pipx libc6-${{ matrix.arch_deb }}-cross libstdc++-14-dev-${{ matrix.arch_deb }}-cross \
           binutils-${{ matrix.arch_gnu }}-linux-gnu${{ matrix.arch_gnu_abi }}
         pipx install meson==0.55.1
     - name: ccache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         fetch-depth: 2
     - name: Install APT Dependencies
       run: |
-        sudo apt-get install -y ninja-build ninja-build pipx
+        sudo apt-get install -y --no-install-recommends ninja-build ninja-build pipx
         pipx install meson==0.55.1
     - run: |
         meson setup build --prefix $PWD/install -Dtests=false
@@ -37,7 +37,7 @@ jobs:
       with:
         fetch-depth: 2
     - name: Install pcre2grep
-      run: sudo apt-get update && sudo apt-get install -y pcre2-utils
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends pcre2-utils
     # Check for trailing whitespace
     - name: Trailing whitespace
       run: find simde/ \( -name '*.c' -o -name '*.h' \) -exec grep -nP '\s+$' {} + && exit 1 || exit 0
@@ -120,7 +120,7 @@ jobs:
         key: ${{ github.job }}-${{ matrix.isax }}
     - name: Install APT Dependencies
       run: |
-        sudo apt-get install -y ninja-build ninja-build pipx parallel
+        sudo apt-get install -y --no-install-recommends ninja-build ninja-build pipx
         # sudo apt-get purge -y gcc g++
         # sudo ln -s /usr/bin/gcc-13 /usr/bin/gcc
         # sudo ln -s /usr/bin/g++-13 /usr/bin/g++
@@ -160,7 +160,7 @@ jobs:
       run: |
         #sudo add-apt-repository ppa:aschultz/backports
         sudo apt-get update
-        sudo apt-get install -y ninja-build ninja-build pipx parallel g++-12 gcc-12 qemu-user-static
+        sudo apt-get install -y --no-install-recommends ninja-build ninja-build pipx g++-12 gcc-12 qemu-user-static
         # sudo apt-get purge -y gcc g++
         # sudo ln -s /usr/bin/gcc-12 /usr/bin/gcc
         # sudo ln -s /usr/bin/g++-12 /usr/bin/g++
@@ -194,7 +194,7 @@ jobs:
     - name: Install APT Dependencies
       run: |
         sudo apt-get update && \
-        sudo apt-get install -y ninja-build ninja-build pipx parallel &&\
+        sudo apt-get install -y --no-install-recommends ninja-build ninja-build pipx &&\
         pipx install meson==0.55.1
     - name: Install emscripten
       run: |
@@ -232,7 +232,7 @@ jobs:
     - name: Install APT Dependencies
       run: |
         sudo apt-get update && \
-        sudo apt-get -yq install libxml2-utils ninja-build parallel pipx && \
+        sudo apt-get -y --no-install-recommends install libxml2-utils ninja-build pipx && \
         pipx install meson==0.55.1
     - name: Convert
       run: ./test/native-aliases.sh
@@ -257,7 +257,7 @@ jobs:
       run: cat /proc/cpuinfo
     - name: Install APT Dependencies
       run: |
-        sudo apt-get install -y ninja-build ninja-build parallel libsleef-dev pipx
+        sudo apt-get install -y --no-install-recommends ninja-build ninja-build libsleef-dev pipx
         pipx install meson==0.55.1
     - name: Configure
       run: meson setup build -Dsleef=enabled
@@ -323,7 +323,7 @@ jobs:
       run: |
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt-get update
-        sudo apt-get -yq install gcovr pipx ninja-build parallel gcc-${{ matrix.version }} g++-${{ matrix.version }}
+        sudo apt-get -y install --no-install-recommends gcovr pipx ninja-build gcc-${{ matrix.version }} g++-${{ matrix.version }}
         sudo apt-get -y purge g++ gcc
         pipx install meson==0.55.1
     - name: ccache
@@ -416,14 +416,12 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
-    - run: sudo apt-get update
     - name: CPU Information
       run: cat /proc/cpuinfo
     - name: Install APT Dependencies
       run: |
-        sudo apt-get update -y
         sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
-        sudo apt-get -yq install ninja-build parallel \
+        sudo apt-get update && sudo apt-get -y --no-install-recommends install ninja-build \
           gcc-${{ matrix.version }}-${{ matrix.arch_gnu }}-linux-gnu${{ matrix.arch_gnu_abi }} \
           g++-${{ matrix.version }}-${{ matrix.arch_gnu }}-linux-gnu${{ matrix.arch_gnu_abi }} binfmt-support \
           qemu-user-static pipx libc6-${{ matrix.arch_deb }}-cross libstdc++-${{ matrix.version }}-dev-${{ matrix.arch_deb }}-cross
@@ -469,7 +467,7 @@ jobs:
     - run: apt-get update
     - name: Install git
       run: |
-        apt-get install -y git
+        apt-get install -y --no-install-recommends git ca-certificates
     - uses: actions/checkout@v4
       with:
         submodules: recursive
@@ -477,16 +475,14 @@ jobs:
       run: cat /proc/cpuinfo
     - name: Install APT Dependencies
       run: |
-        apt-get install -y python3 python3-pip git ninja-build pkg-config libglib2.0-dev \
-          lsb-release wget software-properties-common gnupg qemu-user pipx
-        apt-get install -y clang-${{ matrix.version }} lldb-${{ matrix.version }} lld-${{ matrix.version }}
         #add-apt-repository ppa:savoury1/virtualisation
         #add-apt-repository ppa:savoury1/display
         apt-get update -y
-        apt-get -yq install ninja-build parallel \
-          binfmt-support libc6-${{ matrix.arch_deb }}-cross \
-          libstdc++-12-dev-${{ matrix.arch_deb }}-cross binutils-${{ matrix.arch_gnu }}-linux-gnu
-        apt install meson
+        apt-get install -y --no-install-recommends ninja-build pkg-config \
+          qemu-user-static clang-${{ matrix.version }} ninja-build binfmt-support \
+          libc6-${{ matrix.arch_deb }}-cross meson llvm-${{ matrix.version }} \
+          libstdc++-12-dev-${{ matrix.arch_deb }}-cross \
+          binutils-${{ matrix.arch_gnu }}-linux-gnu
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
@@ -525,10 +521,6 @@ jobs:
           distro: ubuntu-24.04
     runs-on: ${{ matrix.distro }}
     steps:
-    - run: sudo apt-get update
-    - name: Install git
-      run: |
-        sudo apt-get install -y git
     - uses: actions/checkout@v4
       with:
         submodules: recursive
@@ -536,14 +528,11 @@ jobs:
       run: cat /proc/cpuinfo
     - name: Install APT Dependencies
       run: |
-        sudo apt-get install -y python3 git ninja-build pkg-config libglib2.0-dev \
-          lsb-release wget software-properties-common gnupg qemu-user pipx
-        sudo apt-get install -y clang-${{ matrix.version }} lldb-${{ matrix.version }} lld-${{ matrix.version }}
-        sudo apt-get update -y
-        sudo apt-get -yq install ninja-build parallel \
-          binfmt-support libc6-${{ matrix.arch_deb }}-cross \
-          libstdc++-12-dev-${{ matrix.arch_deb }}-cross binutils-${{ matrix.arch_gnu }}-linux-gnu
-        sudo apt install meson
+        sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+          ninja-build pkg-config qemu-user-static clang-${{ matrix.version }} \
+          ninja-build binfmt-support libc6-${{ matrix.arch_deb }}-cross meson \
+          libstdc++-12-dev-${{ matrix.arch_deb }}-cross \
+          binutils-${{ matrix.arch_gnu }}-linux-gnu
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
@@ -619,15 +608,14 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
-    - run: sudo apt-get update
     - name: CPU Information
       run: cat /proc/cpuinfo
     - name: Install APT Dependencies
       run: |
-        sudo apt-get update -y
         sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa && \
-        sudo apt-get -yq install ninja-build parallel \
-          binfmt-support clang-${{ matrix.version }} clang++-${{ matrix.version }} \
+        sudo apt-get update -y && \
+        sudo apt-get -y --no-install-recommends install ninja-build \
+          binfmt-support clang-${{ matrix.version }} \
           qemu-user-static pipx libc6-${{ matrix.arch_deb }}-cross libstdc++-14-dev-${{ matrix.arch_deb }}-cross \
           binutils-${{ matrix.arch_gnu }}-linux-gnu${{ matrix.arch_gnu_abi }}
         pipx install meson==0.55.1
@@ -738,7 +726,8 @@ jobs:
     - name: Install APT Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get -yq install gcovr ninja-build pipx clang-${{ matrix.version }}
+        sudo apt-get -y --no-install-recommends install gcovr ninja-build pipx \
+          clang-${{ matrix.version }}
         pipx install meson==0.55.1
         sudo rm /usr/bin/gcc /usr/bin/g++ /usr/bin/cc /usr/bin/c++
         sudo ln -s $(command -v clang-${{ matrix.version }}) /usr/bin/cc
@@ -857,7 +846,7 @@ jobs:
     - name: CPU Information
       run: cat /proc/cpuinfo
     - name: Install APT Dependencies
-      run: sudo apt-get install -y ninja-build pipx && pipx install meson==0.64
+      run: sudo apt-get install -y --no-install-recommends ninja-build pipx && pipx install meson==0.64
     - name: Install ICC
       run: |
         # download the key to system keyring
@@ -866,7 +855,7 @@ jobs:
         # add signed entry to apt sources and configure the APT client to use Intel repository:
         echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt-get update
-        sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp
+        sudo apt-get install -y --no-install-recommends intel-oneapi-compiler-dpcpp-cpp
         mkdir -p ~/.local/bin/ || true
         for exe in icx icpx; do
           printf '#!/bin/bash\nARGS="$@"\nsource /opt/intel/oneapi/compiler/latest/env/vars.sh >/dev/null\n%s ${ARGS}\n' "${exe}" > ~/.local/bin/"${exe}"
@@ -911,10 +900,10 @@ jobs:
       run: cat /proc/cpuinfo
     - name: Install APT Dependencies
       run: |
-        sudo apt-get update && \
         sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa && \
+        sudo apt-get update && \
         sudo apt-get install -y --no-install-recommends \
-          ninja-build ninja-build meson qemu-user-static binfmt-support \
+          ninja-build meson qemu-user-static binfmt-support \
           libc6-loong64-cross libstdc++-14-dev-loong64-cross \
           gcc-14-loongarch64-linux-gnu g++-14-loongarch64-linux-gnu
     - name: ccache

--- a/docker/cross-files/loongarch64-clang-18-ccache.cross
+++ b/docker/cross-files/loongarch64-clang-18-ccache.cross
@@ -1,0 +1,20 @@
+[binaries]
+c = ['ccache', 'clang-18']
+cpp = ['ccache', 'clang++-18']
+ar = 'llvm-ar-18'
+strip = 'llvm-strip-18'
+objcopy = 'llvm-objcopy-18'
+ld = 'llvm-ld-18'
+exe_wrapper = ['qemu-loongarch64-static', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
+
+[properties]
+c_args = ['--target=loongarch64-linux-gnu', '-march=la464', '-isystem=/usr/loongarch64-linux-gnu/include', '-Wextra', '-Werror']
+cpp_args = ['--target=loongarch64-linux-gnu', '-march=la464', '-isystem=/usr/loongarch64-linux-gnu/include', '-Wextra', '-Werror']
+c_link_args = ['--target=loongarch64-linux-gnu']
+cpp_link_args = ['--target=loongarch64-linux-gnu']
+
+[host_machine]
+system = 'linux'
+cpu_family = 'loongarch64'
+cpu = 'la464'
+endian = 'little'

--- a/docker/cross-files/riscv64+rvv_vlen128_elen64-clang-17-ccache.cross
+++ b/docker/cross-files/riscv64+rvv_vlen128_elen64-clang-17-ccache.cross
@@ -5,7 +5,7 @@ ar = 'llvm-ar-17'
 strip = 'llvm-strip-17'
 objcopy = 'llvm-objcopy-17'
 ld = 'llvm-ld-17'
-exe_wrapper = ['qemu-riscv64', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,vlen=128,elen=64,vext_spec=v1.0']
+exe_wrapper = ['qemu-riscv64-static', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,vlen=128,elen=64,vext_spec=v1.0']
 
 [properties]
 c_args = ['--target=riscv64-linux-gnu',

--- a/docker/cross-files/riscv64+rvv_vlen128_elen64-clang-18-ccache.cross
+++ b/docker/cross-files/riscv64+rvv_vlen128_elen64-clang-18-ccache.cross
@@ -5,7 +5,7 @@ ar = 'llvm-ar-18'
 strip = 'llvm-strip-18'
 objcopy = 'llvm-objcopy-18'
 ld = 'llvm-ld-18'
-exe_wrapper = ['qemu-riscv64', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,vlen=128,elen=64,vext_spec=v1.0']
+exe_wrapper = ['qemu-riscv64-static', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,vlen=128,elen=64,vext_spec=v1.0']
 
 [properties]
 c_args = ['--target=riscv64-linux-gnu',

--- a/docker/cross-files/riscv64+rvv_vlen128_elen64_zvfh-clang-17-ccache.cross
+++ b/docker/cross-files/riscv64+rvv_vlen128_elen64_zvfh-clang-17-ccache.cross
@@ -5,7 +5,7 @@ ar = 'llvm-ar-17'
 strip = 'llvm-strip-17'
 objcopy = 'llvm-objcopy-17'
 ld = 'llvm-ld-17'
-exe_wrapper = ['qemu-riscv64', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,Zfh=true,x-zvfh=true,vlen=128,elen=64,vext_spec=v1.0']
+exe_wrapper = ['qemu-riscv64-static', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,Zfh=true,x-zvfh=true,vlen=128,elen=64,vext_spec=v1.0']
 
 [properties]
 c_args = ['--target=riscv64-linux-gnu',

--- a/docker/cross-files/riscv64+rvv_vlen128_elen64_zvfh-clang-18-ccache.cross
+++ b/docker/cross-files/riscv64+rvv_vlen128_elen64_zvfh-clang-18-ccache.cross
@@ -5,7 +5,7 @@ ar = 'llvm-ar-18'
 strip = 'llvm-strip-18'
 objcopy = 'llvm-objcopy-18'
 ld = 'llvm-ld-18'
-exe_wrapper = ['qemu-riscv64', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,Zfh=true,x-zvfh=true,vlen=128,elen=64,vext_spec=v1.0']
+exe_wrapper = ['qemu-riscv64-static', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,Zfh=true,x-zvfh=true,vlen=128,elen=64,vext_spec=v1.0']
 
 [properties]
 c_args = ['--target=riscv64-linux-gnu',

--- a/docker/cross-files/riscv64+rvv_vlen256_elen64-clang-17-ccache.cross
+++ b/docker/cross-files/riscv64+rvv_vlen256_elen64-clang-17-ccache.cross
@@ -5,7 +5,7 @@ ar = 'llvm-ar-17'
 strip = 'llvm-strip-17'
 objcopy = 'llvm-objcopy-17'
 ld = 'llvm-ld-17'
-exe_wrapper = ['qemu-riscv64', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,vlen=256,elen=64,vext_spec=v1.0']
+exe_wrapper = ['qemu-riscv64-static', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,vlen=256,elen=64,vext_spec=v1.0']
 
 [properties]
 c_args = ['--target=riscv64-linux-gnu',

--- a/docker/cross-files/riscv64+rvv_vlen256_elen64-clang-18-ccache.cross
+++ b/docker/cross-files/riscv64+rvv_vlen256_elen64-clang-18-ccache.cross
@@ -5,7 +5,7 @@ ar = 'llvm-ar-18'
 strip = 'llvm-strip-18'
 objcopy = 'llvm-objcopy-18'
 ld = 'llvm-ld-18'
-exe_wrapper = ['qemu-riscv64', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,vlen=256,elen=64,vext_spec=v1.0']
+exe_wrapper = ['qemu-riscv64-static', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,vlen=256,elen=64,vext_spec=v1.0']
 
 [properties]
 c_args = ['--target=riscv64-linux-gnu',

--- a/docker/cross-files/riscv64+rvv_vlen256_elen64_zvfh-clang-17-ccache.cross
+++ b/docker/cross-files/riscv64+rvv_vlen256_elen64_zvfh-clang-17-ccache.cross
@@ -5,7 +5,7 @@ ar = 'llvm-ar-17'
 strip = 'llvm-strip-17'
 objcopy = 'llvm-objcopy-17'
 ld = 'llvm-ld-17'
-exe_wrapper = ['qemu-riscv64', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,Zfh=true,x-zvfh=true,vlen=256,elen=64,vext_spec=v1.0']
+exe_wrapper = ['qemu-riscv64-static', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,Zfh=true,x-zvfh=true,vlen=256,elen=64,vext_spec=v1.0']
 
 [properties]
 c_args = ['--target=riscv64-linux-gnu',

--- a/docker/cross-files/riscv64+rvv_vlen256_elen64_zvfh-clang-18-ccache.cross
+++ b/docker/cross-files/riscv64+rvv_vlen256_elen64_zvfh-clang-18-ccache.cross
@@ -5,7 +5,7 @@ ar = 'llvm-ar-18'
 strip = 'llvm-strip-18'
 objcopy = 'llvm-objcopy-18'
 ld = 'llvm-ld-18'
-exe_wrapper = ['qemu-riscv64', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,Zfh=true,x-zvfh=true,vlen=256,elen=64,vext_spec=v1.0']
+exe_wrapper = ['qemu-riscv64-static', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,Zfh=true,x-zvfh=true,vlen=256,elen=64,vext_spec=v1.0']
 
 [properties]
 c_args = ['--target=riscv64-linux-gnu',

--- a/docker/cross-files/riscv64+rvv_vlen512_elen64-clang-17-ccache.cross
+++ b/docker/cross-files/riscv64+rvv_vlen512_elen64-clang-17-ccache.cross
@@ -5,7 +5,7 @@ ar = 'llvm-ar-17'
 strip = 'llvm-strip-17'
 objcopy = 'llvm-objcopy-17'
 ld = 'llvm-ld-17'
-exe_wrapper = ['qemu-riscv64', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,vlen=512,elen=64,vext_spec=v1.0']
+exe_wrapper = ['qemu-riscv64-static', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,vlen=512,elen=64,vext_spec=v1.0']
 
 [properties]
 c_args = ['--target=riscv64-linux-gnu',

--- a/docker/cross-files/riscv64+rvv_vlen512_elen64-clang-18-ccache.cross
+++ b/docker/cross-files/riscv64+rvv_vlen512_elen64-clang-18-ccache.cross
@@ -5,7 +5,7 @@ ar = 'llvm-ar-18'
 strip = 'llvm-strip-18'
 objcopy = 'llvm-objcopy-18'
 ld = 'llvm-ld-18'
-exe_wrapper = ['qemu-riscv64', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,vlen=512,elen=64,vext_spec=v1.0']
+exe_wrapper = ['qemu-riscv64-static', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,vlen=512,elen=64,vext_spec=v1.0']
 
 [properties]
 c_args = ['--target=riscv64-linux-gnu',

--- a/docker/cross-files/riscv64+rvv_vlen512_elen64_zvfh-clang-17-ccache.cross
+++ b/docker/cross-files/riscv64+rvv_vlen512_elen64_zvfh-clang-17-ccache.cross
@@ -5,7 +5,7 @@ ar = 'llvm-ar-17'
 strip = 'llvm-strip-17'
 objcopy = 'llvm-objcopy-17'
 ld = 'llvm-ld-17'
-exe_wrapper = ['qemu-riscv64', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,Zfh=true,x-zvfh=true,vlen=512,elen=64,vext_spec=v1.0']
+exe_wrapper = ['qemu-riscv64-static', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,Zfh=true,x-zvfh=true,vlen=512,elen=64,vext_spec=v1.0']
 
 [properties]
 c_args = ['--target=riscv64-linux-gnu',

--- a/docker/cross-files/riscv64+rvv_vlen512_elen64_zvfh-clang-18-ccache.cross
+++ b/docker/cross-files/riscv64+rvv_vlen512_elen64_zvfh-clang-18-ccache.cross
@@ -5,7 +5,7 @@ ar = 'llvm-ar-18'
 strip = 'llvm-strip-18'
 objcopy = 'llvm-objcopy-18'
 ld = 'llvm-ld-18'
-exe_wrapper = ['qemu-riscv64', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,Zfh=true,x-zvfh=true,vlen=512,elen=64,vext_spec=v1.0']
+exe_wrapper = ['qemu-riscv64-static', '-L', '/usr/riscv64-linux-gnu/', '-cpu', 'rv64,v=true,Zfh=true,x-zvfh=true,vlen=512,elen=64,vext_spec=v1.0']
 
 [properties]
 c_args = ['--target=riscv64-linux-gnu',

--- a/simde/simde-f16.h
+++ b/simde/simde-f16.h
@@ -72,6 +72,7 @@ SIMDE_BEGIN_DECLS_
     !(defined(HEDLEY_MSVC_VERSION) && defined(__clang__)) && \
     !(defined(SIMDE_ARCH_MIPS) && defined(__clang__)) && \
     !(defined(SIMDE_ARCH_ZARCH) && defined(__clang__)) && \
+    !(defined(SIMDE_ARCH_LOONGARCH) && defined(__clang__)) && \
     !(defined(__clang__) && defined(SIMDE_ARCH_RISCV64)) && ( \
       defined(SIMDE_X86_AVX512FP16_NATIVE) || \
       (defined(SIMDE_ARCH_X86_SSE2) && HEDLEY_GCC_VERSION_CHECK(12,0,0)) || \


### PR DESCRIPTION
Fixed the compilation issue on the Loongarch platform with clang:
` ../test/x86/avx512/../../../simde/simde-f16.h:100:11: error: _Float16 is not supported on this target.`