### PR TITLE
arm neon `ld1{,q_x[234]}`: speedups on SSE[32] & WASM

### DIFF
--- a/simde/arm/neon/ld1.h
+++ b/simde/arm/neon/ld1.h
@@ -267,6 +267,8 @@ simde_vld1q_f16(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
       r_.v128 = wasm_v128_load(ptr);
     #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
       r_.sv128 = __riscv_vle16_v_f16m1((_Float16 *)ptr , 8);
+    #elif defined(SIMDE_X86_AVX512FP16_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+      r_.m128h = _mm_loadu_ph(SIMDE_ALIGN_CAST(__m128h const *, ptr));
     #else
       simde_memcpy(&r_, ptr, sizeof(r_));
     #endif
@@ -289,6 +291,8 @@ simde_vld1q_f32(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(4)]) {
       r_.v128 = wasm_v128_load(ptr);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv128 = __riscv_vle32_v_f32m1(ptr , 4);
+    #elif defined(SIMDE_X86_SSE_NATIVE)
+      r_.m128 = _mm_loadu_ps(ptr);
     #else
       simde_memcpy(&r_, ptr, sizeof(r_));
     #endif
@@ -311,6 +315,8 @@ simde_vld1q_f64(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(2)]) {
       r_.v128 = wasm_v128_load(ptr);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv128 = __riscv_vle64_v_f64m1(ptr , 2);
+    #elif defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128d = _mm_loadu_pd(ptr);
     #else
       simde_memcpy(&r_, ptr, sizeof(r_));
     #endif
@@ -333,6 +339,10 @@ simde_vld1q_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
       r_.v128 = wasm_v128_load(ptr);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv128 = __riscv_vle8_v_i8m1(ptr , 16);
+    #elif defined(SIMDE_X86_SSE3_NATIVE)
+      r_.m128i = _mm_lddqu_si128(SIMDE_ALIGN_CAST(__m128i const *, ptr));
+    #elif defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i = _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, ptr));
     #else
       simde_memcpy(&r_, ptr, sizeof(r_));
     #endif
@@ -355,6 +365,10 @@ simde_vld1q_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
       r_.v128 = wasm_v128_load(ptr);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv128 = __riscv_vle16_v_i16m1(ptr , 8);
+    #elif defined(SIMDE_X86_SSE3_NATIVE)
+      r_.m128i = _mm_lddqu_si128(SIMDE_ALIGN_CAST(__m128i const *, ptr));
+    #elif defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i = _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, ptr));
     #else
       simde_memcpy(&r_, ptr, sizeof(r_));
     #endif
@@ -377,6 +391,10 @@ simde_vld1q_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
       r_.v128 = wasm_v128_load(ptr);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv128 = __riscv_vle32_v_i32m1(ptr , 4);
+    #elif defined(SIMDE_X86_SSE3_NATIVE)
+      r_.m128i = _mm_lddqu_si128(SIMDE_ALIGN_CAST(__m128i const *, ptr));
+    #elif defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i = _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, ptr));
     #else
       simde_memcpy(&r_, ptr, sizeof(r_));
     #endif
@@ -399,6 +417,10 @@ simde_vld1q_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
       r_.v128 = wasm_v128_load(ptr);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv128 = __riscv_vle64_v_i64m1(ptr , 2);
+    #elif defined(SIMDE_X86_SSE3_NATIVE)
+      r_.m128i = _mm_lddqu_si128(SIMDE_ALIGN_CAST(__m128i const *, ptr));
+    #elif defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i = _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, ptr));
     #else
       simde_memcpy(&r_, ptr, sizeof(r_));
     #endif
@@ -421,6 +443,10 @@ simde_vld1q_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
       r_.v128 = wasm_v128_load(ptr);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv128 = __riscv_vle8_v_u8m1(ptr , 16);
+    #elif defined(SIMDE_X86_SSE3_NATIVE)
+      r_.m128i = _mm_lddqu_si128(SIMDE_ALIGN_CAST(__m128i const *, ptr));
+    #elif defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i = _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, ptr));
     #else
       simde_memcpy(&r_, ptr, sizeof(r_));
     #endif
@@ -443,6 +469,10 @@ simde_vld1q_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
       r_.v128 = wasm_v128_load(ptr);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv128 = __riscv_vle16_v_u16m1(ptr , 8);
+    #elif defined(SIMDE_X86_SSE3_NATIVE)
+      r_.m128i = _mm_lddqu_si128(SIMDE_ALIGN_CAST(__m128i const *, ptr));
+    #elif defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i = _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, ptr));
     #else
       simde_memcpy(&r_, ptr, sizeof(r_));
     #endif
@@ -465,6 +495,10 @@ simde_vld1q_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
       r_.v128 = wasm_v128_load(ptr);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv128 = __riscv_vle32_v_u32m1(ptr , 4);
+    #elif defined(SIMDE_X86_SSE3_NATIVE)
+      r_.m128i = _mm_lddqu_si128(SIMDE_ALIGN_CAST(__m128i const *, ptr));
+    #elif defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i = _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, ptr));
     #else
       simde_memcpy(&r_, ptr, sizeof(r_));
     #endif
@@ -487,6 +521,10 @@ simde_vld1q_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
       r_.v128 = wasm_v128_load(ptr);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       r_.sv128 = __riscv_vle64_v_u64m1(ptr , 2);
+    #elif defined(SIMDE_X86_SSE3_NATIVE)
+      r_.m128i = _mm_lddqu_si128(SIMDE_ALIGN_CAST(__m128i const *, ptr));
+    #elif defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i = _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, ptr));
     #else
       simde_memcpy(&r_, ptr, sizeof(r_));
     #endif

--- a/simde/arm/neon/ld1q_x2.h
+++ b/simde/arm/neon/ld1q_x2.h
@@ -26,12 +26,14 @@
  *   2021      Décio Luiz Gazzoni Filho <decio@decpp.net>
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
  *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw> (Copyright owned by NTHU pllab)
+ *   2025      Michael R. Crusoe <crusoe@debian.org>
  */
 
 #if !defined(SIMDE_ARM_NEON_LD1Q_X2_H)
 #define SIMDE_ARM_NEON_LD1Q_X2_H
 
 #include "types.h"
+#include "ld1.h"
 
 HEDLEY_DIAGNOSTIC_PUSH
 SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
@@ -51,17 +53,11 @@ simde_vld1q_f16_x2(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_f16_x2(ptr);
   #else
-    simde_float16x8_private a_[2];
-    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
-      a_[0].sv128 = __riscv_vle16_v_f16m1((_Float16 *)ptr , 8);
-      a_[1].sv128 = __riscv_vle16_v_f16m1((_Float16 *)(ptr+8) , 8);
-    #else
-      for (size_t i = 0; i < 16; i++) {
-        a_[i / 8].values[i % 8] = ptr[i];
-      }
-    #endif
-    simde_float16x8x2_t s_ = { { simde_float16x8_from_private(a_[0]),
-                                 simde_float16x8_from_private(a_[1]) } };
+    simde_float16x8_t a_[2];
+    for (size_t i = 0; i < 2; i++) {
+      a_[i] = simde_vld1q_f16(ptr + 8*i);
+    }
+    simde_float16x8x2_t s_ = { { a_[0], a_[1] } };
     return s_;
   #endif
 }
@@ -81,17 +77,11 @@ simde_vld1q_f32_x2(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(8)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_f32_x2(ptr);
   #else
-    simde_float32x4_private a_[2];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle32_v_f32m1(ptr , 4);
-      a_[1].sv128 = __riscv_vle32_v_f32m1(ptr+4 , 4);
-    #else
-      for (size_t i = 0; i < 8; i++) {
-        a_[i / 4].values[i % 4] = ptr[i];
-      }
-    #endif
-    simde_float32x4x2_t s_ = { { simde_float32x4_from_private(a_[0]),
-                                 simde_float32x4_from_private(a_[1]) } };
+    simde_float32x4_t a_[2];
+    for (size_t i = 0; i < 2; i++) {
+      a_[i] = simde_vld1q_f32(ptr + 4*i);
+    }
+    simde_float32x4x2_t s_ = { { a_[0], a_[1] } };
     return s_;
   #endif
 }
@@ -111,17 +101,11 @@ simde_vld1q_f64_x2(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(4)]) {
       (!defined(__clang__) || SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0))
     return vld1q_f64_x2(ptr);
   #else
