### PR TITLE
wasm: `__wasm_fp16__` is required for Float16 with emscripten or wasi

### DIFF
--- a/simde/simde-f16.h
+++ b/simde/simde-f16.h
@@ -68,7 +68,8 @@ SIMDE_BEGIN_DECLS_
 #if !defined(SIMDE_FLOAT16_API)
   #if defined(__ARM_FP16_FORMAT_IEEE) && (defined(SIMDE_ARM_NEON_FP16) || defined(__ARM_FP16_ARGS))
     #define SIMDE_FLOAT16_API SIMDE_FLOAT16_API_FP16
-  #elif !defined(__EMSCRIPTEN__) && !(defined(__clang__) && defined(SIMDE_ARCH_POWER)) && \
+  #elif !((defined(__EMSCRIPTEN__) || defined(__wasi__)) && !defined(__wasm_fp16__)) && \
+    !(defined(__clang__) && defined(SIMDE_ARCH_POWER)) && \
     !(defined(HEDLEY_MSVC_VERSION) && defined(__clang__)) && \
     !(defined(SIMDE_ARCH_MIPS) && defined(__clang__)) && \
     !(defined(SIMDE_ARCH_ZARCH) && defined(__clang__)) && \

--- a/test/x86/avx.c
+++ b/test/x86/avx.c
@@ -27,7 +27,7 @@
 #endif
 #include <simde/x86/avx.h>
 #include <test/x86/test-avx.h>
-#if !defined(HEDLEY_MSVC_VERSION)
+#if !defined(HEDLEY_MSVC_VERSION) && !defined(__wasi__)
   #include <sys/mman.h>
 #endif
 
@@ -9853,7 +9853,7 @@ test_simde_mm_maskload_pd (SIMDE_MUNIT_TEST_ARGS) {
   return 0;
 }
 
-#if !defined(HEDLEY_MSVC_VERSION)
+#if !defined(HEDLEY_MSVC_VERSION) && !defined(__wasi__)
 static int
 test_simde_mm_maskload_pd_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS) {
   // ref: https://github.com/simd-everywhere/simde/issues/998
@@ -9914,7 +9914,7 @@ test_simde_mm256_maskload_pd (SIMDE_MUNIT_TEST_ARGS) {
   return 0;
 }
 
-#if !defined(HEDLEY_MSVC_VERSION)
+#if !defined(HEDLEY_MSVC_VERSION) && !defined(__wasi__)
 static int
 test_simde_mm256_maskload_pd_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS) {
   // ref: https://github.com/simd-everywhere/simde/issues/998
@@ -9975,7 +9975,7 @@ test_simde_mm_maskload_ps (SIMDE_MUNIT_TEST_ARGS) {
   return 0;
 }
 
-#if !defined(HEDLEY_MSVC_VERSION)
+#if !defined(HEDLEY_MSVC_VERSION) && !defined(__wasi__)
 static int
 test_simde_mm_maskload_ps_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS) {
   // ref: https://github.com/simd-everywhere/simde/issues/998
@@ -10053,7 +10053,7 @@ test_simde_mm256_maskload_ps (SIMDE_MUNIT_TEST_ARGS) {
   return 0;
 }
 
-#if !defined(HEDLEY_MSVC_VERSION)
+#if !defined(HEDLEY_MSVC_VERSION) && !defined(__wasi__)
 static int
 test_simde_mm256_maskload_ps_no_illegal_memory_access (SIMDE_MUNIT_TEST_ARGS) {
   // ref: https://github.com/simd-everywhere/simde/issues/998
@@ -16645,7 +16645,7 @@ SIMDE_TEST_FUNC_LIST_BEGIN
   SIMDE_TEST_FUNC_LIST_ENTRY(mm_maskload_ps)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm256_maskload_ps)
 
-  #if !defined(HEDLEY_MSVC_VERSION)
+  #if !defined(HEDLEY_MSVC_VERSION) && !defined(__wasi__)
     SIMDE_TEST_FUNC_LIST_ENTRY(mm_maskload_pd_no_illegal_memory_access)
     SIMDE_TEST_FUNC_LIST_ENTRY(mm256_maskload_pd_no_illegal_memory_access)
     SIMDE_TEST_FUNC_LIST_ENTRY(mm_maskload_ps_no_illegal_memory_access)


### PR DESCRIPTION
Fixes: https://github.com/simd-everywhere/simde/issues/1187
