### PR TITLE
Fixes for loongarch compilers

### DIFF
--- a/simde/x86/avx2.h
+++ b/simde/x86/avx2.h
@@ -1119,7 +1119,7 @@ simde_mm256_bsrli_epi128 (simde__m256i a, const int imm8)
     SIMDE_DETECT_CLANG_VERSION_CHECK(3,7,0)
   #define simde_mm256_bsrli_epi128(a, imm8) _mm256_bsrli_epi128(a, imm8)
 #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
-  #define simde_mm256_bslli_epi128(a, imm8) (imm8 > 15 ? __lasx_xvreplgr2vr_d(0) : __lasx_xvbsll_v(a, imm8))
+  #define simde_mm256_bsrli_epi128(a, imm8) (imm8 > 15 ? __lasx_xvreplgr2vr_d(0) : __lasx_xvbsrl_v(a, imm8))
 #endif
 #if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
   #undef _mm256_bsrli_epi128
@@ -4573,6 +4573,8 @@ simde_mm256_slli_epi16 (simde__m256i a, const int imm8)
     for (size_t i = 0 ; i < (sizeof(a_.altivec_i16) / sizeof(a_.altivec_i16[0])) ; i++) {
       r_.altivec_i16[i] = vec_sl(a_.altivec_i16[i], sv);
     }
+  #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      r_.i256 = imm8 > 15 ? __lasx_xvreplgr2vr_h(0) : __lasx_xvsll_h(a_.i256, __lasx_xvreplgr2vr_h(imm8));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
     r_.i16 = a_.i16 << HEDLEY_STATIC_CAST(int16_t, imm8);
   #else
@@ -4586,8 +4588,6 @@ simde_mm256_slli_epi16 (simde__m256i a, const int imm8)
 }
 #if defined(SIMDE_X86_AVX2_NATIVE)
 #  define simde_mm256_slli_epi16(a, imm8) _mm256_slli_epi16(a, imm8)
-#elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
-#  define simde_mm256_slli_epi16(a, imm8) (imm8 > 15 ? __lasx_xvreplgr2vr_h(0) : __lasx_xvslli_h(a, imm8 & 15))
 #elif SIMDE_NATURAL_INT_VECTOR_SIZE_LE(128)
 #  define simde_mm256_slli_epi16(a, imm8) \
      simde_mm256_set_m128i( \
@@ -4612,6 +4612,8 @@ simde_mm256_slli_epi32 (simde__m256i a, const int imm8)
     for (size_t i = 0 ; i < (sizeof(a_.altivec_i32) / sizeof(a_.altivec_i32[0])) ; i++) {
       r_.altivec_i32[i] = vec_sl(a_.altivec_i32[i], sv);
     }
+  #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      r_.i256 = imm8 > 31 ? __lasx_xvreplgr2vr_w(0) : __lasx_xvsll_w(a_.i256, __lasx_xvreplgr2vr_w(imm8));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
     r_.i32 = a_.i32 << HEDLEY_STATIC_CAST(int32_t, imm8);
   #else
@@ -4625,8 +4627,6 @@ simde_mm256_slli_epi32 (simde__m256i a, const int imm8)
 }
 #if defined(SIMDE_X86_AVX2_NATIVE)
 #  define simde_mm256_slli_epi32(a, imm8) _mm256_slli_epi32(a, imm8)
-#elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
-#  define simde_mm256_slli_epi32(a, imm8) (imm8 > 31 ? __lasx_xvreplgr2vr_w(0) : __lasx_xvslli_w(a, imm8 & 31))
 #elif SIMDE_NATURAL_INT_VECTOR_SIZE_LE(128)
 #  define simde_mm256_slli_epi32(a, imm8) \
      simde_mm256_set_m128i( \
@@ -4646,7 +4646,9 @@ simde_mm256_slli_epi64 (simde__m256i a, const int imm8)
     r_,
     a_ = simde__m256i_to_private(a);
 
-#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+#if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+  r_.i256 = imm8 > 63 ? __lasx_xvreplgr2vr_d(0) : __lasx_xvsll_d(a_.i256, __lasx_xvreplgr2vr_d(imm8));
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
   r_.i64 = a_.i64 << HEDLEY_STATIC_CAST(int64_t, imm8);
 #else
   SIMDE_VECTORIZE
@@ -4659,8 +4661,6 @@ simde_mm256_slli_epi64 (simde__m256i a, const int imm8)
 }
 #if defined(SIMDE_X86_AVX2_NATIVE)
 #  define simde_mm256_slli_epi64(a, imm8) _mm256_slli_epi64(a, imm8)
