### PR TITLE
x86 sse2: add powerpc*-darwin support for `simde_mm_pause`

### DIFF
--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -5245,7 +5245,11 @@ simde_mm_pause (void) {
       __asm__ __volatile__("isb\n");
     #endif
   #elif defined(SIMDE_ARCH_POWER)
-    __asm__ __volatile__ ("or 27,27,27" ::: "memory");
+    #if defined(__APPLE__)
+      __asm__ __volatile__ ("or r27,r27,r27" ::: "memory");
+    #else
+      __asm__ __volatile__ ("or 27,27,27" ::: "memory");
+    #endif
   #elif defined(SIMDE_ARCH_WASM)
     __asm__ __volatile__ ("nop");
   #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)


### PR DESCRIPTION
See: https://github.com/simd-everywhere/simde/issues/1313