-    simde_float64x2_private a_[2];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle64_v_f64m1(ptr , 2);
-      a_[1].sv128 = __riscv_vle64_v_f64m1(ptr+2 , 2);
-    #else
-      for (size_t i = 0; i < 4; i++) {
-        a_[i / 2].values[i % 2] = ptr[i];
-      }
-    #endif
-    simde_float64x2x2_t s_ = { { simde_float64x2_from_private(a_[0]),
-                                 simde_float64x2_from_private(a_[1]) } };
+    simde_float64x2_t a_[2];
+    for (size_t i = 0; i < 2; i++) {
+      a_[i] = simde_vld1q_f64(ptr + 2*i);
+    }
+    simde_float64x2x2_t s_ = { { a_[0], a_[1] } };
     return s_;
   #endif
 }
@@ -141,17 +125,11 @@ simde_vld1q_s8_x2(int8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_s8_x2(ptr);
   #else
-    simde_int8x16_private a_[2];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle8_v_i8m1(ptr , 16);
-      a_[1].sv128 = __riscv_vle8_v_i8m1(ptr+16 , 16);
-    #else
-      for (size_t i = 0; i < 32; i++) {
-        a_[i / 16].values[i % 16] = ptr[i];
-      }
-    #endif
-    simde_int8x16x2_t s_ = { { simde_int8x16_from_private(a_[0]),
-                               simde_int8x16_from_private(a_[1]) } };
+    simde_int8x16_t a_[2];
+    for (size_t i = 0; i < 2; i++) {
+      a_[i] = simde_vld1q_s8(ptr + 16*i);
+    }
+    simde_int8x16x2_t s_ = { { a_[0], a_[1] } };
     return s_;
   #endif
 }
@@ -171,17 +149,11 @@ simde_vld1q_s16_x2(int16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_s16_x2(ptr);
   #else
-    simde_int16x8_private a_[2];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle16_v_i16m1(ptr , 8);
-      a_[1].sv128 = __riscv_vle16_v_i16m1(ptr+8 , 8);
-    #else
-      for (size_t i = 0; i < 16; i++) {
-        a_[i / 8].values[i % 8] = ptr[i];
-      }
-    #endif
-    simde_int16x8x2_t s_ = { { simde_int16x8_from_private(a_[0]),
-                               simde_int16x8_from_private(a_[1]) } };
+    simde_int16x8_t a_[2];
+    for (size_t i = 0; i < 2; i++) {
+      a_[i] = simde_vld1q_s16(ptr + 8*i);
+    }
+    simde_int16x8x2_t s_ = { { a_[0], a_[1] } };
     return s_;
   #endif
 }
@@ -201,17 +173,11 @@ simde_vld1q_s32_x2(int32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_s32_x2(ptr);
   #else
-    simde_int32x4_private a_[2];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle32_v_i32m1(ptr , 4);
-      a_[1].sv128 = __riscv_vle32_v_i32m1(ptr+4 , 4);
-    #else
-      for (size_t i = 0; i < 8; i++) {
-        a_[i / 4].values[i % 4] = ptr[i];
-      }
-    #endif
-    simde_int32x4x2_t s_ = { { simde_int32x4_from_private(a_[0]),
-                               simde_int32x4_from_private(a_[1]) } };
+    simde_int32x4_t a_[2];
+    for (size_t i = 0; i < 2; i++) {
+      a_[i] = simde_vld1q_s32(ptr + 4*i);
+    }
+    simde_int32x4x2_t s_ = { { a_[0], a_[1] } };
     return s_;
   #endif
 }
@@ -231,17 +197,11 @@ simde_vld1q_s64_x2(int64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_s64_x2(ptr);
   #else
-    simde_int64x2_private a_[2];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle64_v_i64m1(ptr , 2);
-      a_[1].sv128 = __riscv_vle64_v_i64m1(ptr+2 , 2);
-    #else
-      for (size_t i = 0; i < 4; i++) {
-        a_[i / 2].values[i % 2] = ptr[i];
-      }
-    #endif
-    simde_int64x2x2_t s_ = { { simde_int64x2_from_private(a_[0]),
-                               simde_int64x2_from_private(a_[1]) } };
+    simde_int64x2_t a_[2];
+    for (size_t i = 0; i < 2; i++) {
+      a_[i] = simde_vld1q_s64(ptr + 2*i);
+    }
+    simde_int64x2x2_t s_ = { { a_[0], a_[1] } };
     return s_;
   #endif
 }
@@ -261,17 +221,11 @@ simde_vld1q_u8_x2(uint8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_u8_x2(ptr);
   #else
-    simde_uint8x16_private a_[2];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle8_v_u8m1(ptr , 16);
-      a_[1].sv128 = __riscv_vle8_v_u8m1(ptr+16 , 16);
-    #else
-      for (size_t i = 0; i < 32; i++) {
-        a_[i / 16].values[i % 16] = ptr[i];
-      }
-    #endif
-    simde_uint8x16x2_t s_ = { { simde_uint8x16_from_private(a_[0]),
-                                simde_uint8x16_from_private(a_[1]) } };
+    simde_uint8x16_t a_[2];
+    for (size_t i = 0; i < 2; i++) {
+      a_[i] = simde_vld1q_u8(ptr + 16*i);
+    }
+    simde_uint8x16x2_t s_ = { { a_[0], a_[1] } };
     return s_;
   #endif
 }
@@ -291,17 +245,11 @@ simde_vld1q_u16_x2(uint16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_u16_x2(ptr);
   #else
-    simde_uint16x8_private a_[2];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle16_v_u16m1(ptr , 8);
-      a_[1].sv128 = __riscv_vle16_v_u16m1(ptr+8 , 8);
-    #else
-      for (size_t i = 0; i < 16; i++) {
-        a_[i / 8].values[i % 8] = ptr[i];
-      }
-    #endif
-    simde_uint16x8x2_t s_ = { { simde_uint16x8_from_private(a_[0]),
-                                simde_uint16x8_from_private(a_[1]) } };
+    simde_uint16x8_t a_[2];
+    for (size_t i = 0; i < 2; i++) {
+      a_[i] = simde_vld1q_u16(ptr + 8*i);
+    }
+    simde_uint16x8x2_t s_ = { { a_[0], a_[1] } };
     return s_;
   #endif
 }