-#elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
-#  define simde_mm256_slli_epi64(a, imm8) (imm8 > 63 ? __lasx_xvreplgr2vr_d(0) : __lasx_xvslli_d(a, imm8))
 #elif SIMDE_NATURAL_INT_VECTOR_SIZE_LE(128)
 #  define simde_mm256_slli_epi64(a, imm8) \
      simde_mm256_set_m128i( \
@@ -4934,7 +4934,9 @@ simde_mm256_srai_epi16 (simde__m256i a, const int imm8)
 
   if (shift > 15) shift = 15;
 
-  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+  #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    r_.i256 = __lasx_xvsra_h(a_.i256, __lasx_xvreplgr2vr_h(shift));
+  #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
     r_.i16 = a_.i16 >> HEDLEY_STATIC_CAST(int16_t, shift);
   #else
     SIMDE_VECTORIZE
@@ -4947,8 +4949,6 @@ simde_mm256_srai_epi16 (simde__m256i a, const int imm8)
 }
 #if defined(SIMDE_X86_AVX2_NATIVE)
 #  define simde_mm256_srai_epi16(a, imm8) _mm256_srai_epi16(a, imm8)
-#elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
-#  define simde_mm256_srai_epi16(a, imm8) __lasx_xvsrai_h(a, (imm8 > 15 ? 15 : imm8))
 #elif SIMDE_NATURAL_INT_VECTOR_SIZE_LE(128)
 #  define simde_mm256_srai_epi16(a, imm8) \
      simde_mm256_set_m128i( \
@@ -4971,7 +4971,9 @@ simde_mm256_srai_epi32 (simde__m256i a, const int imm8)
 
   if (shift > 31) shift = 31;
 
-  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+  #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    r_.i256 = __lasx_xvsra_w(a_.i256, __lasx_xvreplgr2vr_w(shift));
+  #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
     r_.i32 = a_.i32 >> HEDLEY_STATIC_CAST(int16_t, shift);
   #else
     SIMDE_VECTORIZE
@@ -4984,8 +4986,6 @@ simde_mm256_srai_epi32 (simde__m256i a, const int imm8)
 }
 #if defined(SIMDE_X86_AVX2_NATIVE)
 #  define simde_mm256_srai_epi32(a, imm8) _mm256_srai_epi32(a, imm8)
