### PR TITLE
silence some warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,10 +122,10 @@ jobs:
         verbose: 2
     - name: Install APT Dependencies
       run: |
-        sudo apt-get install -y --no-install-recommends ninja-build ninja-build pipx
-        # sudo apt-get purge -y gcc g++
-        # sudo ln -s /usr/bin/gcc-13 /usr/bin/gcc
-        # sudo ln -s /usr/bin/g++-13 /usr/bin/g++
+        sudo apt-get install -y --no-install-recommends ninja-build ninja-build pipx gcc-14 g++-14
+        sudo apt-get purge -y gcc g++
+        sudo ln -s /usr/bin/gcc-14 /usr/bin/gcc
+        sudo ln -s /usr/bin/g++-14 /usr/bin/g++
         pipx install meson==0.55.1
     - name: add ccache to the build path
       run: |

--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -3793,6 +3793,11 @@ simde_mm_load_si128 (simde__m128i const* mem_addr) {
   #define _mm_load_si128(mem_addr) simde_mm_load_si128(mem_addr)
 #endif
 
+#if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_
+#endif
+
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128d
 simde_mm_loadh_pd (simde__m128d a, simde_float64 const* mem_addr) {
@@ -3822,6 +3827,10 @@ simde_mm_loadh_pd (simde__m128d a, simde_float64 const* mem_addr) {
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
   #define _mm_loadh_pd(a, mem_addr) simde_mm_loadh_pd(a, mem_addr)
+#endif
+
+#if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+HEDLEY_DIAGNOSTIC_POP
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES

--- a/simde/x86/sse3.h
+++ b/simde/x86/sse3.h
@@ -479,6 +479,11 @@ simde_mm_movedup_pd (simde__m128d a) {
 #  define _mm_movedup_pd(a) simde_mm_movedup_pd(a)
 #endif
 
+#if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_
+#endif
+
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128
 simde_mm_movehdup_ps (simde__m128 a) {
@@ -541,6 +546,10 @@ simde_mm_moveldup_ps (simde__m128 a) {
 }
 #if defined(SIMDE_X86_SSE3_ENABLE_NATIVE_ALIASES)
 #  define _mm_moveldup_ps(a) simde_mm_moveldup_ps(a)
+#endif
+
+#if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+HEDLEY_DIAGNOSTIC_POP
 #endif
 
 SIMDE_END_DECLS_

--- a/test/x86/avx.c
+++ b/test/x86/avx.c
@@ -14945,6 +14945,11 @@ test_simde_mm256_sub_pd(SIMDE_MUNIT_TEST_ARGS) {
   return 0;
 }
 
+#if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+  HEDLEY_DIAGNOSTIC_PUSH
+  SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_
+#endif
+
 static int
 test_simde_mm256_undefined_ps(SIMDE_MUNIT_TEST_ARGS) {
   simde__m256 r;
@@ -14982,6 +14987,10 @@ test_simde_mm256_undefined_si256(SIMDE_MUNIT_TEST_ARGS) {
   simde_assert_m256i_equal(simde_mm256_castpd_si256(r), simde_mm256_castpd_si256(e));
   return 0;
 }
+
+#if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+  HEDLEY_DIAGNOSTIC_POP
+#endif
 
 static int
 test_simde_mm256_unpackhi_ps(SIMDE_MUNIT_TEST_ARGS) {


### PR DESCRIPTION
- x86 sse2,sse3, avx: silence some false-positive warnings about unitialized structs
- gh-actions: x86 upgrade to GCC-14