@@ -321,17 +269,11 @@ simde_vld1q_u32_x2(uint32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_u32_x2(ptr);
   #else
-    simde_uint32x4_private a_[2];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle32_v_u32m1(ptr , 4);
-      a_[1].sv128 = __riscv_vle32_v_u32m1(ptr+4 , 4);
-    #else
-      for (size_t i = 0; i < 8; i++) {
-        a_[i / 4].values[i % 4] = ptr[i];
-      }
-    #endif
-    simde_uint32x4x2_t s_ = { { simde_uint32x4_from_private(a_[0]),
-                                simde_uint32x4_from_private(a_[1]) } };
+    simde_uint32x4_t a_[2];
+    for (size_t i = 0; i < 2; i++) {
+      a_[i] = simde_vld1q_u32(ptr + 4*i);
+    }
+    simde_uint32x4x2_t s_ = { { a_[0], a_[1] } };
     return s_;
   #endif
 }
@@ -351,17 +293,11 @@ simde_vld1q_u64_x2(uint64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_u64_x2(ptr);
   #else
-    simde_uint64x2_private a_[2];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle64_v_u64m1(ptr , 2);
-      a_[1].sv128 = __riscv_vle64_v_u64m1(ptr+2 , 2);
-    #else
-      for (size_t i = 0; i < 4; i++) {
-        a_[i / 2].values[i % 2] = ptr[i];
-      }
-    #endif
-    simde_uint64x2x2_t s_ = { { simde_uint64x2_from_private(a_[0]),
-                                simde_uint64x2_from_private(a_[1]) } };
+    simde_uint64x2_t a_[2];
+    for (size_t i = 0; i < 2; i++) {
+      a_[i] = simde_vld1q_u64(ptr + 2*i);
+    }
+    simde_uint64x2x2_t s_ = { { a_[0], a_[1] } };
     return s_;
   #endif
 }
@@ -380,17 +316,11 @@ simde_vld1q_p8_x2(simde_poly8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_p8_x2(ptr);
   #else
-    simde_poly8x16_private a_[2];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle8_v_u8m1(ptr , 16);
-      a_[1].sv128 = __riscv_vle8_v_u8m1(ptr+16 , 16);
-    #else
-      for (size_t i = 0; i < 32; i++) {
-        a_[i / 16].values[i % 16] = ptr[i];
-      }
-    #endif
-    simde_poly8x16x2_t s_ = { { simde_poly8x16_from_private(a_[0]),
-                                simde_poly8x16_from_private(a_[1]) } };
+    simde_poly8x16_t a_[2];
+    for (size_t i = 0; i < 2; i++) {
+      a_[i] = simde_vld1q_p8(ptr + 8*i);
+    }
+    simde_poly8x16x2_t s_ = { { a_[0], a_[1] } };
     return s_;
   #endif
 }
@@ -408,17 +338,11 @@ simde_vld1q_p16_x2(simde_poly16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_p16_x2(ptr);
   #else
-    simde_poly16x8_private a_[2];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle16_v_u16m1(ptr , 8);
-      a_[1].sv128 = __riscv_vle16_v_u16m1(ptr+8 , 8);
-    #else
-      for (size_t i = 0; i < 16; i++) {
-        a_[i / 8].values[i % 8] = ptr[i];
-      }
-    #endif
-    simde_poly16x8x2_t s_ = { { simde_poly16x8_from_private(a_[0]),
-                                simde_poly16x8_from_private(a_[1]) } };
+    simde_poly16x8_t a_[2];
+    for (size_t i = 0; i < 2; i++) {
+      a_[i] = simde_vld1q_p16(ptr + 4*i);
+    }
+    simde_poly16x8x2_t s_ = { { a_[0], a_[1] } };
     return s_;
   #endif
 }
@@ -436,17 +360,11 @@ simde_vld1q_p64_x2(simde_poly64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_p64_x2(ptr);
   #else
-    simde_poly64x2_private a_[2];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle64_v_u64m1(ptr , 2);
-      a_[1].sv128 = __riscv_vle64_v_u64m1(ptr+2 , 2);
-    #else
-      for (size_t i = 0; i < 4; i++) {
-        a_[i / 2].values[i % 2] = ptr[i];
-      }
-    #endif
-    simde_poly64x2x2_t s_ = { { simde_poly64x2_from_private(a_[0]),
-                                simde_poly64x2_from_private(a_[1]) } };
+    simde_poly64x2_t a_[2];
+    for (size_t i = 0; i < 2; i++) {
+      a_[i] = simde_vld1q_p64(ptr + 2*i);
+    }
+    simde_poly64x2x2_t s_ = { { a_[0], a_[1] } };
     return s_;
   #endif
 }
@@ -476,7 +394,6 @@ simde_vld1q_bf16_x2(simde_bfloat16 const ptr[HEDLEY_ARRAY_PARAM(16)]) {
   #undef vld1q_bf16_x2
   #define vld1q_bf16_x2(a) simde_vld1q_bf16_x2((a))
 #endif
-
 
 #endif /* !defined(SIMDE_BUG_INTEL_857088) */
 

--- a/simde/arm/neon/ld1q_x3.h
+++ b/simde/arm/neon/ld1q_x3.h
@@ -25,12 +25,14 @@
  *   2021      Zhi An Ng <zhin@google.com> (Copyright owned by Google, LLC)
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
  *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw> (Copyright owned by NTHU pllab)
+ *   2025      Michael R. Crusoe <crusoe@debian.org>
  */
 
 #if !defined(SIMDE_ARM_NEON_LD1Q_X3_H)
 #define SIMDE_ARM_NEON_LD1Q_X3_H
 
 #include "types.h"
+#include "ld1.h"
 
 HEDLEY_DIAGNOSTIC_PUSH
 SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
@@ -50,19 +52,11 @@ simde_vld1q_f16_x3(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(24)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_f16_x3(ptr);
   #else
-    simde_float16x8_private a_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
-      a_[0].sv128 = __riscv_vle16_v_f16m1((_Float16 *)ptr , 8);
-      a_[1].sv128 = __riscv_vle16_v_f16m1((_Float16 *)(ptr+8) , 8);
-      a_[2].sv128 = __riscv_vle16_v_f16m1((_Float16 *)(ptr+16) , 8);
-    #else
-      for (size_t i = 0; i < 24; i++) {
-        a_[i / 8].values[i % 8] = ptr[i];
-      }
-    #endif
-    simde_float16x8x3_t s_ = { { simde_float16x8_from_private(a_[0]),
-                                 simde_float16x8_from_private(a_[1]),
-                                 simde_float16x8_from_private(a_[2]) } };
+    simde_float16x8_t a_[3];
+    for (size_t i = 0; i < 3; i++) {
+      a_[i] = simde_vld1q_f16(ptr + 8*i);
+    }
+    simde_float16x8x3_t s_ = { { a_[0], a_[1], a_[2] } };
     return s_;
   #endif
 }
@@ -83,19 +77,11 @@ simde_vld1q_f32_x3(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(12)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_f32_x3(ptr);
   #else
-    simde_float32x4_private a_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle32_v_f32m1(ptr , 4);
-      a_[1].sv128 = __riscv_vle32_v_f32m1(ptr+4 , 4);
-      a_[2].sv128 = __riscv_vle32_v_f32m1(ptr+8 , 4);
-    #else
-      for (size_t i = 0; i < 12; i++) {
-        a_[i / 4].values[i % 4] = ptr[i];
-      }
-    #endif
-    simde_float32x4x3_t s_ = { { simde_float32x4_from_private(a_[0]),
-                                 simde_float32x4_from_private(a_[1]),
-                                 simde_float32x4_from_private(a_[2]) } };
+    simde_float32x4_t a_[3];
+    for (size_t i = 0; i < 3; i++) {
+      a_[i] = simde_vld1q_f32(ptr + 4*i);
+    }
+    simde_float32x4x3_t s_ = { { a_[0], a_[1], a_[2] } };
     return s_;
   #endif
 }
@@ -115,19 +101,11 @@ simde_vld1q_f64_x3(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(6)]) {
       (!defined(__clang__) || SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0))
     return vld1q_f64_x3(ptr);
   #else
