### PR TITLE
[Neon][RVV] Fallback to autovec without mrvv-vector-bits flag.

### DIFF
--- a/simde/simde-common.h
+++ b/simde/simde-common.h
@@ -1200,7 +1200,7 @@ HEDLEY_DIAGNOSTIC_POP
 #endif
 
 /* Initial support for RISCV V extensions based on ZVE64D. */
-#if defined(SIMDE_ARCH_RISCV_ZVE64D) && SIMDE_NATURAL_VECTOR_SIZE >= 64
+#if defined(SIMDE_ARCH_RISCV_ZVE64D) && SIMDE_NATURAL_VECTOR_SIZE >= 64 && defined(__riscv_v_fixed_vlen)
   #define RVV_FIXED_TYPE_DEF(name, lmul) \
     typedef vint8##name##_t  fixed_vint8##name##_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen * lmul))); \
     typedef vint16##name##_t fixed_vint16##name##_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen * lmul))); \

--- a/simde/simde-features.h
+++ b/simde/simde-features.h
@@ -380,7 +380,7 @@
 #endif
 
 #if !defined(SIMDE_RISCV_V_NATIVE) && !defined(SIMDE_RISCV_V_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
-  #if defined(SIMDE_ARCH_RISCV_V)
+  #if defined(SIMDE_ARCH_RISCV_V) && defined(__riscv_v_fixed_vlen)
     #define SIMDE_RISCV_V_NATIVE
   #endif
 #endif


### PR DESCRIPTION
Fallback to auto vectorization if there is no mvv-vector-bits flag.