### PR TITLE
Fix simde_math_fpclass functions so they work.

### DIFF
--- a/simde/simde-math.h
+++ b/simde/simde-math.h
@@ -454,7 +454,7 @@ simde_math_fpclassf(float v, const int imm8) {
   fu.f = v;
   uint32_t bits = fu.u;
   uint8_t NegNum = (bits >> 31) & 1;
-  uint32_t const ExpMask = 0x3F800000; // [30:23]
+  uint32_t const ExpMask = 0x7F800000; // [30:23]
   uint32_t const MantMask = 0x007FFFFF; // [22:0]
   uint8_t ExpAllOnes = ((bits & ExpMask) == ExpMask);
   uint8_t ExpAllZeros = ((bits & ExpMask) == 0);
@@ -471,14 +471,14 @@ simde_math_fpclassf(float v, const int imm8) {
   uint8_t Denorm_res = ExpAllZeros & (!MantAllZeros);
   uint8_t FinNeg_res = NegNum & (!ExpAllOnes) & (!ZeroNumber);
   uint8_t sNaN_res = ExpAllOnes & (!MantAllZeros) & (!SignalingBit);
-  result = (((imm8 >> 0) & qNaN_res)   | \
-            ((imm8 >> 1) & Pzero_res)  | \
-            ((imm8 >> 2) & Nzero_res)  | \
-            ((imm8 >> 3) & Pinf_res)   | \
-            ((imm8 >> 4) & Ninf_res)   | \
-            ((imm8 >> 5) & Denorm_res) | \
-            ((imm8 >> 6) & FinNeg_res) | \
-            ((imm8 >> 7) & sNaN_res));
+  result = ((((imm8 >> 0) & qNaN_res) ? SIMDE_MATH_FP_QNAN : 0)       | \
+            (((imm8 >> 1) & Pzero_res) ? SIMDE_MATH_FP_PZERO : 0)     | \
+            (((imm8 >> 2) & Nzero_res) ? SIMDE_MATH_FP_NZERO : 0)     | \
+            (((imm8 >> 3) & Pinf_res) ? SIMDE_MATH_FP_PINF : 0)       | \
+            (((imm8 >> 4) & Ninf_res) ? SIMDE_MATH_FP_NINF : 0)       | \
+            (((imm8 >> 5) & Denorm_res) ? SIMDE_MATH_FP_DENORMAL : 0) | \
+            (((imm8 >> 6) & FinNeg_res) ? SIMDE_MATH_FP_NEGATIVE : 0) | \
+            (((imm8 >> 7) & sNaN_res)  ? SIMDE_MATH_FP_SNAN : 0)) ;
   return result;
 }
 
@@ -509,14 +509,14 @@ simde_math_fpclass(double v, const int imm8) {
   uint8_t Denorm_res = ExpAllZeros & (!MantAllZeros);
   uint8_t FinNeg_res = NegNum & (!ExpAllOnes) & (!ZeroNumber);
   uint8_t sNaN_res = ExpAllOnes & (!MantAllZeros) & (!SignalingBit);
-  result = (((imm8 >> 0) & qNaN_res)   | \
-            ((imm8 >> 1) & Pzero_res)  | \
-            ((imm8 >> 2) & Nzero_res)  | \
-            ((imm8 >> 3) & Pinf_res)   | \
-            ((imm8 >> 4) & Ninf_res)   | \
-            ((imm8 >> 5) & Denorm_res) | \
-            ((imm8 >> 6) & FinNeg_res) | \
-            ((imm8 >> 7) & sNaN_res));
+  result = ((((imm8 >> 0) & qNaN_res) ? SIMDE_MATH_FP_QNAN : 0)       | \
+            (((imm8 >> 1) & Pzero_res) ? SIMDE_MATH_FP_PZERO : 0)     | \
+            (((imm8 >> 2) & Nzero_res) ? SIMDE_MATH_FP_NZERO : 0)     | \
+            (((imm8 >> 3) & Pinf_res) ? SIMDE_MATH_FP_PINF : 0)       | \
+            (((imm8 >> 4) & Ninf_res) ? SIMDE_MATH_FP_NINF : 0)       | \
+            (((imm8 >> 5) & Denorm_res) ? SIMDE_MATH_FP_DENORMAL : 0) | \
+            (((imm8 >> 6) & FinNeg_res) ? SIMDE_MATH_FP_NEGATIVE : 0) | \
+            (((imm8 >> 7) & sNaN_res)  ? SIMDE_MATH_FP_SNAN : 0)) ;
   return result;
 }
 


### PR DESCRIPTION
Functions were simply mashing all results into the low bit, instead of spreading them out across the 8 bit result as intended.  The 32-bit version had a wrong constant for exponent mask as well.

I don't know where to put tests for things like this...  here's my test code.

```
#include <stdio.h>
#include <stdlib.h>


#include "simde/simde/simde-common.h"
#include "simde/simde/simde-math.h"



void main()
{
	simde_float64 sNaNf64 = simde_uint64_as_float64(0x7FF0000000000001);
	simde_float64 denormalf64 = simde_uint64_as_float64(0x0000000000000001);

	simde_float32 sNaNf32 = simde_uint32_as_float32(0x7F800001);
	simde_float32 denormalf32 = simde_uint32_as_float32(0x00000001);

	if (simde_math_fpclassf(SIMDE_MATH_NAN, 0xff) != SIMDE_MATH_FP_QNAN)
	{
		printf("32QNAN test failed\n");
	}

	if (simde_math_fpclassf(SIMDE_FLOAT32_C(0.0), 0xff) != SIMDE_MATH_FP_PZERO)
	{
		printf("32PZERO test failed\n");
	}

	if (simde_math_fpclassf(-SIMDE_FLOAT32_C(0.0), 0xff) != SIMDE_MATH_FP_NZERO)
	{
		printf("32NZERO test failed\n");
	}

	if (simde_math_fpclassf(SIMDE_MATH_INFINITY, 0xff) != SIMDE_MATH_FP_PINF)
	{
		printf("32PINF test failed, %f\n", SIMDE_MATH_INFINITY);
	}

	if (simde_math_fpclassf(-SIMDE_MATH_INFINITY, 0xff) != SIMDE_MATH_FP_NINF)
	{
		printf("32NINF test failed\n");
	}

	if (simde_math_fpclassf(denormalf32, 0xff) != SIMDE_MATH_FP_DENORMAL)
	{
		printf("32DENORMAL test failed\n");
	}

	if (simde_math_fpclassf(-SIMDE_FLOAT64_C(42.23), 0xff) != SIMDE_MATH_FP_NEGATIVE)
	{
		printf("32NEGATIVE test failed\n");
	}

	if (simde_math_fpclassf(sNaNf32, 0xff) != SIMDE_MATH_FP_SNAN)
	{
		printf("32SNAN test failed\n");
	}

	// Test that it doesn't report if we tell it not to...
	if (simde_math_fpclassf(sNaNf32, ~SIMDE_MATH_FP_SNAN) == SIMDE_MATH_FP_SNAN)
	{
		printf("32SNAN test failed\n");
	}


	if (simde_math_fpclass(SIMDE_MATH_NAN, 0xff) != SIMDE_MATH_FP_QNAN)
	{
		printf("64QNAN test failed\n");
	}

	if (simde_math_fpclass(SIMDE_FLOAT32_C(0.0), 0xff) != SIMDE_MATH_FP_PZERO)
	{
		printf("64PZERO test failed\n");
	}

	if (simde_math_fpclass(-SIMDE_FLOAT32_C(0.0), 0xff) != SIMDE_MATH_FP_NZERO)
	{
		printf("64NZERO test failed\n");
	}

	if (simde_math_fpclass(SIMDE_MATH_INFINITY, 0xff) != SIMDE_MATH_FP_PINF)
	{
		printf("64PINF test failed\n");
	}

	if (simde_math_fpclass(-SIMDE_MATH_INFINITY, 0xff) != SIMDE_MATH_FP_NINF)
	{
		printf("64NINF test failed\n");
	}

	if (simde_math_fpclass(denormalf64, 0xff) != SIMDE_MATH_FP_DENORMAL)
	{
		printf("64PINF test failed\n");
	}

	if (simde_math_fpclass(-SIMDE_FLOAT64_C(42.23), 0xff) != SIMDE_MATH_FP_NEGATIVE)
	{
		printf("64NEGATIVE test failed\n");
	}

	if (simde_math_fpclass(sNaNf64, 0xff) != SIMDE_MATH_FP_SNAN)
	{
		printf("64SNAN test failed\n");
	}

	if (simde_math_fpclassf(sNaNf64, ~SIMDE_MATH_FP_SNAN) == SIMDE_MATH_FP_SNAN)
	{
		printf("64SNAN test failed\n");
	}
}

```