-    simde_float64x2_private a_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle64_v_f64m1(ptr , 2);
-      a_[1].sv128 = __riscv_vle64_v_f64m1(ptr+2 , 2);
-      a_[2].sv128 = __riscv_vle64_v_f64m1(ptr+4 , 2);
-    #else
-      for (size_t i = 0; i < 6; i++) {
-        a_[i / 2].values[i % 2] = ptr[i];
-      }
-    #endif
-    simde_float64x2x3_t s_ = { { simde_float64x2_from_private(a_[0]),
-                                 simde_float64x2_from_private(a_[1]),
-                                 simde_float64x2_from_private(a_[2]) } };
+    simde_float64x2_t a_[3];
+    for (size_t i = 0; i < 3; i++) {
+      a_[i] = simde_vld1q_f64(ptr + 2*i);
+    }
+    simde_float64x2x3_t s_ = { { a_[0], a_[1], a_[2] } };
     return s_;
   #endif
 }
@@ -147,19 +125,11 @@ simde_vld1q_s8_x3(int8_t const ptr[HEDLEY_ARRAY_PARAM(48)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_s8_x3(ptr);
   #else
-    simde_int8x16_private a_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle8_v_i8m1(ptr , 16);
-      a_[1].sv128 = __riscv_vle8_v_i8m1(ptr+16 , 16);
-      a_[2].sv128 = __riscv_vle8_v_i8m1(ptr+32 , 16);
-    #else
-      for (size_t i = 0; i < 48; i++) {
-        a_[i / 16].values[i % 16] = ptr[i];
-      }
-    #endif
-    simde_int8x16x3_t s_ = { { simde_int8x16_from_private(a_[0]),
-                               simde_int8x16_from_private(a_[1]),
-                               simde_int8x16_from_private(a_[2]) } };
+    simde_int8x16_t a_[3];
+    for (size_t i = 0; i < 3; i++) {
+      a_[i] = simde_vld1q_s8(ptr + 16*i);
+    }
+    simde_int8x16x3_t s_ = { { a_[0], a_[1], a_[2] } };
     return s_;
   #endif
 }
@@ -172,26 +142,18 @@ simde_vld1q_s8_x3(int8_t const ptr[HEDLEY_ARRAY_PARAM(48)]) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_int16x8x3_t
-simde_vld1q_s16_x3(int16_t const ptr[HEDLEY_ARRAY_PARAM(12)]) {
+simde_vld1q_s16_x3(int16_t const ptr[HEDLEY_ARRAY_PARAM(24)]) {
   #if \
       defined(SIMDE_ARM_NEON_A32V7_NATIVE) && \
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE))) && \
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_s16_x3(ptr);
   #else
-    simde_int16x8_private a_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle16_v_i16m1(ptr , 8);
-      a_[1].sv128 = __riscv_vle16_v_i16m1(ptr+8 , 8);
-      a_[2].sv128 = __riscv_vle16_v_i16m1(ptr+16 , 8);
-    #else
-      for (size_t i = 0; i < 24; i++) {
-        a_[i / 8].values[i % 8] = ptr[i];
-      }
-    #endif
-    simde_int16x8x3_t s_ = { { simde_int16x8_from_private(a_[0]),
-                               simde_int16x8_from_private(a_[1]),
-                               simde_int16x8_from_private(a_[2]) } };
+    simde_int16x8_t a_[3];
+    for (size_t i = 0; i < 3; i++) {
+      a_[i] = simde_vld1q_s16(ptr + 8*i);
+    }
+    simde_int16x8x3_t s_ = { { a_[0], a_[1], a_[2] } };
     return s_;
   #endif
 }
@@ -204,26 +166,18 @@ simde_vld1q_s16_x3(int16_t const ptr[HEDLEY_ARRAY_PARAM(12)]) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_int32x4x3_t
-simde_vld1q_s32_x3(int32_t const ptr[HEDLEY_ARRAY_PARAM(6)]) {
+simde_vld1q_s32_x3(int32_t const ptr[HEDLEY_ARRAY_PARAM(12)]) {
   #if \
       defined(SIMDE_ARM_NEON_A32V7_NATIVE) && \
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE))) && \
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_s32_x3(ptr);
   #else
-    simde_int32x4_private a_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle32_v_i32m1(ptr , 4);
-      a_[1].sv128 = __riscv_vle32_v_i32m1(ptr+4 , 4);
-      a_[2].sv128 = __riscv_vle32_v_i32m1(ptr+8 , 4);
-    #else
-      for (size_t i = 0; i < 12; i++) {
-        a_[i / 4].values[i % 4] = ptr[i];
-      }
-    #endif
-    simde_int32x4x3_t s_ = { { simde_int32x4_from_private(a_[0]),
-                               simde_int32x4_from_private(a_[1]),
-                               simde_int32x4_from_private(a_[2]) } };
+    simde_int32x4_t a_[3];
+    for (size_t i = 0; i < 3; i++) {
+      a_[i] = simde_vld1q_s32(ptr + 4*i);
+    }
+    simde_int32x4x3_t s_ = { { a_[0], a_[1], a_[2] } };
     return s_;
   #endif
 }
@@ -236,26 +190,18 @@ simde_vld1q_s32_x3(int32_t const ptr[HEDLEY_ARRAY_PARAM(6)]) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_int64x2x3_t
-simde_vld1q_s64_x3(int64_t const ptr[HEDLEY_ARRAY_PARAM(3)]) {
+simde_vld1q_s64_x3(int64_t const ptr[HEDLEY_ARRAY_PARAM(6)]) {
   #if \
       defined(SIMDE_ARM_NEON_A32V7_NATIVE) && \
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE))) && \
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_s64_x3(ptr);
   #else
-    simde_int64x2_private a_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle64_v_i64m1(ptr , 2);
-      a_[1].sv128 = __riscv_vle64_v_i64m1(ptr+2 , 2);
-      a_[2].sv128 = __riscv_vle64_v_i64m1(ptr+4 , 2);
-    #else
-      for (size_t i = 0; i < 6; i++) {
-        a_[i / 2].values[i % 2] = ptr[i];
-      }
-    #endif
-    simde_int64x2x3_t s_ = { { simde_int64x2_from_private(a_[0]),
-                               simde_int64x2_from_private(a_[1]),
-                               simde_int64x2_from_private(a_[2]) } };
+    simde_int64x2_t a_[3];
+    for (size_t i = 0; i < 3; i++) {
+      a_[i] = simde_vld1q_s64(ptr + 2*i);
+    }
+    simde_int64x2x3_t s_ = { { a_[0], a_[1], a_[2] } };
     return s_;
   #endif
 }
