### PR TITLE
x86 sse2 for loongarch: fix GCC build failure

### DIFF
--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -1344,7 +1344,7 @@ simde_mm_bslli_si128 (simde__m128i a, const int imm8)
   #define simde_mm_bslli_si128(a, imm8) _mm_slli_si128(a, imm8)
 #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
   #define simde_mm_bslli_si128(a, imm8) \
-  (((imm8)<=0) ? (a) : (((imm8)>15) ? simde_mm_setzero_si128() : simde__m128i_from_lsx_i8((v16i8)__lsx_vbsll_v(simde__m128i_to_private(a).lsx_i64, (imm8)))))
+  (((imm8)<=0) ? (simde__m128i)(a) : (((imm8)>15) ? simde_mm_setzero_si128() : simde__m128i_from_lsx_i8((v16i8)__lsx_vbsll_v(simde__m128i_to_private(a).lsx_i64, (imm8)))))
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
   #define simde_mm_bslli_si128(a, imm8) \
   simde__m128i_from_neon_i8(((imm8) <= 0) ? simde__m128i_to_neon_i8(a) : (((imm8) > 15) ? (vdupq_n_s8(0)) : (vextq_s8(vdupq_n_s8(0), simde__m128i_to_neon_i8(a), 16 - (imm8)))))
@@ -1442,7 +1442,7 @@ simde_mm_bsrli_si128 (simde__m128i a, const int imm8)
   #define simde_mm_bsrli_si128(a, imm8) _mm_srli_si128(a, imm8)
 #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
   #define simde_mm_bsrli_si128(a, imm8) \
-  (((imm8)<=0) ? (a) : (((imm8)>15) ? simde_mm_setzero_si128() : simde__m128i_from_lsx_i8((v16i8)__lsx_vbsrl_v(simde__m128i_to_private(a).lsx_i64, (imm8)))))
+  (((imm8)<=0) ? (simde__m128i)(a) : (((imm8)>15) ? simde_mm_setzero_si128() : simde__m128i_from_lsx_i8((v16i8)__lsx_vbsrl_v(simde__m128i_to_private(a).lsx_i64, (imm8)))))
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
   #define simde_mm_bsrli_si128(a, imm8) \
   simde__m128i_from_neon_i8(((imm8 < 0) || (imm8 > 15)) ? vdupq_n_s8(0) : (vextq_s8(simde__m128i_to_private(a).neon_i8, vdupq_n_s8(0), ((imm8 & 15) != 0) ? imm8 : (imm8 & 15))))


### PR DESCRIPTION
It seems there is some problem for GCC in dealing with vector type on Ternary Operator, see below:

```
//test.c
#define SIMDE_ENABLE_NATIVE_ALIASES
#include "/home/jin/data/community/simde-loong64/simde/x86/sse2.h"
int main()
{
        __m128i a = {8};
        __m128i b = _mm_slli_si128(a, 3);
        return 0;
}
```

gcc -mlsx test.c，the compile output is:

```
In file included from test.c:2:
test.c: In function ‘main’:
/home/jin/data/community/simde-loong64/simde/x86/sse2.h:1347:22: error: type mismatch in conditional expression
   (((imm8)<=0) ? (a) : (((imm8)>15) ? simde_mm_setzero_si128() : simde__m128i_from_lsx_i8((v16i8)__lsx_vbsll_v(simde__m128i_to_private(a).lsx_i64, (imm8)))))
                      ^
/home/jin/data/community/simde-loong64/simde/x86/sse2.h:1406:35: note: in expansion of macro ‘simde_mm_bslli_si128’
   #define _mm_slli_si128(a, imm8) simde_mm_bslli_si128(a, imm8)
                                   ^~~~~~~~~~~~~~~~~~~~
test.c:6:14: note: in expansion of macro ‘_mm_slli_si128’
  __m128i b = _mm_slli_si128(a, 3);
              ^~~~~~~~~~~~~~
```

We can simplify the demo like bellow, which is tested on x86:

```
//1.c
#include <immintrin.h>
int main() {
        __m128i a, b;
        int i = 3;
        b = i > 0 ? a : a + a;
        return 0;
}
```

gcc 1.c, the compile output is:

```
> 
> > 1.c: In function ‘main’:
> > 1.c:5:23: error: type mismatch in conditional expression
> >     5 |         b = i > 0 ? a : a + a;
> >       |                       ^
```

I have reported the strange phenomenon to our compiler team, they are wroking on it.
But I think there is no harm in adding the `simde__m128i` type-cast for `(a)` to work round this problem.

