### PR TITLE
[Neon][RVV] Enable RVV when there are zve64d and zvl128b flags.

### DIFF
--- a/simde/simde-arch.h
+++ b/simde/simde-arch.h
@@ -541,7 +541,7 @@
 #if defined(__riscv_zve64d)
 #  define SIMDE_ARCH_RISCV_ZVE64D 1
 #endif
-#if defined(__riscv_v)
+#if defined(__riscv_v) || (defined(__riscv_zve64d) && defined(__riscv_zvl128b))
 #  define SIMDE_ARCH_RISCV_V 1
 #endif
 #if defined(__riscv_zvfh)


### PR DESCRIPTION
Enable RVV when there are zve64d and zvl128b flags.