@@ -275,19 +221,11 @@ simde_vld1q_u8_x3(uint8_t const ptr[HEDLEY_ARRAY_PARAM(48)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_u8_x3(ptr);
   #else
-    simde_uint8x16_private a_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle8_v_u8m1(ptr , 16);
-      a_[1].sv128 = __riscv_vle8_v_u8m1(ptr+16 , 16);
-      a_[2].sv128 = __riscv_vle8_v_u8m1(ptr+32 , 16);
-    #else
-      for (size_t i = 0; i < 48; i++) {
-        a_[i / 16].values[i % 16] = ptr[i];
-      }
-    #endif
-    simde_uint8x16x3_t s_ = { { simde_uint8x16_from_private(a_[0]),
-                                simde_uint8x16_from_private(a_[1]),
-                                simde_uint8x16_from_private(a_[2]) } };
+    simde_uint8x16_t a_[3];
+    for (size_t i = 0; i < 3; i++) {
+      a_[i] = simde_vld1q_u8(ptr + 16*i);
+    }
+    simde_uint8x16x3_t s_ = { { a_[0], a_[1], a_[2] } };
     return s_;
   #endif
 }
@@ -307,19 +245,11 @@ simde_vld1q_u16_x3(uint16_t const ptr[HEDLEY_ARRAY_PARAM(24)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_u16_x3(ptr);
   #else
-    simde_uint16x8_private a_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle16_v_u16m1(ptr , 8);
-      a_[1].sv128 = __riscv_vle16_v_u16m1(ptr+8 , 8);
-      a_[2].sv128 = __riscv_vle16_v_u16m1(ptr+16 , 8);
-    #else
-      for (size_t i = 0; i < 24; i++) {
-        a_[i / 8].values[i % 8] = ptr[i];
-      }
-    #endif
-    simde_uint16x8x3_t s_ = { { simde_uint16x8_from_private(a_[0]),
-                                simde_uint16x8_from_private(a_[1]),
-                                simde_uint16x8_from_private(a_[2]) } };
+    simde_uint16x8_t a_[3];
+    for (size_t i = 0; i < 3; i++) {
+      a_[i] = simde_vld1q_u16(ptr + 8*i);
+    }
+    simde_uint16x8x3_t s_ = { { a_[0], a_[1], a_[2] } };
     return s_;
   #endif
 }
@@ -332,26 +262,18 @@ simde_vld1q_u16_x3(uint16_t const ptr[HEDLEY_ARRAY_PARAM(24)]) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_uint32x4x3_t
-simde_vld1q_u32_x3(uint32_t const ptr[HEDLEY_ARRAY_PARAM(6)]) {
+simde_vld1q_u32_x3(uint32_t const ptr[HEDLEY_ARRAY_PARAM(12)]) {
   #if \
       defined(SIMDE_ARM_NEON_A32V7_NATIVE) && \
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE))) && \
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_u32_x3(ptr);
   #else
-    simde_uint32x4_private a_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle32_v_u32m1(ptr , 4);
-      a_[1].sv128 = __riscv_vle32_v_u32m1(ptr+4 , 4);
-      a_[2].sv128 = __riscv_vle32_v_u32m1(ptr+8 , 4);
-    #else
-      for (size_t i = 0; i < 12; i++) {
-        a_[i / 4].values[i % 4] = ptr[i];
-      }
-    #endif
-    simde_uint32x4x3_t s_ = { { simde_uint32x4_from_private(a_[0]),
-                                simde_uint32x4_from_private(a_[1]),
-                                simde_uint32x4_from_private(a_[2]) } };
+    simde_uint32x4_t a_[3];
+    for (size_t i = 0; i < 3; i++) {
+      a_[i] = simde_vld1q_u32(ptr + 4*i);
+    }
+    simde_uint32x4x3_t s_ = { { a_[0], a_[1], a_[2] } };
     return s_;
   #endif
 }
@@ -364,26 +286,18 @@ simde_vld1q_u32_x3(uint32_t const ptr[HEDLEY_ARRAY_PARAM(6)]) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_uint64x2x3_t
-simde_vld1q_u64_x3(uint64_t const ptr[HEDLEY_ARRAY_PARAM(3)]) {
+simde_vld1q_u64_x3(uint64_t const ptr[HEDLEY_ARRAY_PARAM(6)]) {
   #if \
       defined(SIMDE_ARM_NEON_A32V7_NATIVE) && \
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE))) && \
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_u64_x3(ptr);
   #else
-    simde_uint64x2_private a_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle64_v_u64m1(ptr , 2);
-      a_[1].sv128 = __riscv_vle64_v_u64m1(ptr+2 , 2);
-      a_[2].sv128 = __riscv_vle64_v_u64m1(ptr+4 , 2);
-    #else
-      for (size_t i = 0; i < 6; i++) {
-        a_[i / 2].values[i % 2] = ptr[i];
-      }
-    #endif
-    simde_uint64x2x3_t s_ = { { simde_uint64x2_from_private(a_[0]),
-                                simde_uint64x2_from_private(a_[1]),
-                                simde_uint64x2_from_private(a_[2]) } };
+    simde_uint64x2_t a_[3];
+    for (size_t i = 0; i < 3; i++) {
+      a_[i] = simde_vld1q_u64(ptr + 2*i);
+    }
+    simde_uint64x2x3_t s_ = { { a_[0], a_[1], a_[2] } };
     return s_;
   #endif
 }
@@ -402,19 +316,11 @@ simde_vld1q_p8_x3(simde_poly8_t const ptr[HEDLEY_ARRAY_PARAM(48)]) {
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,5,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_p8_x3(ptr);
   #else
-    simde_poly8x16_private a_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle8_v_u8m1(ptr , 16);
-      a_[1].sv128 = __riscv_vle8_v_u8m1(ptr+16 , 16);
-      a_[2].sv128 = __riscv_vle8_v_u8m1(ptr+32 , 16);
-    #else
-      for (size_t i = 0; i < 48; i++) {
-        a_[i / 16].values[i % 16] = ptr[i];
-      }
-    #endif
-    simde_poly8x16x3_t s_ = { { simde_poly8x16_from_private(a_[0]),
-                                simde_poly8x16_from_private(a_[1]),
-                                simde_poly8x16_from_private(a_[2]) } };
+    simde_poly8x16_t a_[3];
+    for (size_t i = 0; i < 3; i++) {
+      a_[i] = simde_vld1q_p8(ptr + 8*i);
+    }
+    simde_poly8x16x3_t s_ = { { a_[0], a_[1], a_[2] } };
     return s_;
   #endif
 }
@@ -432,19 +338,11 @@ simde_vld1q_p16_x3(simde_poly16_t const ptr[HEDLEY_ARRAY_PARAM(24)]) {
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,5,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_p16_x3(ptr);
   #else
-    simde_poly16x8_private a_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle16_v_u16m1(ptr , 8);
-      a_[1].sv128 = __riscv_vle16_v_u16m1(ptr+8 , 8);
-      a_[2].sv128 = __riscv_vle16_v_u16m1(ptr+16 , 8);
-    #else
-      for (size_t i = 0; i < 24; i++) {
-        a_[i / 8].values[i % 8] = ptr[i];
-      }
-    #endif
-    simde_poly16x8x3_t s_ = { { simde_poly16x8_from_private(a_[0]),
-                                simde_poly16x8_from_private(a_[1]),
-                                simde_poly16x8_from_private(a_[2]) } };
+    simde_poly16x8_t a_[3];
+    for (size_t i = 0; i < 3; i++) {
+      a_[i] = simde_vld1q_p16(ptr + 4*i);
+    }
+    simde_poly16x8x3_t s_ = { { a_[0], a_[1], a_[2] } };
     return s_;
   #endif
 }
