### PR TITLE
Fix clang type redef error

### DIFF
--- a/simde/x86/avx512/types.h
+++ b/simde/x86/avx512/types.h
@@ -607,7 +607,7 @@ typedef uint64_t simde__mmask64;
 #endif
 #if !defined(__mmask64) && defined(SIMDE_ENABLE_NATIVE_ALIASES)
   #if !defined(HEDLEY_INTEL_VERSION)
-    #if defined(HEDLEY_GCC_VERSION)
+    #if defined(HEDLEY_GCC_VERSION) || (defined(__clang__) && SIMDE_DETECT_CLANG_VERSION_CHECK(3, 6, 0))
       typedef unsigned long long __mmask64;
     #else
       typedef uint64_t __mmask64;


### PR DESCRIPTION
Clang has a `typedef unsigned long long __mask64` defined in `avx512bwintrin.h` ([link](https://clang.llvm.org/doxygen/avx512bwintrin_8h.html#a910ccf7d2141c4a3b8675e2480cc33ff)) and  causes `typedef redefinition with different types ('uint64_t' (aka 'unsigned long') vs 'unsigned long long')` error. 
This PR adds clang case in to the logic to fix this error.

See this for more detail: https://github.com/simd-everywhere/simde/commit/e8390a3bfb3bd9e5119a9883fb29b07169b2fe4d#r149134782