-#elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
-#  define simde_mm256_srai_epi32(a, imm8) __lasx_xvsrai_w(a, (imm8 > 31 ? 31 : imm8))
 #elif SIMDE_NATURAL_INT_VECTOR_SIZE_LE(128)
 #  define simde_mm256_srai_epi32(a, imm8) \
      simde_mm256_set_m128i( \
@@ -5195,6 +5195,8 @@ simde_mm256_srli_epi16 (simde__m256i a, const int imm8)
     for (size_t i = 0 ; i < (sizeof(a_.altivec_u16) / sizeof(a_.altivec_u16[0])) ; i++) {
       r_.altivec_u16[i] = vec_sr(a_.altivec_u16[i], sv);
     }
+  #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    r_.i256 = __lasx_xvsrl_h(a_.i256, __lasx_xvreplgr2vr_h(imm8));
   #else
     if (HEDLEY_STATIC_CAST(unsigned int, imm8) > 15) {
       simde_memset(&r_, 0, sizeof(r_));
@@ -5214,8 +5216,6 @@ simde_mm256_srli_epi16 (simde__m256i a, const int imm8)
 }
 #if defined(SIMDE_X86_AVX2_NATIVE)
 #  define simde_mm256_srli_epi16(a, imm8) _mm256_srli_epi16(a, imm8)
-#elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
-#  define simde_mm256_srli_epi16(a, imm8) (imm8 > 15 ? __lasx_xvreplgr2vr_h(0) : __lasx_xvsrli_h(a, imm8 & 15))
 #elif SIMDE_NATURAL_INT_VECTOR_SIZE_LE(128)
 #  define simde_mm256_srli_epi16(a, imm8) \
      simde_mm256_set_m128i( \
@@ -5240,6 +5240,8 @@ simde_mm256_srli_epi32 (simde__m256i a, const int imm8)
     for (size_t i = 0 ; i < (sizeof(a_.altivec_u32) / sizeof(a_.altivec_u32[0])) ; i++) {
       r_.altivec_u32[i] = vec_sr(a_.altivec_u32[i], sv);
     }
+  #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    r_.i256 = imm8 > 31 ? __lasx_xvreplgr2vr_w(0) : __lasx_xvsrl_w(a_.i256, __lasx_xvreplgr2vr_w(imm8));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
     r_.u32 = a_.u32 >> SIMDE_CAST_VECTOR_SHIFT_COUNT(16, imm8);
   #else
@@ -5253,8 +5255,6 @@ simde_mm256_srli_epi32 (simde__m256i a, const int imm8)
 }
 #if defined(SIMDE_X86_AVX2_NATIVE)
 #  define simde_mm256_srli_epi32(a, imm8) _mm256_srli_epi32(a, imm8)
-#elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
-#  define simde_mm256_srli_epi32(a, imm8) __lasx_xvsrli_w(a, imm8)
 #elif SIMDE_NATURAL_INT_VECTOR_SIZE_LE(128)
 #  define simde_mm256_srli_epi32(a, imm8) \
      simde_mm256_set_m128i( \
@@ -5274,7 +5274,9 @@ simde_mm256_srli_epi64 (simde__m256i a, const int imm8)
     r_,
     a_ = simde__m256i_to_private(a);
 
-#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+#if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+  r_.i256 = imm8 > 63 ? __lasx_xvreplgr2vr_d(0) : __lasx_xvsrl_d(a_.i256, __lasx_xvreplgr2vr_d(imm8));
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
   r_.u64 = a_.u64 >> SIMDE_CAST_VECTOR_SHIFT_COUNT(32, imm8);
 #else
   SIMDE_VECTORIZE
@@ -5287,8 +5289,6 @@ simde_mm256_srli_epi64 (simde__m256i a, const int imm8)
 }
 #if defined(SIMDE_X86_AVX2_NATIVE)
 #  define simde_mm256_srli_epi64(a, imm8) _mm256_srli_epi64(a, imm8)
-#elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
-#  define simde_mm256_srli_epi64(a, imm8) __lasx_xvsrli_d(a, imm8)
 #elif SIMDE_NATURAL_INT_VECTOR_SIZE_LE(128)
 #  define simde_mm256_srli_epi64(a, imm8) \
      simde_mm256_set_m128i( \

--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -6163,7 +6163,7 @@ simde_mm_sll_epi16 (simde__m128i a, simde__m128i count) {
     #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_u16 = vshlq_u16(a_.neon_u16, vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, count_.u64[0])));
     #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
-      r_.lsx_i64 = __lsx_vslli_h(a_.lsx_i64, count_.u64[0]);
+      r_.lsx_i64 = __lsx_vsll_h(a_.lsx_i64, __lsx_vreplgr2vr_h(count_.u64[0]));
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 = ((wasm_i64x2_extract_lane(count_.wasm_v128, 0) < 16) ? wasm_i16x8_shl(a_.wasm_v128, HEDLEY_STATIC_CAST(int32_t, wasm_i64x2_extract_lane(count_.wasm_v128, 0))) : wasm_i16x8_const(0,0,0,0,0,0,0,0));
     #else
@@ -6199,7 +6199,7 @@ simde_mm_sll_epi32 (simde__m128i a, simde__m128i count) {
     #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_u32 = vshlq_u32(a_.neon_u32, vdupq_n_s32(HEDLEY_STATIC_CAST(int32_t, count_.u64[0])));
     #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
-      r_.lsx_i64 = __lsx_vslli_w(a_.lsx_i64, count_.u64[0]);
+      r_.lsx_i64 = __lsx_vsll_w(a_.lsx_i64, __lsx_vreplgr2vr_w(count_.u64[0]));
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 = ((wasm_i64x2_extract_lane(count_.wasm_v128, 0) < 32) ? wasm_i32x4_shl(a_.wasm_v128, HEDLEY_STATIC_CAST(int32_t, wasm_i64x2_extract_lane(count_.wasm_v128, 0))) : wasm_i32x4_const(0,0,0,0));
     #else
@@ -6561,7 +6561,9 @@ simde_mm_slli_epi16 (simde__m128i a, const int imm8)
     r_,
     a_ = simde__m128i_to_private(a);
 
-  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+  #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
+    r_.lsx_i64 = __lsx_vsll_h(a_.lsx_i64, __lsx_vreplgr2vr_h(imm8));
+  #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
     r_.i16 = a_.i16 << SIMDE_CAST_VECTOR_SHIFT_COUNT(8, imm8 & 0xff);
   #else
     const int s = (imm8 > HEDLEY_STATIC_CAST(int, sizeof(r_.i16[0]) * CHAR_BIT) - 1) ? 0 : imm8;
@@ -6589,8 +6591,6 @@ simde_mm_slli_epi16 (simde__m128i a, const int imm8)
 #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_mm_slli_epi16(a, imm8) \
     ((imm8 & ~15) ? simde_mm_setzero_si128() : simde__m128i_from_altivec_i16(vec_sl(simde__m128i_to_altivec_i16(a), vec_splat_u16(HEDLEY_STATIC_CAST(unsigned short, imm8)))))
-#elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
-  #define simde_mm_slli_epi16(a, imm8) ((imm8 & ~15) ? simde_mm_setzero_si128() : simde__m128i_from_lsx_i64(__lsx_vslli_h(simde__m128i_to_private(a).lsx_i64, ((imm8) & 15))))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
   #define _mm_slli_epi16(a, imm8) simde_mm_slli_epi16(a, imm8)
@@ -6607,7 +6607,9 @@ simde_mm_slli_epi32 (simde__m128i a, const int imm8)
     r_,
     a_ = simde__m128i_to_private(a);
 
-  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+  #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
+    r_.lsx_i64 = __lsx_vsll_w(a_.lsx_i64, __lsx_vreplgr2vr_w(imm8));
+  #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
     r_.i32 = a_.i32 << imm8;
   #else
     SIMDE_VECTORIZE
@@ -6646,8 +6648,6 @@ simde_mm_slli_epi32 (simde__m128i a, const int imm8)
        } \
        ret; \
      }))