@@ -456,25 +354,17 @@ simde_vld1q_p16_x3(simde_poly16_t const ptr[HEDLEY_ARRAY_PARAM(24)]) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_poly64x2x3_t
-simde_vld1q_p64_x3(simde_poly64_t const ptr[HEDLEY_ARRAY_PARAM(3)]) {
+simde_vld1q_p64_x3(simde_poly64_t const ptr[HEDLEY_ARRAY_PARAM(6)]) {
   #if \
       defined(SIMDE_ARM_NEON_A32V8_NATIVE) && \
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,5,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_p64_x3(ptr);
   #else
-    simde_poly64x2_private a_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle64_v_u64m1(ptr , 2);
-      a_[1].sv128 = __riscv_vle64_v_u64m1(ptr+2 , 2);
-      a_[2].sv128 = __riscv_vle64_v_u64m1(ptr+4 , 2);
-    #else
-      for (size_t i = 0; i < 6; i++) {
-        a_[i / 2].values[i % 2] = ptr[i];
-      }
-    #endif
-    simde_poly64x2x3_t s_ = { { simde_poly64x2_from_private(a_[0]),
-                                simde_poly64x2_from_private(a_[1]),
-                                simde_poly64x2_from_private(a_[2]) } };
+    simde_poly64x2_t a_[3];
+    for (size_t i = 0; i < 3; i++) {
+      a_[i] = simde_vld1q_p64(ptr + 2*i);
+    }
+    simde_poly64x2x3_t s_ = { { a_[0], a_[1], a_[2] } };
     return s_;
   #endif
 }

--- a/simde/arm/neon/ld1q_x4.h
+++ b/simde/arm/neon/ld1q_x4.h
@@ -26,12 +26,14 @@
  *   2021      Décio Luiz Gazzoni Filho <decio@decpp.net>
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
  *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw> (Copyright owned by NTHU pllab)
+ *   2025      Michael R. Crusoe <crusoe@debian.org>
  */
 
 #if !defined(SIMDE_ARM_NEON_LD1Q_X4_H)
 #define SIMDE_ARM_NEON_LD1Q_X4_H
 
 #include "types.h"
+#include "ld1.h"
 
 HEDLEY_DIAGNOSTIC_PUSH
 SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
@@ -51,21 +53,11 @@ simde_vld1q_f16_x4(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_f16_x4(ptr);
   #else
-    simde_float16x8_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
-      a_[0].sv128 = __riscv_vle16_v_f16m1((_Float16 *)ptr , 8);
-      a_[1].sv128 = __riscv_vle16_v_f16m1((_Float16 *)(ptr+8) , 8);
-      a_[2].sv128 = __riscv_vle16_v_f16m1((_Float16 *)(ptr+16) , 8);
-      a_[3].sv128 = __riscv_vle16_v_f16m1((_Float16 *)(ptr+24) , 8);
-    #else
-      for (size_t i = 0; i < 32; i++) {
-        a_[i / 8].values[i % 8] = ptr[i];
-      }
-    #endif
-    simde_float16x8x4_t s_ = { { simde_float16x8_from_private(a_[0]),
-                                 simde_float16x8_from_private(a_[1]),
-                                 simde_float16x8_from_private(a_[2]),
-                                 simde_float16x8_from_private(a_[3]) } };
+    simde_float16x8_t a_[4];
+    for (size_t i = 0; i < 4; i++) {
+      a_[i] = simde_vld1q_f16(ptr + 8*i);
+    }
+    simde_float16x8x4_t s_ = { { a_[0], a_[1], a_[2], a_[3] } };
     return s_;
   #endif
 }
@@ -86,21 +78,11 @@ simde_vld1q_f32_x4(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(16)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_f32_x4(ptr);
   #else
-    simde_float32x4_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle32_v_f32m1(ptr , 4);
-      a_[1].sv128 = __riscv_vle32_v_f32m1(ptr+4 , 4);
-      a_[2].sv128 = __riscv_vle32_v_f32m1(ptr+8 , 4);
-      a_[3].sv128 = __riscv_vle32_v_f32m1(ptr+12 , 4);
-    #else
-      for (size_t i = 0; i < 16; i++) {
-        a_[i / 4].values[i % 4] = ptr[i];
-      }
-    #endif
-    simde_float32x4x4_t s_ = { { simde_float32x4_from_private(a_[0]),
-                                 simde_float32x4_from_private(a_[1]),
-                                 simde_float32x4_from_private(a_[2]),
-                                 simde_float32x4_from_private(a_[3]) } };
+    simde_float32x4_t a_[4];
+    for (size_t i = 0; i < 4; i++) {
+      a_[i] = simde_vld1q_f32(ptr + 4*i);
+    }
+    simde_float32x4x4_t s_ = { { a_[0], a_[1], a_[2], a_[3] } };
     return s_;
   #endif
 }
@@ -120,21 +102,11 @@ simde_vld1q_f64_x4(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(8)]) {
       (!defined(__clang__) || SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0))
     return vld1q_f64_x4(ptr);
   #else
-    simde_float64x2_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle64_v_f64m1(ptr , 2);
-      a_[1].sv128 = __riscv_vle64_v_f64m1(ptr+2 , 2);
-      a_[2].sv128 = __riscv_vle64_v_f64m1(ptr+4 , 2);
-      a_[3].sv128 = __riscv_vle64_v_f64m1(ptr+6 , 2);
-    #else
-      for (size_t i = 0; i < 8; i++) {
-        a_[i / 2].values[i % 2] = ptr[i];
-      }
-    #endif
-    simde_float64x2x4_t s_ = { { simde_float64x2_from_private(a_[0]),
-                                 simde_float64x2_from_private(a_[1]),
-                                 simde_float64x2_from_private(a_[2]),
-                                 simde_float64x2_from_private(a_[3]) } };
+    simde_float64x2_t a_[4];
+    for (size_t i = 0; i < 4; i++) {
+      a_[i] = simde_vld1q_f64(ptr + 2*i);
+    }
+    simde_float64x2x4_t s_ = { { a_[0], a_[1], a_[2], a_[3] } };
     return s_;
   #endif
 }
