### PR TITLE
test.h: define __STDC_FORMAT_MACROS if not defined

### DIFF
--- a/test/test.h
+++ b/test/test.h
@@ -6,6 +6,12 @@
 #include "../simde/simde-f16.h"
 #include "../simde/simde-bf16.h"
 
+#if (!defined(__clang__) || SIMDE_DETECT_CLANG_VERSION_CHECK(13, 0, 0))
+  #ifndef __STDC_FORMAT_MACROS
+    #define __STDC_FORMAT_MACROS
+  #endif
+#endif
+
 #include <time.h>
 #include <stdlib.h>
 #include <math.h>


### PR DESCRIPTION
Fixes this:
```
In file included from test/common/common.cpp:1:
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h: In function 'void simde_test_codegen_i8(size_t, char*, int8_t)':
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:187:61: error: expected ')' before 'PRId8'
  187 |     simde_test_codegen_snprintf_(buf, buf_len, "%cINT8_C(%4" PRId8 ")", (value < 0) ? '-' : ' ', HEDLEY_STATIC_CAST(int8_t, (value < 0) ? -value : value));
      |                                 ~                           ^~~~~~
      |                                                             )
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:14:1: note: 'PRId8' is defined in header '<cinttypes>'; this is probably fixable by adding '#include <cinttypes>'
   13 | #include <stdarg.h>
  +++ |+#include <cinttypes>
   14 | 
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:187:59: warning: conversion lacks type at end of format [-Wformat=]
  187 |     simde_test_codegen_snprintf_(buf, buf_len, "%cINT8_C(%4" PRId8 ")", (value < 0) ? '-' : ' ', HEDLEY_STATIC_CAST(int8_t, (value < 0) ? -value : value));
      |                                                           ^
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:187:48: warning: too many arguments for format [-Wformat-extra-args]
  187 |     simde_test_codegen_snprintf_(buf, buf_len, "%cINT8_C(%4" PRId8 ")", (value < 0) ? '-' : ' ', HEDLEY_STATIC_CAST(int8_t, (value < 0) ? -value : value));
      |                                                ^~~~~~~~~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h: In function 'void simde_test_codegen_i16(size_t, char*, int16_t)':
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:198:62: error: expected ')' before 'PRId16'
  198 |     simde_test_codegen_snprintf_(buf, buf_len, "%cINT16_C(%6" PRId16 ")", (value < 0) ? '-' : ' ', HEDLEY_STATIC_CAST(int16_t, (value < 0) ? -value : value));
      |                                 ~                            ^~~~~~~
      |                                                              )
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:198:63: note: 'PRId16' is defined in header '<cinttypes>'; this is probably fixable by adding '#include <cinttypes>'
  198 |     simde_test_codegen_snprintf_(buf, buf_len, "%cINT16_C(%6" PRId16 ")", (value < 0) ? '-' : ' ', HEDLEY_STATIC_CAST(int16_t, (value < 0) ? -value : value));
      |                                                               ^~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:198:60: warning: conversion lacks type at end of format [-Wformat=]
  198 |     simde_test_codegen_snprintf_(buf, buf_len, "%cINT16_C(%6" PRId16 ")", (value < 0) ? '-' : ' ', HEDLEY_STATIC_CAST(int16_t, (value < 0) ? -value : value));
      |                                                            ^
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:198:48: warning: too many arguments for format [-Wformat-extra-args]
  198 |     simde_test_codegen_snprintf_(buf, buf_len, "%cINT16_C(%6" PRId16 ")", (value < 0) ? '-' : ' ', HEDLEY_STATIC_CAST(int16_t, (value < 0) ? -value : value));
      |                                                ^~~~~~~~~~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h: In function 'void simde_test_codegen_i32(size_t, char*, int32_t)':
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:209:63: error: expected ')' before 'PRId32'
  209 |     simde_test_codegen_snprintf_(buf, buf_len, "%cINT32_C(%12" PRId32 ")", (value < 0) ? '-' : ' ', HEDLEY_STATIC_CAST(int32_t, (value < 0) ? -value : value));
      |                                 ~                             ^~~~~~~
      |                                                               )
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:209:64: note: 'PRId32' is defined in header '<cinttypes>'; this is probably fixable by adding '#include <cinttypes>'
  209 |     simde_test_codegen_snprintf_(buf, buf_len, "%cINT32_C(%12" PRId32 ")", (value < 0) ? '-' : ' ', HEDLEY_STATIC_CAST(int32_t, (value < 0) ? -value : value));
      |                                                                ^~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:209:61: warning: conversion lacks type at end of format [-Wformat=]
  209 |     simde_test_codegen_snprintf_(buf, buf_len, "%cINT32_C(%12" PRId32 ")", (value < 0) ? '-' : ' ', HEDLEY_STATIC_CAST(int32_t, (value < 0) ? -value : value));
      |                                                             ^
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:209:48: warning: too many arguments for format [-Wformat-extra-args]
  209 |     simde_test_codegen_snprintf_(buf, buf_len, "%cINT32_C(%12" PRId32 ")", (value < 0) ? '-' : ' ', HEDLEY_STATIC_CAST(int32_t, (value < 0) ? -value : value));
      |                                                ^~~~~~~~~~~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h: In function 'void simde_test_codegen_i64(size_t, char*, int64_t)':
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:220:63: error: expected ')' before 'PRId64'
  220 |     simde_test_codegen_snprintf_(buf, buf_len, "%cINT64_C(%20" PRId64 ")", (value < 0) ? '-' : ' ', HEDLEY_STATIC_CAST(int64_t, (value < 0) ? -value : value));
      |                                 ~                             ^~~~~~~
      |                                                               )
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:220:64: note: 'PRId64' is defined in header '<cinttypes>'; this is probably fixable by adding '#include <cinttypes>'
  220 |     simde_test_codegen_snprintf_(buf, buf_len, "%cINT64_C(%20" PRId64 ")", (value < 0) ? '-' : ' ', HEDLEY_STATIC_CAST(int64_t, (value < 0) ? -value : value));
      |                                                                ^~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:220:61: warning: conversion lacks type at end of format [-Wformat=]
  220 |     simde_test_codegen_snprintf_(buf, buf_len, "%cINT64_C(%20" PRId64 ")", (value < 0) ? '-' : ' ', HEDLEY_STATIC_CAST(int64_t, (value < 0) ? -value : value));
      |                                                             ^
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:220:48: warning: too many arguments for format [-Wformat-extra-args]
  220 |     simde_test_codegen_snprintf_(buf, buf_len, "%cINT64_C(%20" PRId64 ")", (value < 0) ? '-' : ' ', HEDLEY_STATIC_CAST(int64_t, (value < 0) ? -value : value));
      |                                                ^~~~~~~~~~~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h: In function 'void simde_test_codegen_u8(size_t, char*, uint8_t)':
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:229:60: error: expected ')' before 'PRIu8'
  229 |     simde_test_codegen_snprintf_(buf, buf_len, "UINT8_C(%3" PRIu8 ")", value);
      |                                 ~                          ^~~~~~
      |                                                            )
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:229:61: note: 'PRIu8' is defined in header '<cinttypes>'; this is probably fixable by adding '#include <cinttypes>'
  229 |     simde_test_codegen_snprintf_(buf, buf_len, "UINT8_C(%3" PRIu8 ")", value);
      |                                                             ^~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:229:58: warning: conversion lacks type at end of format [-Wformat=]
  229 |     simde_test_codegen_snprintf_(buf, buf_len, "UINT8_C(%3" PRIu8 ")", value);
      |                                                          ^
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:229:48: warning: too many arguments for format [-Wformat-extra-args]
  229 |     simde_test_codegen_snprintf_(buf, buf_len, "UINT8_C(%3" PRIu8 ")", value);
      |                                                ^~~~~~~~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h: In function 'void simde_test_codegen_u16(size_t, char*, uint16_t)':
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:238:61: error: expected ')' before 'PRIu16'
  238 |     simde_test_codegen_snprintf_(buf, buf_len, "UINT16_C(%5" PRIu16 ")", value);
      |                                 ~                           ^~~~~~~
      |                                                             )
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:238:62: note: 'PRIu16' is defined in header '<cinttypes>'; this is probably fixable by adding '#include <cinttypes>'
  238 |     simde_test_codegen_snprintf_(buf, buf_len, "UINT16_C(%5" PRIu16 ")", value);
      |                                                              ^~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:238:59: warning: conversion lacks type at end of format [-Wformat=]
  238 |     simde_test_codegen_snprintf_(buf, buf_len, "UINT16_C(%5" PRIu16 ")", value);
      |                                                           ^
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:238:48: warning: too many arguments for format [-Wformat-extra-args]
  238 |     simde_test_codegen_snprintf_(buf, buf_len, "UINT16_C(%5" PRIu16 ")", value);
      |                                                ^~~~~~~~~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h: In function 'void simde_test_codegen_u32(size_t, char*, uint32_t)':
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:247:62: error: expected ')' before 'PRIu32'
  247 |     simde_test_codegen_snprintf_(buf, buf_len, "UINT32_C(%10" PRIu32 ")", value);
      |                                 ~                            ^~~~~~~
      |                                                              )
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:247:63: note: 'PRIu32' is defined in header '<cinttypes>'; this is probably fixable by adding '#include <cinttypes>'
  247 |     simde_test_codegen_snprintf_(buf, buf_len, "UINT32_C(%10" PRIu32 ")", value);
      |                                                               ^~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:247:60: warning: conversion lacks type at end of format [-Wformat=]
  247 |     simde_test_codegen_snprintf_(buf, buf_len, "UINT32_C(%10" PRIu32 ")", value);
      |                                                            ^
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:247:48: warning: too many arguments for format [-Wformat-extra-args]
  247 |     simde_test_codegen_snprintf_(buf, buf_len, "UINT32_C(%10" PRIu32 ")", value);
      |                                                ^~~~~~~~~~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h: In function 'void simde_test_codegen_u64(size_t, char*, uint64_t)':
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:256:62: error: expected ')' before 'PRIu64'
  256 |     simde_test_codegen_snprintf_(buf, buf_len, "UINT64_C(%20" PRIu64 ")", value);
      |                                 ~                            ^~~~~~~
      |                                                              )
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:256:63: note: 'PRIu64' is defined in header '<cinttypes>'; this is probably fixable by adding '#include <cinttypes>'
  256 |     simde_test_codegen_snprintf_(buf, buf_len, "UINT64_C(%20" PRIu64 ")", value);
      |                                                               ^~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:256:60: warning: conversion lacks type at end of format [-Wformat=]
  256 |     simde_test_codegen_snprintf_(buf, buf_len, "UINT64_C(%20" PRIu64 ")", value);
      |                                                            ^
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:256:48: warning: too many arguments for format [-Wformat-extra-args]
  256 |     simde_test_codegen_snprintf_(buf, buf_len, "UINT64_C(%20" PRIu64 ")", value);
      |                                                ^~~~~~~~~~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h: In function 'void simde_test_codegen_p8(size_t, char*, simde_poly8)':
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:266:66: error: expected ')' before 'PRIu8'
  266 |     simde_test_codegen_snprintf_(buf, buf_len, "SIMDE_POLY8_C(%3" PRIu8 ")", value_);
      |                                 ~                                ^~~~~~
      |                                                                  )
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:266:67: note: 'PRIu8' is defined in header '<cinttypes>'; this is probably fixable by adding '#include <cinttypes>'
  266 |     simde_test_codegen_snprintf_(buf, buf_len, "SIMDE_POLY8_C(%3" PRIu8 ")", value_);
      |                                                                   ^~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:266:64: warning: conversion lacks type at end of format [-Wformat=]
  266 |     simde_test_codegen_snprintf_(buf, buf_len, "SIMDE_POLY8_C(%3" PRIu8 ")", value_);
      |                                                                ^
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:266:48: warning: too many arguments for format [-Wformat-extra-args]
  266 |     simde_test_codegen_snprintf_(buf, buf_len, "SIMDE_POLY8_C(%3" PRIu8 ")", value_);
      |                                                ^~~~~~~~~~~~~~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h: In function 'void simde_test_codegen_p16(size_t, char*, simde_poly16)':
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:276:67: error: expected ')' before 'PRIu16'
  276 |     simde_test_codegen_snprintf_(buf, buf_len, "SIMDE_POLY16_C(%5" PRIu16 ")", value_);
      |                                 ~                                 ^~~~~~~
      |                                                                   )
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:276:68: note: 'PRIu16' is defined in header '<cinttypes>'; this is probably fixable by adding '#include <cinttypes>'
  276 |     simde_test_codegen_snprintf_(buf, buf_len, "SIMDE_POLY16_C(%5" PRIu16 ")", value_);
      |                                                                    ^~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:276:65: warning: conversion lacks type at end of format [-Wformat=]
  276 |     simde_test_codegen_snprintf_(buf, buf_len, "SIMDE_POLY16_C(%5" PRIu16 ")", value_);
      |                                                                 ^
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:276:48: warning: too many arguments for format [-Wformat-extra-args]
  276 |     simde_test_codegen_snprintf_(buf, buf_len, "SIMDE_POLY16_C(%5" PRIu16 ")", value_);
      |                                                ^~~~~~~~~~~~~~~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h: In function 'void simde_test_codegen_p64(size_t, char*, simde_poly64)':
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:286:68: error: expected ')' before 'PRIu64'
  286 |     simde_test_codegen_snprintf_(buf, buf_len, "SIMDE_POLY64_C(%20" PRIu64 ")", value_);
      |                                 ~                                  ^~~~~~~
      |                                                                    )
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:286:69: note: 'PRIu64' is defined in header '<cinttypes>'; this is probably fixable by adding '#include <cinttypes>'
  286 |     simde_test_codegen_snprintf_(buf, buf_len, "SIMDE_POLY64_C(%20" PRIu64 ")", value_);
      |                                                                     ^~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:286:66: warning: conversion lacks type at end of format [-Wformat=]
  286 |     simde_test_codegen_snprintf_(buf, buf_len, "SIMDE_POLY64_C(%20" PRIu64 ")", value_);
      |                                                                  ^
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:286:48: warning: too many arguments for format [-Wformat-extra-args]
  286 |     simde_test_codegen_snprintf_(buf, buf_len, "SIMDE_POLY64_C(%20" PRIu64 ")", value_);
      |                                                ^~~~~~~~~~~~~~~~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h: In function 'int simde_assert_equal_vp8_(size_t, const simde_poly8*, const simde_poly8*, const char*, int, const char*, const char*)':
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:951:80: error: expected ')' before 'PRIu8'
  951 |       simde_test_debug_printf_("%s:%d: assertion failed: %s[%zu] ~= %s[%zu] (%" PRIu8 " ~= %" PRIu8 ")\n",
      |                               ~                                                ^~~~~~
      |                                                                                )
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:951:81: note: 'PRIu8' is defined in header '<cinttypes>'; this is probably fixable by adding '#include <cinttypes>'
  951 |       simde_test_debug_printf_("%s:%d: assertion failed: %s[%zu] ~= %s[%zu] (%" PRIu8 " ~= %" PRIu8 ")\n",
      |                                                                                 ^~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:951:78: warning: spurious trailing '%' in format [-Wformat=]
  951 |       simde_test_debug_printf_("%s:%d: assertion failed: %s[%zu] ~= %s[%zu] (%" PRIu8 " ~= %" PRIu8 ")\n",
      |                                                                              ^
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:951:32: warning: too many arguments for format [-Wformat-extra-args]
  951 |       simde_test_debug_printf_("%s:%d: assertion failed: %s[%zu] ~= %s[%zu] (%" PRIu8 " ~= %" PRIu8 ")\n",
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h: In function 'int simde_assert_equal_p8_(simde_poly8, simde_poly8, const char*, int, const char*, const char*)':
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:966:68: error: expected ')' before 'PRIu8'
  966 |     simde_test_debug_printf_("%s:%d: assertion failed: %s ~= %s (%" PRIu8 " ~= %" PRIu8 ")\n",
      |                             ~                                      ^~~~~~
      |                                                                    )
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:966:69: note: 'PRIu8' is defined in header '<cinttypes>'; this is probably fixable by adding '#include <cinttypes>'
  966 |     simde_test_debug_printf_("%s:%d: assertion failed: %s ~= %s (%" PRIu8 " ~= %" PRIu8 ")\n",
      |                                                                     ^~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:966:66: warning: spurious trailing '%' in format [-Wformat=]
  966 |     simde_test_debug_printf_("%s:%d: assertion failed: %s ~= %s (%" PRIu8 " ~= %" PRIu8 ")\n",
      |                                                                  ^
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:966:30: warning: too many arguments for format [-Wformat-extra-args]
  966 |     simde_test_debug_printf_("%s:%d: assertion failed: %s ~= %s (%" PRIu8 " ~= %" PRIu8 ")\n",
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h: In function 'int simde_assert_equal_vp16_(size_t, const simde_poly16*, const simde_poly16*, const char*, int, const char*, const char*)':
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:983:80: error: expected ')' before 'PRIu16'
  983 |       simde_test_debug_printf_("%s:%d: assertion failed: %s[%zu] ~= %s[%zu] (%" PRIu16 " ~= %" PRIu16 ")\n",
      |                               ~                                                ^~~~~~~
      |                                                                                )
../simde-b673cb2ec15a160ae34d8c002af5d550bd127375/test/common/../test.h:983:81: note: 'PRIu16' is defined in header '<cinttypes>'; this is probably fixable by adding '#include <cinttypes>'
  983 |       simde_test_debug_printf_("%s:%d: assertion failed: %s[%zu] ~= %s[%zu] (%" PRIu16 " ~= %" PRIu16 ")\n",
      |                                                                                 ^~~~~~
```

P. S. Including `<cinttypes>` isn’t a satisfactory fix, though gcc will be happy with it. But other compilers/platforms may still need `__STDC_FORMAT_MACROS`, so just use that instead.