-#elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
-  #define simde_mm_slli_epi32(a, imm8) ((imm8 & ~31) ? simde_mm_setzero_si128() : simde__m128i_from_lsx_i64(__lsx_vslli_w(simde__m128i_to_private(a).lsx_i64, ((imm8) & 31))))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
   #define _mm_slli_epi32(a, imm8) simde_mm_slli_epi32(a, imm8)
@@ -6664,7 +6664,9 @@ simde_mm_slli_epi64 (simde__m128i a, const int imm8)
     r_,
     a_ = simde__m128i_to_private(a);
 
-  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+  #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
+    r_.lsx_i64 = __lsx_vsll_d(a_.lsx_i64, __lsx_vreplgr2vr_d(imm8));
+  #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
     r_.i64 = a_.i64 << imm8;
   #else
     SIMDE_VECTORIZE
@@ -6688,8 +6690,6 @@ simde_mm_slli_epi64 (simde__m128i a, const int imm8)
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
   #define simde_mm_slli_epi64(a, imm8) \
     ((imm8 < 64) ? wasm_i64x2_shl(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i64x2_const(0,0))
-#elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
-  #define simde_mm_slli_epi64(a, imm8) ((imm8 & ~63) ? simde_mm_setzero_si128() : simde__m128i_from_lsx_i64(__lsx_vslli_d(simde__m128i_to_private(a).lsx_i64, ((imm8) & 63))))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
   #define _mm_slli_epi64(a, imm8) simde_mm_slli_epi64(a, imm8)
@@ -6706,7 +6706,9 @@ simde_mm_srli_epi16 (simde__m128i a, const int imm8)
     r_,
     a_ = simde__m128i_to_private(a);
 
-  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+  #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
+   r_.lsx_i64 = __lsx_vsrl_h(a_.lsx_i64, __lsx_vreplgr2vr_h(imm8));
+  #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
     r_.u16 = a_.u16 >> SIMDE_CAST_VECTOR_SHIFT_COUNT(8, imm8);
   #else
     SIMDE_VECTORIZE
@@ -6733,8 +6735,6 @@ simde_mm_srli_epi16 (simde__m128i a, const int imm8)
 #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
   #define simde_mm_srli_epi16(a, imm8) \
     ((imm8 & ~15) ? simde_mm_setzero_si128() : simde__m128i_from_altivec_i16(vec_sr(simde__m128i_to_altivec_i16(a), vec_splat_u16(HEDLEY_STATIC_CAST(unsigned short, imm8)))))
-#elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
-  #define simde_mm_srli_epi16(a, imm8) ((imm8 & ~15) ? simde_mm_setzero_si128() : simde__m128i_from_lsx_i64(__lsx_vsrli_h(simde__m128i_to_private(a).lsx_i64, ((imm8) & 15))))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
   #define _mm_srli_epi16(a, imm8) simde_mm_srli_epi16(a, imm8)
@@ -6751,7 +6751,9 @@ simde_mm_srli_epi32 (simde__m128i a, const int imm8)
     r_,
     a_ = simde__m128i_to_private(a);
 
-  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+  #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
+   r_.lsx_i64 = __lsx_vsrl_w(a_.lsx_i64, __lsx_vreplgr2vr_w(imm8));
+  #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
     r_.u32 = a_.u32 >> SIMDE_CAST_VECTOR_SHIFT_COUNT(8, imm8 & 0xff);
   #else
     SIMDE_VECTORIZE
@@ -6790,8 +6792,6 @@ simde_mm_srli_epi32 (simde__m128i a, const int imm8)
         } \
         ret; \
     }))