@@ -154,21 +126,11 @@ simde_vld1q_s8_x4(int8_t const ptr[HEDLEY_ARRAY_PARAM(64)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_s8_x4(ptr);
   #else
-    simde_int8x16_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle8_v_i8m1(ptr , 16);
-      a_[1].sv128 = __riscv_vle8_v_i8m1(ptr+16 , 16);
-      a_[2].sv128 = __riscv_vle8_v_i8m1(ptr+32 , 16);
-      a_[3].sv128 = __riscv_vle8_v_i8m1(ptr+48 , 16);
-    #else
-      for (size_t i = 0; i < 64; i++) {
-        a_[i / 16].values[i % 16] = ptr[i];
-      }
-    #endif
-    simde_int8x16x4_t s_ = { { simde_int8x16_from_private(a_[0]),
-                               simde_int8x16_from_private(a_[1]),
-                               simde_int8x16_from_private(a_[2]),
-                               simde_int8x16_from_private(a_[3]) } };
+    simde_int8x16_t a_[4];
+    for (size_t i = 0; i < 4; i++) {
+      a_[i] = simde_vld1q_s8(ptr + 16*i);
+    }
+    simde_int8x16x4_t s_ = { { a_[0], a_[1], a_[2], a_[3] } };
     return s_;
   #endif
 }
@@ -188,21 +150,11 @@ simde_vld1q_s16_x4(int16_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_s16_x4(ptr);
   #else
-    simde_int16x8_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle16_v_i16m1(ptr , 8);
-      a_[1].sv128 = __riscv_vle16_v_i16m1(ptr+8 , 8);
-      a_[2].sv128 = __riscv_vle16_v_i16m1(ptr+16 , 8);
-      a_[3].sv128 = __riscv_vle16_v_i16m1(ptr+24 , 8);
-    #else
-      for (size_t i = 0; i < 32; i++) {
-        a_[i / 8].values[i % 8] = ptr[i];
-      }
-    #endif
-    simde_int16x8x4_t s_ = { { simde_int16x8_from_private(a_[0]),
-                               simde_int16x8_from_private(a_[1]),
-                               simde_int16x8_from_private(a_[2]),
-                               simde_int16x8_from_private(a_[3]) } };
+    simde_int16x8_t a_[4];
+    for (size_t i = 0; i < 4; i++) {
+      a_[i] = simde_vld1q_s16(ptr + 8*i);
+    }
+    simde_int16x8x4_t s_ = { { a_[0], a_[1], a_[2], a_[3] } };
     return s_;
   #endif
 }
@@ -222,21 +174,11 @@ simde_vld1q_s32_x4(int32_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_s32_x4(ptr);
   #else
-    simde_int32x4_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle32_v_i32m1(ptr , 4);
-      a_[1].sv128 = __riscv_vle32_v_i32m1(ptr+4 , 4);
-      a_[2].sv128 = __riscv_vle32_v_i32m1(ptr+8 , 4);
-      a_[3].sv128 = __riscv_vle32_v_i32m1(ptr+12 , 4);
-    #else
-      for (size_t i = 0; i < 16; i++) {
-        a_[i / 4].values[i % 4] = ptr[i];
-      }
-    #endif
-    simde_int32x4x4_t s_ = { { simde_int32x4_from_private(a_[0]),
-                               simde_int32x4_from_private(a_[1]),
-                               simde_int32x4_from_private(a_[2]),
-                               simde_int32x4_from_private(a_[3]) } };
+    simde_int32x4_t a_[4];
+    for (size_t i = 0; i < 4; i++) {
+      a_[i] = simde_vld1q_s32(ptr + 4*i);
+    }
+    simde_int32x4x4_t s_ = { { a_[0], a_[1], a_[2], a_[3] } };
     return s_;
   #endif
 }
@@ -256,21 +198,11 @@ simde_vld1q_s64_x4(int64_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_s64_x4(ptr);
   #else
-    simde_int64x2_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle64_v_i64m1(ptr , 2);
-      a_[1].sv128 = __riscv_vle64_v_i64m1(ptr+2 , 2);
-      a_[2].sv128 = __riscv_vle64_v_i64m1(ptr+4 , 2);
-      a_[3].sv128 = __riscv_vle64_v_i64m1(ptr+6 , 2);
-    #else
-      for (size_t i = 0; i < 8; i++) {
-        a_[i / 2].values[i % 2] = ptr[i];
-      }
-    #endif
-    simde_int64x2x4_t s_ = { { simde_int64x2_from_private(a_[0]),
-                               simde_int64x2_from_private(a_[1]),
-                               simde_int64x2_from_private(a_[1]),
-                               simde_int64x2_from_private(a_[1]) } };
+    simde_int64x2_t a_[4];
+    for (size_t i = 0; i < 4; i++) {
+      a_[i] = simde_vld1q_s64(ptr + 2*i);
+    }
+    simde_int64x2x4_t s_ = { { a_[0], a_[1], a_[2], a_[3] } };
     return s_;
   #endif
 }
@@ -290,21 +222,11 @@ simde_vld1q_u8_x4(uint8_t const ptr[HEDLEY_ARRAY_PARAM(64)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_u8_x4(ptr);
   #else
-    simde_uint8x16_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle8_v_u8m1(ptr , 16);
-      a_[1].sv128 = __riscv_vle8_v_u8m1(ptr+16 , 16);
-      a_[2].sv128 = __riscv_vle8_v_u8m1(ptr+32 , 16);
-      a_[3].sv128 = __riscv_vle8_v_u8m1(ptr+48 , 16);
-    #else
-      for (size_t i = 0; i < 64; i++) {
-        a_[i / 16].values[i % 16] = ptr[i];
-      }
-    #endif
-    simde_uint8x16x4_t s_ = { { simde_uint8x16_from_private(a_[0]),
-                                simde_uint8x16_from_private(a_[1]),
-                                simde_uint8x16_from_private(a_[2]),
-                                simde_uint8x16_from_private(a_[3]) } };
+    simde_uint8x16_t a_[4];
+    for (size_t i = 0; i < 4; i++) {
+      a_[i] = simde_vld1q_u8(ptr + 16*i);
+    }
+    simde_uint8x16x4_t s_ = { { a_[0], a_[1], a_[2], a_[3] } };
     return s_;
   #endif
 }
@@ -324,21 +246,11 @@ simde_vld1q_u16_x4(uint16_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_u16_x4(ptr);
   #else
-    simde_uint16x8_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle16_v_u16m1(ptr , 8);
-      a_[1].sv128 = __riscv_vle16_v_u16m1(ptr+8 , 8);
-      a_[2].sv128 = __riscv_vle16_v_u16m1(ptr+16 , 8);
-      a_[3].sv128 = __riscv_vle16_v_u16m1(ptr+24 , 8);
-    #else
-      for (size_t i = 0; i < 32; i++) {
-        a_[i / 8].values[i % 8] = ptr[i];
-      }
-    #endif
-    simde_uint16x8x4_t s_ = { { simde_uint16x8_from_private(a_[0]),
-                                simde_uint16x8_from_private(a_[1]),
-                                simde_uint16x8_from_private(a_[2]),
-                                simde_uint16x8_from_private(a_[3]) } };
+    simde_uint16x8_t a_[4];
+    for (size_t i = 0; i < 4; i++) {
+      a_[i] = simde_vld1q_u16(ptr + 8*i);
+    }
+    simde_uint16x8x4_t s_ = { { a_[0], a_[1], a_[2], a_[3] } };
     return s_;
   #endif
 }
@@ -358,21 +270,11 @@ simde_vld1q_u32_x4(uint32_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_u32_x4(ptr);
   #else
-    simde_uint32x4_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle32_v_u32m1(ptr , 4);
-      a_[1].sv128 = __riscv_vle32_v_u32m1(ptr+4 , 4);
-      a_[2].sv128 = __riscv_vle32_v_u32m1(ptr+8 , 4);
-      a_[3].sv128 = __riscv_vle32_v_u32m1(ptr+12 , 4);
-    #else
-      for (size_t i = 0; i < 16; i++) {
-        a_[i / 4].values[i % 4] = ptr[i];
-      }
-    #endif
-    simde_uint32x4x4_t s_ = { { simde_uint32x4_from_private(a_[0]),
-                                simde_uint32x4_from_private(a_[1]),
-                                simde_uint32x4_from_private(a_[2]),
-                                simde_uint32x4_from_private(a_[3]) } };
+    simde_uint32x4_t a_[4];
+    for (size_t i = 0; i < 4; i++) {
+      a_[i] = simde_vld1q_u32(ptr + 4*i);
+    }
+    simde_uint32x4x4_t s_ = { { a_[0], a_[1], a_[2], a_[3] } };
     return s_;
   #endif
 }
@@ -392,21 +294,11 @@ simde_vld1q_u64_x4(uint64_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
       (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION_CHECK(7,0,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_u64_x4(ptr);
   #else
-    simde_uint64x2_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle64_v_u64m1(ptr , 2);
-      a_[1].sv128 = __riscv_vle64_v_u64m1(ptr+2 , 2);
-      a_[2].sv128 = __riscv_vle64_v_u64m1(ptr+4 , 2);
-      a_[3].sv128 = __riscv_vle64_v_u64m1(ptr+6 , 2);
-    #else
-      for (size_t i = 0; i < 8; i++) {
-        a_[i / 2].values[i % 2] = ptr[i];
-      }
-    #endif
-    simde_uint64x2x4_t s_ = { { simde_uint64x2_from_private(a_[0]),
-                                simde_uint64x2_from_private(a_[1]),
-                                simde_uint64x2_from_private(a_[2]),
-                                simde_uint64x2_from_private(a_[3]) } };
+    simde_uint64x2_t a_[4];
+    for (size_t i = 0; i < 4; i++) {
+      a_[i] = simde_vld1q_u64(ptr + 2*i);
+    }
+    simde_uint64x2x4_t s_ = { { a_[0], a_[1], a_[2], a_[3] } };
     return s_;
   #endif
 }
@@ -425,21 +317,11 @@ simde_vld1q_p8_x4(simde_poly8_t const ptr[HEDLEY_ARRAY_PARAM(64)]) {
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,5,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_p8_x4(ptr);
   #else
-    simde_poly8x16_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle8_v_u8m1(ptr , 16);
-      a_[1].sv128 = __riscv_vle8_v_u8m1(ptr+16 , 16);
-      a_[2].sv128 = __riscv_vle8_v_u8m1(ptr+32 , 16);
-      a_[3].sv128 = __riscv_vle8_v_u8m1(ptr+48 , 16);
-    #else
-      for (size_t i = 0; i < 64; i++) {
-        a_[i / 16].values[i % 16] = ptr[i];
-      }
-    #endif
-    simde_poly8x16x4_t s_ = { { simde_poly8x16_from_private(a_[0]),
-                                simde_poly8x16_from_private(a_[1]),
-                                simde_poly8x16_from_private(a_[2]),
-                                simde_poly8x16_from_private(a_[3]) } };
+    simde_poly8x16_t a_[4];
+    for (size_t i = 0; i < 4; i++) {
+      a_[i] = simde_vld1q_p8(ptr + 8*i);
+    }
+    simde_poly8x16x4_t s_ = { { a_[0], a_[1], a_[2], a_[3] } };
     return s_;
   #endif
 }
@@ -457,21 +339,11 @@ simde_vld1q_p16_x4(simde_poly16_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,5,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_p16_x4(ptr);
   #else
-    simde_poly16x8_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle16_v_u16m1(ptr , 8);
-      a_[1].sv128 = __riscv_vle16_v_u16m1(ptr+8 , 8);
-      a_[2].sv128 = __riscv_vle16_v_u16m1(ptr+16 , 8);
-      a_[3].sv128 = __riscv_vle16_v_u16m1(ptr+24 , 8);
-    #else
-      for (size_t i = 0; i < 32; i++) {
-        a_[i / 8].values[i % 8] = ptr[i];
-      }
-    #endif
-    simde_poly16x8x4_t s_ = { { simde_poly16x8_from_private(a_[0]),
-                                simde_poly16x8_from_private(a_[1]),
-                                simde_poly16x8_from_private(a_[2]),
-                                simde_poly16x8_from_private(a_[3]) } };
+    simde_poly16x8_t a_[4];
+    for (size_t i = 0; i < 4; i++) {
+      a_[i] = simde_vld1q_p16(ptr + 4*i);
+    }
+    simde_poly16x8x4_t s_ = { { a_[0], a_[1], a_[2], a_[3] } };
     return s_;
   #endif
 }
@@ -489,21 +361,11 @@ simde_vld1q_p64_x4(simde_poly64_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
       (!defined(HEDLEY_GCC_VERSION) || (HEDLEY_GCC_VERSION_CHECK(8,5,0) && defined(SIMDE_ARM_NEON_A64V8_NATIVE)))
     return vld1q_p64_x4(ptr);
   #else
-    simde_poly64x2_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE)
-      a_[0].sv128 = __riscv_vle64_v_u64m1(ptr , 2);
-      a_[1].sv128 = __riscv_vle64_v_u64m1(ptr+2 , 2);
-      a_[2].sv128 = __riscv_vle64_v_u64m1(ptr+4 , 2);
-      a_[3].sv128 = __riscv_vle64_v_u64m1(ptr+6 , 2);
-    #else
-      for (size_t i = 0; i < 8; i++) {
-        a_[i / 2].values[i % 2] = ptr[i];
-      }
-    #endif
-    simde_poly64x2x4_t s_ = { { simde_poly64x2_from_private(a_[0]),
-                                simde_poly64x2_from_private(a_[1]),
-                                simde_poly64x2_from_private(a_[2]),
-                                simde_poly64x2_from_private(a_[3]) } };
+    simde_poly64x2_t a_[4];
+    for (size_t i = 0; i < 4; i++) {
+      a_[i] = simde_vld1q_p64(ptr + 2*i);
+    }
+    simde_poly64x2x4_t s_ = { { a_[0], a_[1], a_[2], a_[3] } };
     return s_;
   #endif
 }

--- a/simde/arm/neon/types.h
+++ b/simde/arm/neon/types.h
@@ -394,6 +394,10 @@ typedef union {
     __m128 m128;
   #endif
 
+  #if defined(SIMDE_X86_AVX512FP16_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    __m128h m128h;
+  #endif
+
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     int32x4_t neon;
   #endif
@@ -1465,6 +1469,10 @@ typedef union {
   SIMDE_DEFINE_CONVERSION_FUNCTION_(simde_uint32x4_from_m128i,   simde_uint32x4_t,           __m128i)
   SIMDE_DEFINE_CONVERSION_FUNCTION_(simde_uint64x2_from_m128i,   simde_uint64x2_t,           __m128i)
   SIMDE_DEFINE_CONVERSION_FUNCTION_(simde_float64x2_from_m128d, simde_float64x2_t,           __m128d)
+#endif
+#if defined(SIMDE_X86_AVX512FP16_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  SIMDE_DEFINE_CONVERSION_FUNCTION_(simde_float16x8_to_m128h,             __m128h, simde_float16x8_t)
+  SIMDE_DEFINE_CONVERSION_FUNCTION_(simde_float16x8_from_m128h, simde_float16x8_t,           __m128h)
 #endif
 
 #if defined(SIMDE_WASM_SIMD128_NATIVE)


### PR DESCRIPTION
- Consolidate and propogate the use of these speedups to all `vld1q_*_x[234]` functions
- Speedups for SSE3+ confirmed with the libjpeg-turbo benchmarks
- Entropy encoding went from 309 to 883 Mcoefficients/sec on GCC 12.2