### PR TITLE
_mm256_castps128_ps256 maybe uninitialized

### DIFF
--- a/simde/x86/avx.h
+++ b/simde/x86/avx.h
@@ -2179,10 +2179,16 @@ simde_mm256_castps128_ps256 (simde__m128 a) {
   #else
     simde__m256_private r_;
     simde__m128_private a_ = simde__m128_to_private(a);
-
+    #if defined(__CLANG) || defined(__GNUC__)
+    #pragma GCC diagnostics push
+    #pragma GCC diagnostics ignored "-Wmaybe-uninitialized"
+    #endif
     r_.m128_private[0] = a_;
 
     return simde__m256_from_private(r_);
+    #if defined(__CLANG) || defined(__GNUC__)
+    #pragma GCC diagnostics pop
+    #endif
   #endif
 }
 #if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)


### PR DESCRIPTION
The nature of this intrinsic leaves half of the SIMD register uninitialized.  Add a #pragma to remove the warning.