-#elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
-  #define simde_mm_srli_epi32(a, imm8) ((imm8 & ~31) ? simde_mm_setzero_si128() : simde__m128i_from_lsx_i64(__lsx_vsrli_w(simde__m128i_to_private(a).lsx_i64, ((imm8) & 31))))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
   #define _mm_srli_epi32(a, imm8) simde_mm_srli_epi32(a, imm8)
@@ -6810,6 +6810,8 @@ simde_mm_srli_epi64 (simde__m128i a, const int imm8)
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_u64 = vshlq_u64(a_.neon_u64, vdupq_n_s64(-imm8));
+  #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
+   r_.lsx_i64 = __lsx_vsrl_d(a_.lsx_i64, __lsx_vreplgr2vr_d(imm8));
   #else
     #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_94488)
       r_.u64 = a_.u64 >> SIMDE_CAST_VECTOR_SHIFT_COUNT(8, imm8);
@@ -6836,8 +6838,6 @@ simde_mm_srli_epi64 (simde__m128i a, const int imm8)
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
   #define simde_mm_srli_epi64(a, imm8) \
     ((imm8 < 64) ? wasm_u64x2_shr(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i64x2_const(0,0))
-#elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
-  #define simde_mm_srli_epi64(a, imm8) ((imm8 & ~63) ? simde_mm_setzero_si128() : simde__m128i_from_lsx_i64(__lsx_vsrli_d(simde__m128i_to_private(a).lsx_i64, ((imm8) & 63))))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
   #define _mm_srli_epi64(a, imm8) simde_mm_srli_epi64(a, imm8)


### PR DESCRIPTION
Happy New Year, Michael @mr-c. 

We rewrited the PR https://github.com/simd-everywhere/simde/pull/1247 (can be closed now) and seperated it into two patches. We did two things on them.

1）The first thing is to fix a typo for lasx implemention in x86 avx2 that modified simde_mm256_bslli_epi128 to simde_mm256_bsrli_epi128, very sorry for this typo error.
2）The second thing is to work around compiler errors in use-cases that users would pass variables for shift count for slli/srli/srai instrutions, which can not support for loongarch at present.

We hope you could take some time to review this for us, if you have any questions please feel free to let us know, thank you Michael， thank you. 