### PR TITLE
Add NEON float16 multi-vectors to native aliases

### DIFF
--- a/simde/arm/neon/types.h
+++ b/simde/arm/neon/types.h
@@ -1287,7 +1287,13 @@ typedef union {
 #endif
 
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES) || defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
-  typedef   simde_float16_t     float16_t;
+  typedef   simde_float16_t          float16_t;
+  typedef   simde_float16x4x2_t  float16x4x2_t;
+  typedef   simde_float16x4x3_t  float16x4x3_t;
+  typedef   simde_float16x4x4_t  float16x4x4_t;
+  typedef   simde_float16x8x2_t  float16x8x2_t;
+  typedef   simde_float16x8x3_t  float16x8x3_t;
+  typedef   simde_float16x8x4_t  float16x8x4_t;
 #endif
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   typedef   simde_float32_t     float32_t;

--- a/test/native-aliases.sh
+++ b/test/native-aliases.sh
@@ -53,6 +53,17 @@ perl -p -i -e 's/([^a-zA-Z0-9_])simde_msa_/$1__msa_/g' mips/msa/*.{c,h}
 # NEON
 
 perl -p -i -e 's/([^a-zA-Z0-9_])simde_v/$1v/g' $(ls arm/neon/*.{c,h} | grep -v test-neon.h)
+perl -p -i -e 's/([^a-zA-Z0-9_])simde_int8x/$1int8x/g' $(ls arm/neon/*.{c,h} | grep -v test-neon.h | grep -v reinterpret)
+perl -p -i -e 's/([^a-zA-Z0-9_])simde_int16x/$1int16x/g' $(ls arm/neon/*.{c,h} | grep -v test-neon.h | grep -v reinterpret)
+perl -p -i -e 's/([^a-zA-Z0-9_])simde_int32x/$1int32x/g' $(ls arm/neon/*.{c,h} | grep -v test-neon.h | grep -v reinterpret)
+perl -p -i -e 's/([^a-zA-Z0-9_])simde_int64x/$1int64x/g' $(ls arm/neon/*.{c,h} | grep -v test-neon.h | grep -v reinterpret)
+perl -p -i -e 's/([^a-zA-Z0-9_])simde_uint8x/$1uint8x/g' $(ls arm/neon/*.{c,h} | grep -v test-neon.h | grep -v reinterpret)
+perl -p -i -e 's/([^a-zA-Z0-9_])simde_uint16x/$1uint16x/g' $(ls arm/neon/*.{c,h} | grep -v test-neon.h | grep -v reinterpret)
+perl -p -i -e 's/([^a-zA-Z0-9_])simde_uint32x/$1uint32x/g' $(ls arm/neon/*.{c,h} | grep -v test-neon.h | grep -v reinterpret)
+perl -p -i -e 's/([^a-zA-Z0-9_])simde_uint64x/$1uint64x/g' $(ls arm/neon/*.{c,h} | grep -v test-neon.h | grep -v reinterpret)
+perl -p -i -e 's/([^a-zA-Z0-9_])simde_float16x/$1float16x/g' $(ls arm/neon/*.{c,h} | grep -v test-neon.h | grep -v reinterpret)
+perl -p -i -e 's/([^a-zA-Z0-9_])simde_float32x/$1float32x/g' $(ls arm/neon/*.{c,h} | grep -v test-neon.h | grep -v reinterpret)
+perl -p -i -e 's/([^a-zA-Z0-9_])simde_float64x/$1float64x/g' $(ls arm/neon/*.{c,h} | grep -v test-neon.h | grep -v reinterpret)
 
 # SVE
 


### PR DESCRIPTION
Half-precision multi-vector types are available on the VFPv3_fp16 and VFPv4 architectures for ARMv7