### PR TITLE
prefer NATIVE implementations over SIMDE_VECTOR_SUBSCRIPT_OPS, remove some broken optimized implementations

### DIFF
--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,14 @@
+name: Lint GitHub Actions workflows
+on: [push, pull_request]
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check workflow files
+        run: |
+          echo "::add-matcher::.github/actionlint-matcher.json"
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color
+        shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         sudo apt-get install -y --no-install-recommends ninja-build ninja-build pipx
         pipx install meson==0.55.1
     - run: |
-        meson setup build --prefix $PWD/install -Dtests=false
+        meson setup build --prefix "$PWD/install" -Dtests=false
         meson install -C build --quiet
         diff <(find simde/ -type f -name "*.h")  <(cd install/include/; find simde -type f -name "*.h" )
 
@@ -65,16 +65,34 @@ jobs:
       run: for f in simde/mips/msa/*.h; do grep -q "include \"msa/$(basename "$f")\"" simde/mips/msa.h || (echo "Missing $f" && exit 1); done
     # Make sure we can find the expected header guards.  It's easy to miss this when doing C&P
     - name: Header guards
-      run: for file in $(find simde/*/ -name '*.h'); do grep -q "$(echo "$file" | tr '[:lower:]' '[:upper:]' | tr '[:punct:]' '_')" "$file" || (echo "Missing or incorrect header guard in $file" && exit 1); done
+      run: |
+        while IFS= read -r -d '' file
+        do
+          grep -q "$(echo "$file" | tr '[:lower:]' '[:upper:]' | tr '[:punct:]' '_')" "$file" || (echo "Missing or incorrect header guard in $file" && exit 1)
+        done < <(find simde/*/ -name '*.h' -print0)
     # There should be an empty line at the end of every file
     - name: Newline at EOF
-      run: for file in $(find simde -name '*.h'); do if [ -n "$(tail -c 1 "$file")" ]; then echo "No newline at end of $file" && exit 1; fi; done
+      run: |
+        while IFS= read -r -d '' file
+        do
+          if [ -n "$(tail -c 1 "$file")" ]
+          then echo "No newline at end of $file" && exit 1
+          fi
+        done < <(find simde -name '*.h' -print0)
     # Don't #ifndef ; use !defined(...) instead.  ifndef leads to annoying inconsistencies
     - name: ifndef
-      run: for file in $(find simde -name '*.h'); do grep -qP '^ *# *ifndef ' "${file}" && exit 1 || exit 0; done
+      run: |
+        while IFS= read -r -d '' file
+        do
+          grep -qP '^ *# *ifndef ' "${file}" && exit 1 || exit 0
+        done < <(find simde -name '*.h' -print0)
     # List of headers we want Meson to install
     - name: Meson install headers
-      run: for file in $(find simde -name '*.h'); do grep -qF "$(basename "${file}" .h)" meson.build || (echo "${file} missing from top-level meson.build" && exit 1); done
+      run: |
+        while IFS= read -r -d '' file
+        do
+          grep -qF "$(basename "${file}" .h)" meson.build || (echo "${file} missing from top-level meson.build" && exit 1)
+        done < <(find simde -name '*.h' -print0)
     # Make sure we don't accidentally use `vector ...` instead of SIMDE_POWER_ALTIVEC_VECTOR(...)
     - name: AltiVec raw vector keyword
       run: find simde/ \( -name '*.c' -o -name '*.h' \) -exec grep -nP 'vector( +)((bool|signed|unsigned) +)?(double|float|long long|long|int|short|char)' {} + && exit 1 || exit 0
@@ -134,12 +152,14 @@ jobs:
       run: meson setup build || (cat build/meson-logs/meson-log.txt ; false)
     - name: Test run native?
       run: |
-        test/check-flags.sh query && echo Tests with $CFLAGS will be run natively
-        test/check-flags.sh query || echo Tests with $CFLAGS will be run using SDE
+        test/check-flags.sh query && echo Tests with "$CFLAGS" will be run natively
+        test/check-flags.sh query || echo Tests with "$CFLAGS" will be run using SDE
     - name: Build
       run: ninja -C build -v
     - name: Test
-      run: meson test -C build --print-errorlogs --wrapper "${GITHUB_WORKSPACE}/test/check-flags.sh sde" $(meson test -C build --list | grep -v emul)
+      run: |
+        # shellcheck disable=SC2046
+        meson test -C build --print-errorlogs --wrapper "${GITHUB_WORKSPACE}/test/check-flags.sh sde" $(meson test -C build --list | grep -v emul)
 
   x86-xop:
     runs-on: ubuntu-22.04
@@ -288,7 +308,9 @@ jobs:
     - name: Build
       run: ninja -C build -v
     - name: Test
-      run: meson test -C build --print-errorlogs $(meson test -C build --list | grep -v emul)
+      run: |
+        # shellcheck disable=SC2046
+        meson test -C build --print-errorlogs $(meson test -C build --list | grep -v emul)
 
   gcc:
     strategy:
@@ -372,7 +394,9 @@ jobs:
     - name: Build
       run: meson compile -C build --verbose
     - name: Test
-      run: meson test -C build --print-errorlogs $(meson test -C build --list | grep -v emul)
+      run: |
+        # shellcheck disable=SC2046
+        meson test -C build --print-errorlogs $(meson test -C build --list | grep -v emul)
 
   gcc-qemu:
     strategy:
@@ -475,7 +499,9 @@ jobs:
     - name: Build
       run: ninja -C build -v
     - name: Test
-      run: meson test -C build --print-errorlogs --print-errorlogs $(meson test -C build --list | grep -v emul)
+      run: |
+        # shellcheck disable=SC2046
+        meson test -C build --print-errorlogs --print-errorlogs $(meson test -C build --list | grep -v emul)
 
   clang17-qemu-rvv:
     strategy:
@@ -530,7 +556,9 @@ jobs:
     - name: Build
       run: ninja -C build -v
     - name: Test
-      run: meson test -C build --print-errorlogs --print-errorlogs $(meson test -C build --list | grep -v emul)
+      run: |
+        # shellcheck disable=SC2046
+        meson test -C build --print-errorlogs --print-errorlogs $(meson test -C build --list | grep -v emul)
 
   clang18-qemu-rvv:
     strategy:
@@ -582,7 +610,9 @@ jobs:
     - name: Build
       run: ninja -C build -v
     - name: Test
-      run: meson test -C build --print-errorlogs --print-errorlogs $(meson test -C build --list | grep -v emul)
+      run: |
+        # shellcheck disable=SC2046
+        meson test -C build --print-errorlogs --print-errorlogs $(meson test -C build --list | grep -v emul)
 
   clang-qemu:
     strategy:
@@ -670,7 +700,9 @@ jobs:
     - name: Build
       run: ninja -C build -v
     - name: Test
-      run: meson test -C build --print-errorlogs --print-errorlogs $(meson test -C build --list | grep -v emul)
+      run: |
+        # shellcheck disable=SC2046
+        meson test -C build --print-errorlogs --print-errorlogs $(meson test -C build --list | grep -v emul)
 
   clang:
     strategy:
@@ -832,8 +864,8 @@ jobs:
           clang-${{ matrix.version }}
         pipx install meson==0.55.1
         sudo rm /usr/bin/gcc /usr/bin/g++ /usr/bin/cc /usr/bin/c++
-        sudo ln -s $(command -v clang-${{ matrix.version }}) /usr/bin/cc
-        sudo ln -s $(command -v clang-${{ matrix.version }}) /usr/bin/c++
+        sudo ln -s "$(command -v clang-${{ matrix.version }})" /usr/bin/cc
+        sudo ln -s "$(command -v clang-${{ matrix.version }})" /usr/bin/c++
     - name: add ccache to the build path
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
@@ -842,7 +874,9 @@ jobs:
     - name: Build
       run: meson compile -C build --verbose
     - name: Test
-      run: meson test -C build --print-errorlogs $(meson test -C build --list | grep -v emul)
+      run: |
+        # shellcheck disable=SC2046
+        meson test -C build --print-errorlogs $(meson test -C build --list | grep -v emul)
 
   macos:
     strategy:
@@ -919,7 +953,9 @@ jobs:
     - name: Build
       run: ninja -C build -v
     - name: Test
-      run: meson test -C build --print-errorlogs $(meson test -C build --list | grep -v emul)
+      run: |
+        # shellcheck disable=SC2046
+        meson test -C build --print-errorlogs $(meson test -C build --list | grep -v emul)
 
   icc:
     runs-on: ubuntu-24.04
@@ -945,6 +981,7 @@ jobs:
         sudo apt-get install -y --no-install-recommends intel-oneapi-compiler-dpcpp-cpp
         mkdir -p ~/.local/bin/ || true
         for exe in icx icpx; do
+          # shellcheck disable=SC2016
           printf '#!/bin/bash\nARGS="$@"\nsource /opt/intel/oneapi/compiler/latest/env/vars.sh >/dev/null\n%s ${ARGS}\n' "${exe}" > ~/.local/bin/"${exe}"
           chmod 0755 ~/.local/bin/"${exe}";
         done
@@ -953,4 +990,6 @@ jobs:
     - name: Build
       run: ninja -C build -v
     - name: Test
-      run: meson test -C build --print-errorlogs $(meson test -C build --list | grep -v emul)
+      run: |
+        # shellcheck disable=SC2046
+        meson test -C build --print-errorlogs $(meson test -C build --list | grep -v emul)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,6 +435,11 @@ jobs:
           arch_gnu: powerpc64le
           arch_deb: ppc64el
           distro: ubuntu-24.04
+        - version: 14
+          cross: loongarch64
+          arch_gnu: loongarch64
+          arch_deb: loong64
+          distro: ubuntu-24.04
         # - version: 14
         #   cross: mips64el
         #   arch_gnu: mips64el
@@ -949,30 +954,3 @@ jobs:
       run: ninja -C build -v
     - name: Test
       run: meson test -C build --print-errorlogs $(meson test -C build --list | grep -v emul)
-
-  linux-gcc-loongarch64:
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@v4
-    - name: CPU Information
-      run: cat /proc/cpuinfo
-    - name: Install APT Dependencies
-      run: |
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa && \
-        sudo apt-get update && \
-        sudo apt-get install -y --no-install-recommends \
-          ninja-build meson qemu-user-static binfmt-support \
-          libc6-loong64-cross libstdc++-14-dev-loong64-cross \
-          gcc-14-loongarch64-linux-gnu g++-14-loongarch64-linux-gnu
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        key: ${{ github.job }}-gcc-14
-        evict-old-files: job
-        verbose: 2
-    - name: Configure
-      run: meson setup build --cross-file=docker/cross-files/loongarch64-gcc-14-ccache.cross || (cat build/meson-logs/meson-log.txt ; false)
-    - name: Build
-      run: meson compile -C build -v
-    - name: Test
-      run: meson test -C build --print-errorlogs

--- a/simde/arm/neon/and.h
+++ b/simde/arm/neon/and.h
@@ -111,7 +111,7 @@ simde_vand_s32(simde_int32x2_t a, simde_int32x2_t b) {
 
     #if defined(SIMDE_X86_MMX_NATIVE)
       r_.m64 = _mm_and_si64(a_.m64, b_.m64);
-      #elif defined(SIMDE_RISCV_V_NATIVE)
+    #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv64 = __riscv_vand_vv_i32m1(a_.sv64, b_.sv64, 2);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = a_.values & b_.values;

--- a/simde/arm/neon/cge.h
+++ b/simde/arm/neon/cge.h
@@ -661,10 +661,6 @@ simde_vcge_s32(simde_int32x2_t a, simde_int32x2_t b) {
 
     #if defined(SIMDE_X86_MMX_NATIVE)
       r_.m64 = _mm_or_si64(_mm_cmpgt_pi32(a_.m64, b_.m64), _mm_cmpeq_pi32(a_.m64, b_.m64));
-    #elif defined(SIMDE_RISCV_V_NATIVE)
-      vbool32_t result = __riscv_vmsge_vv_i32m1_b32(a_.sv64, b_.sv64, 2);
-      r_.sv64 = __riscv_vmv_v_x_i32m1(0, 2);
-      r_.sv64 = __riscv_vmerge_vxm_i32m1(r_.sv64, -1, result, 2);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && !defined(SIMDE_BUG_GCC_100762)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
     #else

--- a/simde/arm/neon/cge.h
+++ b/simde/arm/neon/cge.h
@@ -661,12 +661,12 @@ simde_vcge_s32(simde_int32x2_t a, simde_int32x2_t b) {
 
     #if defined(SIMDE_X86_MMX_NATIVE)
       r_.m64 = _mm_or_si64(_mm_cmpgt_pi32(a_.m64, b_.m64), _mm_cmpeq_pi32(a_.m64, b_.m64));
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && !defined(SIMDE_BUG_GCC_100762)
-      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool32_t result = __riscv_vmsge_vv_i32m1_b32(a_.sv64, b_.sv64, 2);
       r_.sv64 = __riscv_vmv_v_x_i32m1(0, 2);
       r_.sv64 = __riscv_vmerge_vxm_i32m1(r_.sv64, -1, result, 2);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && !defined(SIMDE_BUG_GCC_100762)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {

--- a/simde/arm/neon/mvn.h
+++ b/simde/arm/neon/mvn.h
@@ -58,7 +58,7 @@ simde_vmvnq_s8(simde_int8x16_t a) {
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv128 = __riscv_vnot_v_i8m1(a_.sv128, b_.sv128, 16);
+      r_.sv128 = __riscv_vnot_v_i8m1(a_.sv128, 16);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -95,7 +95,7 @@ simde_vmvnq_s16(simde_int16x8_t a) {
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv128 = __riscv_vnot_v_i16m1(a_.sv128, b_.sv128, 8);
+      r_.sv128 = __riscv_vnot_v_i16m1(a_.sv128, 8);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -132,7 +132,7 @@ simde_vmvnq_s32(simde_int32x4_t a) {
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv128 = __riscv_vnot_v_i32m1(a_.sv128, b_.sv128, 4);
+      r_.sv128 = __riscv_vnot_v_i32m1(a_.sv128, 4);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -169,7 +169,7 @@ simde_vmvnq_u8(simde_uint8x16_t a) {
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv128 = __riscv_vnot_v_u8m1(a_.sv128, b_.sv128, 16);
+      r_.sv128 = __riscv_vnot_v_u8m1(a_.sv128, 16);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -206,7 +206,7 @@ simde_vmvnq_u16(simde_uint16x8_t a) {
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv128 = __riscv_vnot_v_u16m1(a_.sv128, b_.sv128, 8);
+      r_.sv128 = __riscv_vnot_v_u16m1(a_.sv128, 8);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -243,7 +243,7 @@ simde_vmvnq_u32(simde_uint32x4_t a) {
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv128 = __riscv_vnot_v_u32m1(a_.sv128, b_.sv128, 4);
+      r_.sv128 = __riscv_vnot_v_u32m1(a_.sv128, 4);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -274,7 +274,7 @@ simde_vmvn_s8(simde_int8x8_t a) {
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv64 = __riscv_vnot_v_i8m1(a_.sv64, b_.sv64, 8);
+      r_.sv64 = __riscv_vnot_v_i8m1(a_.sv64, 8);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -305,7 +305,7 @@ simde_vmvn_s16(simde_int16x4_t a) {
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv64 = __riscv_vnot_v_i16m1(a_.sv64, b_.sv64, 4);
+      r_.sv64 = __riscv_vnot_v_i16m1(a_.sv64, 4);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -336,7 +336,7 @@ simde_vmvn_s32(simde_int32x2_t a) {
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv64 = __riscv_vnot_v_i32m1(a_.sv64, b_.sv64, 2);
+      r_.sv64 = __riscv_vnot_v_i32m1(a_.sv64, 2);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -367,7 +367,7 @@ simde_vmvn_u8(simde_uint8x8_t a) {
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv64 = __riscv_vnot_v_u8m1(a_.sv64, b_.sv64, 8);
+      r_.sv64 = __riscv_vnot_v_u8m1(a_.sv64, 8);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -398,7 +398,7 @@ simde_vmvn_u16(simde_uint16x4_t a) {
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv64 = __riscv_vnot_v_u16m1(a_.sv64, b_.sv64, 4);
+      r_.sv64 = __riscv_vnot_v_u16m1(a_.sv64, 4);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -429,7 +429,7 @@ simde_vmvn_u32(simde_uint32x2_t a) {
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv64 = __riscv_vnot_v_u32m1(a_.sv64, b_.sv64, 2);
+      r_.sv64 = __riscv_vnot_v_u32m1(a_.sv64, 2);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {

--- a/simde/arm/neon/mvn.h
+++ b/simde/arm/neon/mvn.h
@@ -55,10 +55,10 @@ simde_vmvnq_s8(simde_int8x16_t a) {
       r_.m128i = _mm_andnot_si128(a_.m128i, _mm_cmpeq_epi8(a_.m128i, a_.m128i));
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_not(a_.v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv128 = __riscv_vnot_v_i8m1(a_.sv128, 16);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -92,10 +92,10 @@ simde_vmvnq_s16(simde_int16x8_t a) {
       r_.m128i = _mm_andnot_si128(a_.m128i, _mm_cmpeq_epi16(a_.m128i, a_.m128i));
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_not(a_.v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv128 = __riscv_vnot_v_i16m1(a_.sv128, 8);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -129,10 +129,10 @@ simde_vmvnq_s32(simde_int32x4_t a) {
       r_.m128i = _mm_andnot_si128(a_.m128i, _mm_cmpeq_epi32(a_.m128i, a_.m128i));
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_not(a_.v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv128 = __riscv_vnot_v_i32m1(a_.sv128, 4);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -166,10 +166,10 @@ simde_vmvnq_u8(simde_uint8x16_t a) {
       r_.m128i = _mm_andnot_si128(a_.m128i, _mm_cmpeq_epi8(a_.m128i, a_.m128i));
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_not(a_.v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv128 = __riscv_vnot_v_u8m1(a_.sv128, 16);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -203,10 +203,10 @@ simde_vmvnq_u16(simde_uint16x8_t a) {
       r_.m128i = _mm_andnot_si128(a_.m128i, _mm_cmpeq_epi16(a_.m128i, a_.m128i));
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_not(a_.v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv128 = __riscv_vnot_v_u16m1(a_.sv128, 8);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -240,10 +240,10 @@ simde_vmvnq_u32(simde_uint32x4_t a) {
       r_.m128i = _mm_andnot_si128(a_.m128i, _mm_cmpeq_epi32(a_.m128i, a_.m128i));
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_not(a_.v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv128 = __riscv_vnot_v_u32m1(a_.sv128, 4);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -271,10 +271,10 @@ simde_vmvn_s8(simde_int8x8_t a) {
 
     #if defined(SIMDE_X86_MMX_NATIVE)
       r_.m64 = _mm_andnot_si64(a_.m64, _mm_cmpeq_pi8(a_.m64, a_.m64));
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv64 = __riscv_vnot_v_i8m1(a_.sv64, 8);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -302,10 +302,10 @@ simde_vmvn_s16(simde_int16x4_t a) {
 
     #if defined(SIMDE_X86_MMX_NATIVE)
       r_.m64 = _mm_andnot_si64(a_.m64, _mm_cmpeq_pi16(a_.m64, a_.m64));
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv64 = __riscv_vnot_v_i16m1(a_.sv64, 4);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -333,10 +333,10 @@ simde_vmvn_s32(simde_int32x2_t a) {
 
     #if defined(SIMDE_X86_MMX_NATIVE)
       r_.m64 = _mm_andnot_si64(a_.m64, _mm_cmpeq_pi32(a_.m64, a_.m64));
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv64 = __riscv_vnot_v_i32m1(a_.sv64, 2);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -364,10 +364,10 @@ simde_vmvn_u8(simde_uint8x8_t a) {
 
     #if defined(SIMDE_X86_MMX_NATIVE)
       r_.m64 = _mm_andnot_si64(a_.m64, _mm_cmpeq_pi8(a_.m64, a_.m64));
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv64 = __riscv_vnot_v_u8m1(a_.sv64, 8);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -395,10 +395,10 @@ simde_vmvn_u16(simde_uint16x4_t a) {
 
     #if defined(SIMDE_X86_MMX_NATIVE)
       r_.m64 = _mm_andnot_si64(a_.m64, _mm_cmpeq_pi16(a_.m64, a_.m64));
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv64 = __riscv_vnot_v_u16m1(a_.sv64, 4);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
@@ -426,10 +426,10 @@ simde_vmvn_u32(simde_uint32x2_t a) {
 
     #if defined(SIMDE_X86_MMX_NATIVE)
       r_.m64 = _mm_andnot_si64(a_.m64, _mm_cmpeq_pi32(a_.m64, a_.m64));
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.values = ~a_.values;
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv64 = __riscv_vnot_v_u32m1(a_.sv64, 2);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {

--- a/simde/x86/sse.h
+++ b/simde/x86/sse.h
@@ -974,10 +974,10 @@ simde_mm_and_ps (simde__m128 a, simde__m128 b) {
       r_.wasm_v128 = wasm_v128_and(a_.wasm_v128, b_.wasm_v128);
     #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       r_.lsx_i64 = __lsx_vand_v(a_.lsx_i64, b_.lsx_i64);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i32 = a_.i32 & b_.i32;
     #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
       r_.altivec_f32 = vec_and(a_.altivec_f32, b_.altivec_f32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 & b_.i32;
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
@@ -3504,12 +3504,12 @@ simde_mm_mul_ps (simde__m128 a, simde__m128 b) {
       r_.neon_f32 = vmulq_f32(a_.neon_f32, b_.neon_f32);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 = wasm_f32x4_mul(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.f32 = a_.f32 * b_.f32;
     #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
       r_.altivec_f32 = vec_mul(a_.altivec_f32, b_.altivec_f32);
     #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       r_.lsx_f32 = __lsx_vfmul_s(a_.lsx_f32, b_.lsx_f32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f32 = a_.f32 * b_.f32;
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {

--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -3590,8 +3590,6 @@ simde_mm_div_pd (simde__m128d a, simde__m128d b) {
       r_.neon_f64 = vdivq_f64(a_.neon_f64, b_.neon_f64);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 =  wasm_f64x2_div(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
-      r_.lsx_f64 = __lsx_vfdiv_d(b_.lsx_f64, a_.lsx_f64);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.f64 = a_.f64 / b_.f64;
     #else

--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -574,7 +574,7 @@ simde_x_mm_select_pd(simde__m128d a, simde__m128d b, simde__m128d mask) {
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_i64 = vbslq_s64(mask_.neon_u64, b_.neon_i64, a_.neon_i64);
     #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
-      r_.lsx_i64 = __lsx_vbitsel_v(a_.lsx_i64, b_.lsx_i64, mask_.lsx_u64);
+      r_.lsx_i64 = __lsx_vbitsel_v(a_.lsx_i64, b_.lsx_i64, (__m128i)mask_.lsx_u64);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.i64 = a_.i64 ^ ((a_.i64 ^ b_.i64) & mask_.i64);
     #else

--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -571,12 +571,12 @@ simde_x_mm_select_pd(simde__m128d a, simde__m128d b, simde__m128d mask) {
       b_ = simde__m128d_to_private(b),
       mask_ = simde__m128d_to_private(mask);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i64 = a_.i64 ^ ((a_.i64 ^ b_.i64) & mask_.i64);
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_i64 = vbslq_s64(mask_.neon_u64, b_.neon_i64, a_.neon_i64);
     #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
-      r_.lsx_i64 = __lsx_vbitsel_v(a_.lsx_i64, b_.lsx_i64, mask_.lsx_u64)
+      r_.lsx_i64 = __lsx_vbitsel_v(a_.lsx_i64, b_.lsx_i64, mask_.lsx_u64);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 ^ ((a_.i64 ^ b_.i64) & mask_.i64);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
@@ -1171,14 +1171,14 @@ simde_mm_xor_pd (simde__m128d a, simde__m128d b) {
       a_ = simde__m128d_to_private(a),
       b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i32f = a_.i32f ^ b_.i32f;
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 = wasm_v128_xor(a_.wasm_v128, b_.wasm_v128);
     #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_i64 = veorq_s64(a_.neon_i64, b_.neon_i64);
     #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       r_.lsx_i64 = __lsx_vxor_v(a_.lsx_i64, b_.lsx_i64);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f ^ b_.i32f;
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
@@ -2241,9 +2241,7 @@ simde_mm_cmple_pd (simde__m128d a, simde__m128d b) {
       a_ = simde__m128d_to_private(a),
       b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i64 = HEDLEY_REINTERPRET_CAST(__typeof__(r_.i64), (a_.f64 <= b_.f64));
-    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
       r_.neon_u64 = vcleq_f64(a_.neon_f64, b_.neon_f64);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 = wasm_f64x2_le(a_.wasm_v128, b_.wasm_v128);
@@ -2251,6 +2249,8 @@ simde_mm_cmple_pd (simde__m128d a, simde__m128d b) {
       r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmple(a_.altivec_f64, b_.altivec_f64));
     #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       r_.lsx_i64 = __lsx_vfcmp_cle_d(a_.lsx_f64, b_.lsx_f64);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = HEDLEY_REINTERPRET_CAST(__typeof__(r_.i64), (a_.f64 <= b_.f64));
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
@@ -2408,9 +2408,7 @@ simde_mm_cmpgt_pd (simde__m128d a, simde__m128d b) {
       a_ = simde__m128d_to_private(a),
       b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i64 = HEDLEY_REINTERPRET_CAST(__typeof__(r_.i64), (a_.f64 > b_.f64));
-    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
       r_.neon_u64 = vcgtq_f64(a_.neon_f64, b_.neon_f64);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 = wasm_f64x2_gt(a_.wasm_v128, b_.wasm_v128);
@@ -2418,6 +2416,8 @@ simde_mm_cmpgt_pd (simde__m128d a, simde__m128d b) {
       r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmpgt(a_.altivec_f64, b_.altivec_f64));
     #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       r_.lsx_i64 = __lsx_vfcmp_clt_d(b_.lsx_f64, a_.lsx_f64);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = HEDLEY_REINTERPRET_CAST(__typeof__(r_.i64), (a_.f64 > b_.f64));
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
@@ -2470,9 +2470,7 @@ simde_mm_cmpge_pd (simde__m128d a, simde__m128d b) {
       a_ = simde__m128d_to_private(a),
       b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i64 = HEDLEY_REINTERPRET_CAST(__typeof__(r_.i64), (a_.f64 >= b_.f64));
-    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
       r_.neon_u64 = vcgeq_f64(a_.neon_f64, b_.neon_f64);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 = wasm_f64x2_ge(a_.wasm_v128, b_.wasm_v128);
@@ -2480,6 +2478,8 @@ simde_mm_cmpge_pd (simde__m128d a, simde__m128d b) {
       r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmpge(a_.altivec_f64, b_.altivec_f64));
     #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       r_.lsx_i64 = __lsx_vfcmp_cle_d(b_.lsx_f64, a_.lsx_f64);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = HEDLEY_REINTERPRET_CAST(__typeof__(r_.i64), (a_.f64 >= b_.f64));
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
@@ -3586,14 +3586,14 @@ simde_mm_div_pd (simde__m128d a, simde__m128d b) {
       a_ = simde__m128d_to_private(a),
       b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.f64 = a_.f64 / b_.f64;
-    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
       r_.neon_f64 = vdivq_f64(a_.neon_f64, b_.neon_f64);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 =  wasm_f64x2_div(a_.wasm_v128, b_.wasm_v128);
     #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       r_.lsx_f64 = __lsx_vfdiv_d(b_.lsx_f64, a_.lsx_f64);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = a_.f64 / b_.f64;
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
@@ -4123,6 +4123,9 @@ simde_mm_madd_epi16 (simde__m128i a, simde__m128i b) {
       r_.altivec_i32 = vec_mule(a_.altivec_i16, b_.altivec_i16) + vec_mulo(a_.altivec_i16, b_.altivec_i16);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 = wasm_i32x4_dot_i16x8(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
+      __m128i temp_ev = __lsx_vmulwev_w_h(a_.lsx_i64, b_.lsx_i64);
+      r_.lsx_i64 = __lsx_vmaddwod_w_h(temp_ev, a_.lsx_i64, b_.lsx_i64);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_CONVERT_VECTOR_) && HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
       int32_t SIMDE_VECTOR(32) a32, b32, p32;
       SIMDE_CONVERT_VECTOR_(a32, a_.i16);
@@ -4131,9 +4134,6 @@ simde_mm_madd_epi16 (simde__m128i a, simde__m128i b) {
       r_.i32 =
         __builtin_shufflevector(p32, p32, 0, 2, 4, 6) +
         __builtin_shufflevector(p32, p32, 1, 3, 5, 7);
-    #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
-      __m128i temp_ev = __lsx_vmulwev_w_h(a_.lsx_i64, b_.lsx_i64);
-      r_.lsx_i64 = __lsx_vmaddwod_w_h(temp_ev, a_.lsx_i64, b_.lsx_i64);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i16[0])) ; i += 2) {
@@ -4713,14 +4713,14 @@ simde_mm_mul_pd (simde__m128d a, simde__m128d b) {
       a_ = simde__m128d_to_private(a),
       b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.f64 = a_.f64 * b_.f64;
-    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
       r_.neon_f64 = vmulq_f64(a_.neon_f64, b_.neon_f64);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 = wasm_f64x2_mul(a_.wasm_v128, b_.wasm_v128);
     #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       r_.lsx_f64 = __lsx_vfmul_d(a_.lsx_f64, b_.lsx_f64);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = a_.f64 * b_.f64;
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
@@ -4927,14 +4927,14 @@ simde_mm_or_pd (simde__m128d a, simde__m128d b) {
       a_ = simde__m128d_to_private(a),
       b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i32f = a_.i32f | b_.i32f;
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 = wasm_v128_or(a_.wasm_v128, b_.wasm_v128);
     #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_i64 = vorrq_s64(a_.neon_i64, b_.neon_i64);
     #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       r_.lsx_i64 = __lsx_vor_v(a_.lsx_i64, b_.lsx_i64);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f | b_.i32f;
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
@@ -7376,12 +7376,12 @@ simde_x_mm_sub_epu32 (simde__m128i a, simde__m128i b) {
     a_ = simde__m128i_to_private(a),
     b_ = simde__m128i_to_private(b);
 
-  #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-    r_.u32 = a_.u32 - b_.u32;
-  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_u32 = vsubq_u32(a_.neon_u32, b_.neon_u32);
   #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
     r_.lsx_i64 = __lsx_vsub_w(a_.lsx_i64, b_.lsx_i64);
+  #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    r_.u32 = a_.u32 - b_.u32;
   #else
     SIMDE_VECTORIZE
     for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
@@ -7403,14 +7403,14 @@ simde_mm_sub_pd (simde__m128d a, simde__m128d b) {
       a_ = simde__m128d_to_private(a),
       b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.f64 = a_.f64 - b_.f64;
-    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
       r_.neon_f64 = vsubq_f64(a_.neon_f64, b_.neon_f64);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 = wasm_f64x2_sub(a_.wasm_v128, b_.wasm_v128);
     #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       r_.lsx_f64 = __lsx_vfsub_d(a_.lsx_f64, b_.lsx_f64);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = a_.f64 - b_.f64;
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
@@ -7463,10 +7463,10 @@ simde_mm_sub_si64 (simde__m64 a, simde__m64 b) {
       a_ = simde__m64_to_private(a),
       b_ = simde__m64_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i64 = a_.i64 - b_.i64;
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_i64 = vsub_s64(a_.neon_i64, b_.neon_i64);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 - b_.i64;
     #else
       r_.i64[0] = a_.i64[0] - b_.i64[0];
     #endif

--- a/simde/x86/sse4.1.h
+++ b/simde/x86/sse4.1.h
@@ -638,12 +638,12 @@ simde_mm_cmpeq_epi64 (simde__m128i a, simde__m128i b) {
       uint32x4_t cmp = vceqq_u32(a_.neon_u32, b_.neon_u32);
       uint32x4_t swapped = vrev64q_u32(cmp);
       r_.neon_u32 = vandq_u32(cmp, swapped);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i64 = HEDLEY_REINTERPRET_CAST(__typeof__(r_.i64), a_.i64 == b_.i64);
     #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
       r_.altivec_i64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed long long), vec_cmpeq(a_.altivec_i64, b_.altivec_i64));
     #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       r_.lsx_i64 = __lsx_vseq_d(a_.lsx_i64, b_.lsx_i64);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = HEDLEY_REINTERPRET_CAST(__typeof__(r_.i64), a_.i64 == b_.i64);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {

--- a/simde/x86/svml.h
+++ b/simde/x86/svml.h
@@ -2683,9 +2683,7 @@ simde_mm_div_epi8 (simde__m128i a, simde__m128i b) {
       a_ = simde__m128i_to_private(a),
       b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i8x4_div(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.i8 = a_.i8 / b_.i8;
     #else
       SIMDE_VECTORIZE
@@ -2713,9 +2711,7 @@ simde_mm_div_epi16 (simde__m128i a, simde__m128i b) {
       a_ = simde__m128i_to_private(a),
       b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i16x4_div(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.i16 = a_.i16 / b_.i16;
     #else
       SIMDE_VECTORIZE
@@ -2743,9 +2739,7 @@ simde_mm_div_epi32 (simde__m128i a, simde__m128i b) {
       a_ = simde__m128i_to_private(a),
       b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i32x4_div(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.i32 = a_.i32 / b_.i32;
     #else
       SIMDE_VECTORIZE
@@ -2776,9 +2770,7 @@ simde_mm_div_epi64 (simde__m128i a, simde__m128i b) {
       a_ = simde__m128i_to_private(a),
       b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i64x4_div(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.i64 = a_.i64 / b_.i64;
     #else
       SIMDE_VECTORIZE
@@ -2806,9 +2798,7 @@ simde_mm_div_epu8 (simde__m128i a, simde__m128i b) {
       a_ = simde__m128i_to_private(a),
       b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_u8x16_div(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.u8 = a_.u8 / b_.u8;
     #else
       SIMDE_VECTORIZE
@@ -2836,9 +2826,7 @@ simde_mm_div_epu16 (simde__m128i a, simde__m128i b) {
       a_ = simde__m128i_to_private(a),
       b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_u16x16_div(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.u16 = a_.u16 / b_.u16;
     #else
       SIMDE_VECTORIZE
@@ -2866,9 +2854,7 @@ simde_mm_div_epu32 (simde__m128i a, simde__m128i b) {
       a_ = simde__m128i_to_private(a),
       b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_u32x16_div(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.u32 = a_.u32 / b_.u32;
     #else
       SIMDE_VECTORIZE
@@ -2899,9 +2885,7 @@ simde_mm_div_epu64 (simde__m128i a, simde__m128i b) {
       a_ = simde__m128i_to_private(a),
       b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_u64x16_div(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.u64 = a_.u64 / b_.u64;
     #else
       SIMDE_VECTORIZE

--- a/simde/x86/svml.h
+++ b/simde/x86/svml.h
@@ -2071,7 +2071,7 @@ simde_x_mm_deg2rad_ps(simde__m128 a) {
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_53784)
       r_.f32 = a_.f32 * SIMDE_MATH_PI_OVER_180F;
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-    const __typeof__(r_.f32) tmp = { SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F };
+      const __typeof__(r_.f32) tmp = { SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F };
       r_.f32 = a_.f32 * tmp;
     #else
       SIMDE_VECTORIZE
@@ -2097,9 +2097,9 @@ simde_x_mm_deg2rad_pd(simde__m128d a) {
     #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
       r_.neon_f64 = vmulq_n_f64(a_.neon_i64, SIMDE_MATH_PI_OVER_180);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_53784)
-    r_.f64 = a_.f64 * SIMDE_MATH_PI_OVER_180;
+      r_.f64 = a_.f64 * SIMDE_MATH_PI_OVER_180;
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-    const __typeof__(r_.f64) tmp = { SIMDE_MATH_PI_OVER_180, SIMDE_MATH_PI_OVER_180 };
+      const __typeof__(r_.f64) tmp = { SIMDE_MATH_PI_OVER_180, SIMDE_MATH_PI_OVER_180 };
       r_.f64 = a_.f64 * tmp;
     #else
       SIMDE_VECTORIZE
@@ -2127,9 +2127,9 @@ simde_x_mm256_deg2rad_ps(simde__m256 a) {
         r_.m128[i] = simde_x_mm_deg2rad_ps(a_.m128[i]);
       }
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_53784)
-    r_.f32 = a_.f32 * SIMDE_MATH_PI_OVER_180F;
+      r_.f32 = a_.f32 * SIMDE_MATH_PI_OVER_180F;
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-    const __typeof__(r_.f32) tmp = {
+      const __typeof__(r_.f32) tmp = {
         SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F,
         SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F
       };
@@ -2160,9 +2160,9 @@ simde_x_mm256_deg2rad_pd(simde__m256d a) {
         r_.m128d[i] = simde_x_mm_deg2rad_pd(a_.m128d[i]);
       }
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_53784)
-    r_.f64 = a_.f64 * SIMDE_MATH_PI_OVER_180;
+      r_.f64 = a_.f64 * SIMDE_MATH_PI_OVER_180;
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-    const __typeof__(r_.f64) tmp = { SIMDE_MATH_PI_OVER_180, SIMDE_MATH_PI_OVER_180, SIMDE_MATH_PI_OVER_180, SIMDE_MATH_PI_OVER_180 };
+      const __typeof__(r_.f64) tmp = { SIMDE_MATH_PI_OVER_180, SIMDE_MATH_PI_OVER_180, SIMDE_MATH_PI_OVER_180, SIMDE_MATH_PI_OVER_180 };
       r_.f64 = a_.f64 * tmp;
     #else
       SIMDE_VECTORIZE
@@ -2190,9 +2190,9 @@ simde_x_mm512_deg2rad_ps(simde__m512 a) {
         r_.m256[i] = simde_x_mm256_deg2rad_ps(a_.m256[i]);
       }
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_53784)
-    r_.f32 = a_.f32 * SIMDE_MATH_PI_OVER_180F;
+      r_.f32 = a_.f32 * SIMDE_MATH_PI_OVER_180F;
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-    const __typeof__(r_.f32) tmp = {
+      const __typeof__(r_.f32) tmp = {
         SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F,
         SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F,
         SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F,
@@ -2225,9 +2225,9 @@ simde_x_mm512_deg2rad_pd(simde__m512d a) {
         r_.m256d[i] = simde_x_mm256_deg2rad_pd(a_.m256d[i]);
       }
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_53784)
-    r_.f64 = a_.f64 * SIMDE_MATH_PI_OVER_180;
+      r_.f64 = a_.f64 * SIMDE_MATH_PI_OVER_180;
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-    const __typeof__(r_.f64) tmp = {
+      const __typeof__(r_.f64) tmp = {
         SIMDE_MATH_PI_OVER_180, SIMDE_MATH_PI_OVER_180, SIMDE_MATH_PI_OVER_180, SIMDE_MATH_PI_OVER_180,
         SIMDE_MATH_PI_OVER_180, SIMDE_MATH_PI_OVER_180, SIMDE_MATH_PI_OVER_180, SIMDE_MATH_PI_OVER_180
       };
@@ -2683,10 +2683,10 @@ simde_mm_div_epi8 (simde__m128i a, simde__m128i b) {
       a_ = simde__m128i_to_private(a),
       b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x4_div(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.i8 = a_.i8 / b_.i8;
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-    r_.wasm_v128 = wasm_i8x4_div(a_.wasm_v128, b_.wasm_v128);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
@@ -2713,10 +2713,10 @@ simde_mm_div_epi16 (simde__m128i a, simde__m128i b) {
       a_ = simde__m128i_to_private(a),
       b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x4_div(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.i16 = a_.i16 / b_.i16;
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-    r_.wasm_v128 = wasm_i16x4_div(a_.wasm_v128, b_.wasm_v128);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
@@ -2743,10 +2743,10 @@ simde_mm_div_epi32 (simde__m128i a, simde__m128i b) {
       a_ = simde__m128i_to_private(a),
       b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_div(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.i32 = a_.i32 / b_.i32;
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-    r_.wasm_v128 = wasm_i32x4_div(a_.wasm_v128, b_.wasm_v128);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
@@ -2776,10 +2776,10 @@ simde_mm_div_epi64 (simde__m128i a, simde__m128i b) {
       a_ = simde__m128i_to_private(a),
       b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i64x4_div(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.i64 = a_.i64 / b_.i64;
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-    r_.wasm_v128 = wasm_i64x4_div(a_.wasm_v128, b_.wasm_v128);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
@@ -2806,10 +2806,10 @@ simde_mm_div_epu8 (simde__m128i a, simde__m128i b) {
       a_ = simde__m128i_to_private(a),
       b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u8x16_div(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.u8 = a_.u8 / b_.u8;
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-    r_.wasm_v128 = wasm_u8x16_div(a_.wasm_v128, b_.wasm_v128);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
@@ -2836,10 +2836,10 @@ simde_mm_div_epu16 (simde__m128i a, simde__m128i b) {
       a_ = simde__m128i_to_private(a),
       b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u16x16_div(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.u16 = a_.u16 / b_.u16;
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-    r_.wasm_v128 = wasm_u16x16_div(a_.wasm_v128, b_.wasm_v128);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
@@ -2866,10 +2866,10 @@ simde_mm_div_epu32 (simde__m128i a, simde__m128i b) {
       a_ = simde__m128i_to_private(a),
       b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u32x16_div(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.u32 = a_.u32 / b_.u32;
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-    r_.wasm_v128 = wasm_u32x16_div(a_.wasm_v128, b_.wasm_v128);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
@@ -2899,10 +2899,10 @@ simde_mm_div_epu64 (simde__m128i a, simde__m128i b) {
       a_ = simde__m128i_to_private(a),
       b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u64x16_div(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.u64 = a_.u64 / b_.u64;
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-    r_.wasm_v128 = wasm_u64x16_div(a_.wasm_v128, b_.wasm_v128);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {


### PR DESCRIPTION
Misuse RVV intrinsics vnot. We didn't find this error cause it always use builtin vector operation in the testing.