### PR TITLE
Revert "neon riscv64: Enable RVV segment load/store only when we have…

### DIFF
--- a/simde/arm/neon/ld2.h
+++ b/simde/arm/neon/ld2.h
@@ -59,7 +59,7 @@ simde_vld2_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
       simde_vget_high_s8(q)
     };
     return u;
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int8x8_private a_[2];
     vint8m1x2_t dest = __riscv_vlseg2e8_v_i8m1x2(&ptr[0], 8);
     a_[0].sv64 = __riscv_vget_v_i8m1x2_i8m1(dest, 0);
@@ -102,7 +102,7 @@ simde_int16x4x2_t
 simde_vld2_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_s16(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int16x4_private a_[2];
     vint16m1x2_t dest = __riscv_vlseg2e16_v_i16m1x2(&ptr[0], 4);
     a_[0].sv64 = __riscv_vget_v_i16m1x2_i16m1(dest, 0);
@@ -152,7 +152,7 @@ simde_int32x2x2_t
 simde_vld2_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_s32(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int32x2_private a_[2];
     vint32m1x2_t dest = __riscv_vlseg2e32_v_i32m1x2(&ptr[0], 2);
     a_[0].sv64 = __riscv_vget_v_i32m1x2_i32m1(dest, 0);
@@ -195,7 +195,7 @@ simde_int64x1x2_t
 simde_vld2_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_s64(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int64x1_private a_[2];
     vint64m1x2_t dest = __riscv_vlseg2e64_v_i64m1x2(&ptr[0], 1);
     a_[0].sv64 = __riscv_vget_v_i64m1x2_i64m1(dest, 0);
@@ -249,7 +249,7 @@ simde_vld2_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
       simde_vget_high_u8(q)
     };
     return u;
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint8x8_private a_[2];
     vuint8m1x2_t dest = __riscv_vlseg2e8_v_u8m1x2(&ptr[0], 8);
     a_[0].sv64 = __riscv_vget_v_u8m1x2_u8m1(dest, 0);
@@ -292,7 +292,7 @@ simde_uint16x4x2_t
 simde_vld2_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_u16(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint16x4_private a_[2];
     vuint16m1x2_t dest = __riscv_vlseg2e16_v_u16m1x2(&ptr[0], 4);
     a_[0].sv64 = __riscv_vget_v_u16m1x2_u16m1(dest, 0);
@@ -342,7 +342,7 @@ simde_uint32x2x2_t
 simde_vld2_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_u32(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint32x2_private a_[2];
     vuint32m1x2_t dest = __riscv_vlseg2e32_v_u32m1x2(&ptr[0], 2);
     a_[0].sv64 = __riscv_vget_v_u32m1x2_u32m1(dest, 0);
@@ -385,7 +385,7 @@ simde_uint64x1x2_t
 simde_vld2_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_u64(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint64x1_private a_[2];
     vuint64m1x2_t dest = __riscv_vlseg2e64_v_u64m1x2(&ptr[0], 1);
     a_[0].sv64 = __riscv_vget_v_u64m1x2_u64m1(dest, 0);
@@ -428,8 +428,7 @@ simde_float16x4x2_t
 simde_vld2_f16(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vld2_f16(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG) \
-    && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
     simde_float16x4_private r_[2];
     vfloat16m1x2_t dest = __riscv_vlseg2e16_v_f16m1x2((_Float16 *)&ptr[0], 4);
     r_[0].sv64 = __riscv_vget_v_f16m1x2_f16m1(dest, 0);
@@ -467,7 +466,7 @@ simde_float32x2x2_t
 simde_vld2_f32(simde_float32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_f32(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_float32x2_private r_[2];
     vfloat32m1x2_t dest = __riscv_vlseg2e32_v_f32m1x2(&ptr[0], 2);
     r_[0].sv64 = __riscv_vget_v_f32m1x2_f32m1(dest, 0);
@@ -510,7 +509,7 @@ simde_float64x1x2_t
 simde_vld2_f64(simde_float64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld2_f64(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_float64x1_private r_[2];
     vfloat64m1x2_t dest = __riscv_vlseg2e64_v_f64m1x2(&ptr[0], 1);
     r_[0].sv64 = __riscv_vget_v_f64m1x2_f64m1(dest, 0);
@@ -553,7 +552,7 @@ simde_int8x16x2_t
 simde_vld2q_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_s8(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int8x16_private a_[2];
     vint8m1x2_t dest = __riscv_vlseg2e8_v_i8m1x2(&ptr[0], 16);
     a_[0].sv128 = __riscv_vget_v_i8m1x2_i8m1(dest, 0);
@@ -603,7 +602,7 @@ simde_int32x4x2_t
 simde_vld2q_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_s32(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int32x4_private a_[2];
     vint32m1x2_t dest = __riscv_vlseg2e32_v_i32m1x2(&ptr[0], 4);
     a_[0].sv128 = __riscv_vget_v_i32m1x2_i32m1(dest, 0);
@@ -653,7 +652,7 @@ simde_int16x8x2_t
 simde_vld2q_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_s16(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int16x8_private r_[2];
     vint16m1x2_t dest = __riscv_vlseg2e16_v_i16m1x2(&ptr[0], 8);
     r_[0].sv128 = __riscv_vget_v_i16m1x2_i16m1(dest, 0);
@@ -703,7 +702,7 @@ simde_int64x2x2_t
 simde_vld2q_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld2q_s64(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int64x2_private r_[2];
     vint64m1x2_t dest = __riscv_vlseg2e64_v_i64m1x2(&ptr[0], 2);
     r_[0].sv128 = __riscv_vget_v_i64m1x2_i64m1(dest, 0);
@@ -740,7 +739,7 @@ simde_uint8x16x2_t
 simde_vld2q_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_u8(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint8x16_private r_[2];
     vuint8m1x2_t dest = __riscv_vlseg2e8_v_u8m1x2(&ptr[0], 16);
     r_[0].sv128 = __riscv_vget_v_u8m1x2_u8m1(dest, 0);
@@ -790,7 +789,7 @@ simde_uint16x8x2_t
 simde_vld2q_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_u16(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint16x8_private r_[2];
     vuint16m1x2_t dest = __riscv_vlseg2e16_v_u16m1x2(&ptr[0], 8);
     r_[0].sv128 = __riscv_vget_v_u16m1x2_u16m1(dest, 0);
@@ -840,7 +839,7 @@ simde_uint32x4x2_t
 simde_vld2q_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_u32(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint32x4_private r_[2];
     vuint32m1x2_t dest = __riscv_vlseg2e32_v_u32m1x2(&ptr[0], 4);
     r_[0].sv128 = __riscv_vget_v_u32m1x2_u32m1(dest, 0);
@@ -890,7 +889,7 @@ simde_uint64x2x2_t
 simde_vld2q_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld2q_u64(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint64x2_private r_[2];
     vuint64m1x2_t dest = __riscv_vlseg2e64_v_u64m1x2(&ptr[0], 2);
     r_[0].sv128 = __riscv_vget_v_u64m1x2_u64m1(dest, 0);
@@ -927,8 +926,7 @@ simde_float16x8x2_t
 simde_vld2q_f16(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vld2q_f16(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG) \
-    && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
     simde_float16x8_private r_[2];
     vfloat16m1x2_t dest = __riscv_vlseg2e16_v_f16m1x2((_Float16 *)&ptr[0], 8);
     r_[0].sv128 = __riscv_vget_v_f16m1x2_f16m1(dest, 0);
@@ -973,7 +971,7 @@ simde_float32x4x2_t
 simde_vld2q_f32(simde_float32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_f32(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_float32x4_private r_[2];
     vfloat32m1x2_t dest = __riscv_vlseg2e32_v_f32m1x2(&ptr[0], 4);
     r_[0].sv128 = __riscv_vget_v_f32m1x2_f32m1(dest, 0);
@@ -1023,7 +1021,7 @@ simde_float64x2x2_t
 simde_vld2q_f64(simde_float64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld2q_f64(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_float64x2_private r_[2];
     vfloat64m1x2_t dest = __riscv_vlseg2e64_v_f64m1x2(&ptr[0], 2);
     r_[0].sv128 = __riscv_vget_v_f64m1x2_f64m1(dest, 0);
@@ -1062,7 +1060,7 @@ simde_vld2_p8(simde_poly8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld2_p8(ptr);
   #else
     simde_poly8x8_private r_[2];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x2_t dest = __riscv_vlseg2e8_v_u8m1x2(&ptr[0], 8);
       r_[0].sv64 = __riscv_vget_v_u8m1x2_u8m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_u8m1x2_u8m1(dest, 1);
@@ -1097,7 +1095,7 @@ simde_vld2_p16(simde_poly16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
       SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_
     #endif
     simde_poly16x4_private r_[2];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x2_t dest = __riscv_vlseg2e16_v_u16m1x2(&ptr[0], 4);
       r_[0].sv64 = __riscv_vget_v_u16m1x2_u16m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_u16m1x2_u16m1(dest, 1);
@@ -1137,7 +1135,7 @@ simde_vld2_p64(simde_poly64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     #endif
     simde_poly64x1_private r_[2];
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x2_t dest = __riscv_vlseg2e64_v_u64m1x2(&ptr[0], 1);
       r_[0].sv64 = __riscv_vget_v_u64m1x2_u64m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_u64m1x2_u64m1(dest, 1);
@@ -1177,7 +1175,7 @@ simde_vld2q_p8(simde_poly8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     #endif
     simde_poly8x16_private r_[2];
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x2_t dest = __riscv_vlseg2e8_v_u8m1x2(&ptr[0], 16);
       r_[0].sv128 = __riscv_vget_v_u8m1x2_u8m1(dest, 0);
       r_[1].sv128 = __riscv_vget_v_u8m1x2_u8m1(dest, 1);
@@ -1217,7 +1215,7 @@ simde_vld2q_p16(simde_poly16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     #endif
     simde_poly16x8_private r_[2];
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x2_t dest = __riscv_vlseg2e16_v_u16m1x2(&ptr[0], 8);
       r_[0].sv128 = __riscv_vget_v_u16m1x2_u16m1(dest, 0);
       r_[1].sv128 = __riscv_vget_v_u16m1x2_u16m1(dest, 1);
@@ -1253,7 +1251,7 @@ simde_vld2q_p64(simde_poly64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #else
     simde_poly64x2_private r_[2];
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x2_t dest = __riscv_vlseg2e64_v_u64m1x2(&ptr[0], 2);
       r_[0].sv128 = __riscv_vget_v_u64m1x2_u64m1(dest, 0);
       r_[1].sv128 = __riscv_vget_v_u64m1x2_u64m1(dest, 1);

--- a/simde/arm/neon/ld3.h
+++ b/simde/arm/neon/ld3.h
@@ -49,8 +49,7 @@ simde_vld3_f16(simde_float16_t const *ptr) {
     return vld3_f16(ptr);
   #else
     simde_float16x4_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG) && \
-      SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x3_t dest = __riscv_vlseg3e16_v_f16m1x3((_Float16 *)&ptr[0], 4);
       r_[0].sv64 = __riscv_vget_v_f16m1x3_f16m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_f16m1x3_f16m1(dest, 1);
@@ -84,7 +83,7 @@ simde_vld3_f32(simde_float32 const *ptr) {
     return vld3_f32(ptr);
   #else
     simde_float32x2_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat32m1x3_t dest = __riscv_vlseg3e32_v_f32m1x3(&ptr[0], 2);
       r_[0].sv64 = __riscv_vget_v_f32m1x3_f32m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_f32m1x3_f32m1(dest, 1);
@@ -117,7 +116,7 @@ simde_vld3_f64(simde_float64 const *ptr) {
     return vld3_f64(ptr);
   #else
     simde_float64x1_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat64m1x3_t dest = __riscv_vlseg3e64_v_f64m1x3(&ptr[0], 1);
       r_[0].sv64 = __riscv_vget_v_f64m1x3_f64m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_f64m1x3_f64m1(dest, 1);
@@ -150,7 +149,7 @@ simde_vld3_s8(int8_t const *ptr) {
     return vld3_s8(ptr);
   #else
     simde_int8x8_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint8m1x3_t dest = __riscv_vlseg3e8_v_i8m1x3(&ptr[0], 8);
       r_[0].sv64 = __riscv_vget_v_i8m1x3_i8m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_i8m1x3_i8m1(dest, 1);
@@ -183,7 +182,7 @@ simde_vld3_s16(int16_t const *ptr) {
     return vld3_s16(ptr);
   #else
     simde_int16x4_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint16m1x3_t dest = __riscv_vlseg3e16_v_i16m1x3(&ptr[0], 4);
       r_[0].sv64 = __riscv_vget_v_i16m1x3_i16m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_i16m1x3_i16m1(dest, 1);
@@ -216,7 +215,7 @@ simde_vld3_s32(int32_t const *ptr) {
     return vld3_s32(ptr);
   #else
     simde_int32x2_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint32m1x3_t dest = __riscv_vlseg3e32_v_i32m1x3(&ptr[0], 2);
       r_[0].sv64 = __riscv_vget_v_i32m1x3_i32m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_i32m1x3_i32m1(dest, 1);
@@ -249,7 +248,7 @@ simde_vld3_s64(int64_t const *ptr) {
     return vld3_s64(ptr);
   #else
     simde_int64x1_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint64m1x3_t dest = __riscv_vlseg3e64_v_i64m1x3(&ptr[0], 1);
       r_[0].sv64 = __riscv_vget_v_i64m1x3_i64m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_i64m1x3_i64m1(dest, 1);
@@ -282,7 +281,7 @@ simde_vld3_u8(uint8_t const *ptr) {
     return vld3_u8(ptr);
   #else
     simde_uint8x8_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x3_t dest = __riscv_vlseg3e8_v_u8m1x3(&ptr[0], 8);
       r_[0].sv64 = __riscv_vget_v_u8m1x3_u8m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_u8m1x3_u8m1(dest, 1);
@@ -315,7 +314,7 @@ simde_vld3_u16(uint16_t const *ptr) {
     return vld3_u16(ptr);
   #else
     simde_uint16x4_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x3_t dest = __riscv_vlseg3e16_v_u16m1x3(&ptr[0], 4);
       r_[0].sv64 = __riscv_vget_v_u16m1x3_u16m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_u16m1x3_u16m1(dest, 1);
@@ -348,7 +347,7 @@ simde_vld3_u32(uint32_t const *ptr) {
     return vld3_u32(ptr);
   #else
     simde_uint32x2_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint32m1x3_t dest = __riscv_vlseg3e32_v_u32m1x3(&ptr[0], 2);
       r_[0].sv64 = __riscv_vget_v_u32m1x3_u32m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_u32m1x3_u32m1(dest, 1);
@@ -381,7 +380,7 @@ simde_vld3_u64(uint64_t const *ptr) {
     return vld3_u64(ptr);
   #else
     simde_uint64x1_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x3_t dest = __riscv_vlseg3e64_v_u64m1x3(&ptr[0], 1);
       r_[0].sv64 = __riscv_vget_v_u64m1x3_u64m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_u64m1x3_u64m1(dest, 1);
@@ -414,8 +413,7 @@ simde_vld3q_f16(simde_float16_t const *ptr) {
     return vld3q_f16(ptr);
   #else
     simde_float16x8_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG) \
-      && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x3_t dest = __riscv_vlseg3e16_v_f16m1x3((_Float16 *)&ptr[0], 8);
       r_[0].sv128 = __riscv_vget_v_f16m1x3_f16m1(dest, 0);
       r_[1].sv128 = __riscv_vget_v_f16m1x3_f16m1(dest, 1);
@@ -447,7 +445,7 @@ simde_float32x4x3_t
 simde_vld3q_f32(simde_float32 const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_f32(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_float32x4_private r_[3];
     vfloat32m1x3_t dest = __riscv_vlseg3e32_v_f32m1x3(&ptr[0], 4);
     r_[0].sv128 = __riscv_vget_v_f32m1x3_f32m1(dest, 0);
@@ -487,7 +485,7 @@ simde_float64x2x3_t
 simde_vld3q_f64(simde_float64 const *ptr) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld3q_f64(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_float64x2_private r_[3];
     vfloat64m1x3_t dest = __riscv_vlseg3e64_v_f64m1x3(&ptr[0], 2);
     r_[0].sv128 = __riscv_vget_v_f64m1x3_f64m1(dest, 0);
@@ -527,7 +525,7 @@ simde_int8x16x3_t
 simde_vld3q_s8(int8_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_s8(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int8x16_private r_[3];
     vint8m1x3_t dest = __riscv_vlseg3e8_v_i8m1x3(&ptr[0], 16);
     r_[0].sv128 = __riscv_vget_v_i8m1x3_i8m1(dest, 0);
@@ -567,7 +565,7 @@ simde_int16x8x3_t
 simde_vld3q_s16(int16_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_s16(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int16x8_private r_[3];
     vint16m1x3_t dest = __riscv_vlseg3e16_v_i16m1x3(&ptr[0], 8);
     r_[0].sv128 = __riscv_vget_v_i16m1x3_i16m1(dest, 0);
@@ -607,7 +605,7 @@ simde_int32x4x3_t
 simde_vld3q_s32(int32_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_s32(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int32x4_private r_[3];
     vint32m1x3_t dest = __riscv_vlseg3e32_v_i32m1x3(&ptr[0], 4);
     r_[0].sv128 = __riscv_vget_v_i32m1x3_i32m1(dest, 0);
@@ -647,7 +645,7 @@ simde_int64x2x3_t
 simde_vld3q_s64(int64_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld3q_s64(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int64x2_private r_[3];
     vint64m1x3_t dest = __riscv_vlseg3e64_v_i64m1x3(&ptr[0], 2);
     r_[0].sv128 = __riscv_vget_v_i64m1x3_i64m1(dest, 0);
@@ -688,7 +686,7 @@ simde_uint8x16x3_t
 simde_vld3q_u8(uint8_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_u8(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint8x16_private r_[3];
     vuint8m1x3_t dest = __riscv_vlseg3e8_v_u8m1x3(&ptr[0], 16);
     r_[0].sv128 = __riscv_vget_v_u8m1x3_u8m1(dest, 0);
@@ -728,7 +726,7 @@ simde_uint16x8x3_t
 simde_vld3q_u16(uint16_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_u16(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint16x8_private r_[3];
     vuint16m1x3_t dest = __riscv_vlseg3e16_v_u16m1x3(&ptr[0], 8);
     r_[0].sv128 = __riscv_vget_v_u16m1x3_u16m1(dest, 0);
@@ -768,7 +766,7 @@ simde_uint32x4x3_t
 simde_vld3q_u32(uint32_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_u32(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint32x4_private r_[3];
     vuint32m1x3_t dest = __riscv_vlseg3e32_v_u32m1x3(&ptr[0], 4);
     r_[0].sv128 = __riscv_vget_v_u32m1x3_u32m1(dest, 0);
@@ -808,7 +806,7 @@ simde_uint64x2x3_t
 simde_vld3q_u64(uint64_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld3q_u64(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint64x2_private r_[3];
     vuint64m1x3_t dest = __riscv_vlseg3e64_v_u64m1x3(&ptr[0], 2);
     r_[0].sv128 = __riscv_vget_v_u64m1x3_u64m1(dest, 0);
@@ -851,7 +849,7 @@ simde_vld3_p8(simde_poly8_t const *ptr) {
   #else
     simde_poly8x8_private r_[3];
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x3_t dest = __riscv_vlseg3e8_v_u8m1x3(&ptr[0], 8);
       r_[0].sv64 = __riscv_vget_v_u8m1x3_u8m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_u8m1x3_u8m1(dest, 1);
@@ -886,7 +884,7 @@ simde_vld3_p16(simde_poly16_t const *ptr) {
   #else
     simde_poly16x4_private r_[3];
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x3_t dest = __riscv_vlseg3e16_v_u16m1x3(&ptr[0], 4);
       r_[0].sv64 = __riscv_vget_v_u16m1x3_u16m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_u16m1x3_u16m1(dest, 1);
@@ -921,7 +919,7 @@ simde_vld3_p64(simde_poly64_t const *ptr) {
   #else
     simde_poly64x1_private r_[3];
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x3_t dest = __riscv_vlseg3e64_v_u64m1x3(&ptr[0], 1);
       r_[0].sv64 = __riscv_vget_v_u64m1x3_u64m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_u64m1x3_u64m1(dest, 1);
@@ -956,7 +954,7 @@ simde_vld3q_p8(simde_poly8_t const *ptr) {
   #else
     simde_poly8x16_private r_[3];
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x3_t dest = __riscv_vlseg3e8_v_u8m1x3(&ptr[0], 16);
       r_[0].sv128 = __riscv_vget_v_u8m1x3_u8m1(dest, 0);
       r_[1].sv128 = __riscv_vget_v_u8m1x3_u8m1(dest, 1);
@@ -991,7 +989,7 @@ simde_vld3q_p16(simde_poly16_t const *ptr) {
   #else
     simde_poly16x8_private r_[3];
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x3_t dest = __riscv_vlseg3e16_v_u16m1x3(&ptr[0], 8);
       r_[0].sv128 = __riscv_vget_v_u16m1x3_u16m1(dest, 0);
       r_[1].sv128 = __riscv_vget_v_u16m1x3_u16m1(dest, 1);
@@ -1026,7 +1024,7 @@ simde_vld3q_p64(simde_poly64_t const *ptr) {
   #else
     simde_poly64x2_private r_[3];
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x3_t dest = __riscv_vlseg3e64_v_u64m1x3(&ptr[0], 2);
       r_[0].sv128 = __riscv_vget_v_u64m1x3_u64m1(dest, 0);
       r_[1].sv128 = __riscv_vget_v_u64m1x3_u64m1(dest, 1);

--- a/simde/arm/neon/ld4.h
+++ b/simde/arm/neon/ld4.h
@@ -48,8 +48,7 @@ simde_vld4_f16(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld4_f16(ptr);
   #else
     simde_float16x4_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG) \
-      && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x4_t dest = __riscv_vlseg4e16_v_f16m1x4((_Float16 *)&ptr[0], 4);
       a_[0].sv64 = __riscv_vget_v_f16m1x4_f16m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_f16m1x4_f16m1(dest, 1);
@@ -78,7 +77,7 @@ simde_vld4_f32(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld4_f32(ptr);
   #else
     simde_float32x2_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat32m1x4_t dest = __riscv_vlseg4e32_v_f32m1x4(&ptr[0], 2);
       a_[0].sv64 = __riscv_vget_v_f32m1x4_f32m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_f32m1x4_f32m1(dest, 1);
@@ -106,7 +105,7 @@ simde_vld4_f64(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld4_f64(ptr);
   #else
     simde_float64x1_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat64m1x4_t dest = __riscv_vlseg4e64_v_f64m1x4(&ptr[0], 1);
       a_[0].sv64 = __riscv_vget_v_f64m1x4_f64m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_f64m1x4_f64m1(dest, 1);
@@ -134,7 +133,7 @@ simde_vld4_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld4_s8(ptr);
   #else
     simde_int8x8_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint8m1x4_t dest = __riscv_vlseg4e8_v_i8m1x4(&ptr[0], 8);
       a_[0].sv64 = __riscv_vget_v_i8m1x4_i8m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_i8m1x4_i8m1(dest, 1);
@@ -162,7 +161,7 @@ simde_vld4_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld4_s16(ptr);
   #else
     simde_int16x4_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint16m1x4_t dest = __riscv_vlseg4e16_v_i16m1x4(&ptr[0], 4);
       a_[0].sv64 = __riscv_vget_v_i16m1x4_i16m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_i16m1x4_i16m1(dest, 1);
@@ -190,7 +189,7 @@ simde_vld4_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld4_s32(ptr);
   #else
     simde_int32x2_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint32m1x4_t dest = __riscv_vlseg4e32_v_i32m1x4(&ptr[0], 2);
       a_[0].sv64 = __riscv_vget_v_i32m1x4_i32m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_i32m1x4_i32m1(dest, 1);
@@ -218,7 +217,7 @@ simde_vld4_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld4_s64(ptr);
   #else
     simde_int64x1_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint64m1x4_t dest = __riscv_vlseg4e64_v_i64m1x4(&ptr[0], 1);
       a_[0].sv64 = __riscv_vget_v_i64m1x4_i64m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_i64m1x4_i64m1(dest, 1);
@@ -246,7 +245,7 @@ simde_vld4_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld4_u8(ptr);
   #else
     simde_uint8x8_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x4_t dest = __riscv_vlseg4e8_v_u8m1x4(&ptr[0], 8);
       a_[0].sv64 = __riscv_vget_v_u8m1x4_u8m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_u8m1x4_u8m1(dest, 1);
@@ -274,7 +273,7 @@ simde_vld4_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld4_u16(ptr);
   #else
     simde_uint16x4_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x4_t dest = __riscv_vlseg4e16_v_u16m1x4(&ptr[0], 4);
       a_[0].sv64 = __riscv_vget_v_u16m1x4_u16m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_u16m1x4_u16m1(dest, 1);
@@ -302,7 +301,7 @@ simde_vld4_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld4_u32(ptr);
   #else
     simde_uint32x2_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint32m1x4_t dest = __riscv_vlseg4e32_v_u32m1x4(&ptr[0], 2);
       a_[0].sv64 = __riscv_vget_v_u32m1x4_u32m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_u32m1x4_u32m1(dest, 1);
@@ -330,7 +329,7 @@ simde_vld4_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld4_u64(ptr);
   #else
     simde_uint64x1_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x4_t dest = __riscv_vlseg4e64_v_u64m1x4(&ptr[0], 1);
       a_[0].sv64 = __riscv_vget_v_u64m1x4_u64m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_u64m1x4_u64m1(dest, 1);
@@ -358,8 +357,7 @@ simde_vld4q_f16(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld4q_f16(ptr);
   #else
     simde_float16x8_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG) \
-      && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x4_t dest = __riscv_vlseg4e16_v_f16m1x4((_Float16 *)&ptr[0], 8);
       a_[0].sv128 = __riscv_vget_v_f16m1x4_f16m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_f16m1x4_f16m1(dest, 1);
@@ -388,7 +386,7 @@ simde_vld4q_f32(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld4q_f32(ptr);
   #else
     simde_float32x4_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat32m1x4_t dest = __riscv_vlseg4e32_v_f32m1x4(&ptr[0], 4);
       a_[0].sv128 = __riscv_vget_v_f32m1x4_f32m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_f32m1x4_f32m1(dest, 1);
@@ -416,7 +414,7 @@ simde_vld4q_f64(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld4q_f64(ptr);
   #else
     simde_float64x2_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat64m1x4_t dest = __riscv_vlseg4e64_v_f64m1x4(&ptr[0], 2);
       a_[0].sv128 = __riscv_vget_v_f64m1x4_f64m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_f64m1x4_f64m1(dest, 1);
@@ -444,7 +442,7 @@ simde_vld4q_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(64)]) {
     return vld4q_s8(ptr);
   #else
     simde_int8x16_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint8m1x4_t dest = __riscv_vlseg4e8_v_i8m1x4(&ptr[0], 16);
       a_[0].sv128 = __riscv_vget_v_i8m1x4_i8m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_i8m1x4_i8m1(dest, 1);
@@ -472,7 +470,7 @@ simde_vld4q_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld4q_s16(ptr);
   #else
     simde_int16x8_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint16m1x4_t dest = __riscv_vlseg4e16_v_i16m1x4(&ptr[0], 8);
       a_[0].sv128 = __riscv_vget_v_i16m1x4_i16m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_i16m1x4_i16m1(dest, 1);
@@ -500,7 +498,7 @@ simde_vld4q_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld4q_s32(ptr);
   #else
     simde_int32x4_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint32m1x4_t dest = __riscv_vlseg4e32_v_i32m1x4(&ptr[0], 4);
       a_[0].sv128 = __riscv_vget_v_i32m1x4_i32m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_i32m1x4_i32m1(dest, 1);
@@ -528,7 +526,7 @@ simde_vld4q_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld4q_s64(ptr);
   #else
     simde_int64x2_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint64m1x4_t dest = __riscv_vlseg4e64_v_i64m1x4(&ptr[0], 2);
       a_[0].sv128 = __riscv_vget_v_i64m1x4_i64m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_i64m1x4_i64m1(dest, 1);
@@ -592,7 +590,7 @@ simde_vld4q_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(64)]) {
                               simde_uint8x16_from_private(r_[2]),
                               simde_uint8x16_from_private(r_[3])}};
     return s_;
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint8x16_private r_[4];
     vuint8m1x4_t dest = __riscv_vlseg4e8_v_u8m1x4(&ptr[0], 16);
     r_[0].sv128 = __riscv_vget_v_u8m1x4_u8m1(dest, 0);
@@ -628,7 +626,7 @@ simde_vld4q_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld4q_u16(ptr);
   #else
     simde_uint16x8_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x4_t dest = __riscv_vlseg4e16_v_u16m1x4(&ptr[0], 8);
       a_[0].sv128 = __riscv_vget_v_u16m1x4_u16m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_u16m1x4_u16m1(dest, 1);
@@ -656,7 +654,7 @@ simde_vld4q_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld4q_u32(ptr);
   #else
     simde_uint32x4_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint32m1x4_t dest = __riscv_vlseg4e32_v_u32m1x4(&ptr[0], 4);
       a_[0].sv128 = __riscv_vget_v_u32m1x4_u32m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_u32m1x4_u32m1(dest, 1);
@@ -684,7 +682,7 @@ simde_vld4q_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld4q_u64(ptr);
   #else
     simde_uint64x2_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x4_t dest = __riscv_vlseg4e64_v_u64m1x4(&ptr[0], 2);
       a_[0].sv128 = __riscv_vget_v_u64m1x4_u64m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_u64m1x4_u64m1(dest, 1);
@@ -712,7 +710,7 @@ simde_vld4_p8(simde_poly8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld4_p8(ptr);
   #else
     simde_poly8x8_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x4_t dest = __riscv_vlseg4e8_v_u8m1x4(&ptr[0], 8);
       a_[0].sv64 = __riscv_vget_v_u8m1x4_u8m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_u8m1x4_u8m1(dest, 1);
@@ -740,7 +738,7 @@ simde_vld4_p16(simde_poly16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld4_p16(ptr);
   #else
     simde_poly16x4_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x4_t dest = __riscv_vlseg4e16_v_u16m1x4(&ptr[0], 4);
       a_[0].sv64 = __riscv_vget_v_u16m1x4_u16m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_u16m1x4_u16m1(dest, 1);
@@ -768,7 +766,7 @@ simde_vld4_p64(simde_poly64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld4_p64(ptr);
   #else
     simde_poly64x1_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x4_t dest = __riscv_vlseg4e64_v_u64m1x4(&ptr[0], 1);
       a_[0].sv64 = __riscv_vget_v_u64m1x4_u64m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_u64m1x4_u64m1(dest, 1);
@@ -796,7 +794,7 @@ simde_vld4q_p8(simde_poly8_t const ptr[HEDLEY_ARRAY_PARAM(64)]) {
     return vld4q_p8(ptr);
   #else
     simde_poly8x16_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x4_t dest = __riscv_vlseg4e8_v_u8m1x4(&ptr[0], 16);
       a_[0].sv128 = __riscv_vget_v_u8m1x4_u8m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_u8m1x4_u8m1(dest, 1);
@@ -824,7 +822,7 @@ simde_vld4q_p16(simde_poly16_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld4q_p16(ptr);
   #else
     simde_poly16x8_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x4_t dest = __riscv_vlseg4e16_v_u16m1x4(&ptr[0], 8);
       a_[0].sv128 = __riscv_vget_v_u16m1x4_u16m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_u16m1x4_u16m1(dest, 1);
@@ -852,7 +850,7 @@ simde_vld4q_p64(simde_poly64_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld4q_p64(ptr);
   #else
     simde_poly64x2_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x4_t dest = __riscv_vlseg4e64_v_u64m1x4(&ptr[0], 2);
       a_[0].sv128 = __riscv_vget_v_u64m1x4_u64m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_u64m1x4_u64m1(dest, 1);

--- a/simde/arm/neon/st2.h
+++ b/simde/arm/neon/st2.h
@@ -48,8 +48,7 @@ simde_vst2_f16(simde_float16_t *ptr, simde_float16x4x2_t val) {
   #else
     simde_float16x4_private a_[2] = {simde_float16x4_to_private(val.val[0]),
                                      simde_float16x4_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG) \
-      && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x2_t dest = __riscv_vlseg2e16_v_f16m1x2((_Float16 *)ptr, 4);
       dest = __riscv_vset_v_f16m1_f16m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_f16m1_f16m1x2 (dest, 1, a_[1].sv64);
@@ -77,7 +76,7 @@ simde_vst2_f32(simde_float32_t *ptr, simde_float32x2x2_t val) {
   #else
     simde_float32x2_private a_[2] = {simde_float32x2_to_private(val.val[0]),
                                      simde_float32x2_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat32m1x2_t dest = __riscv_vlseg2e32_v_f32m1x2(ptr, 2);
       dest = __riscv_vset_v_f32m1_f32m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_f32m1_f32m1x2 (dest, 1, a_[1].sv64);
@@ -104,7 +103,7 @@ simde_vst2_f64(simde_float64_t *ptr, simde_float64x1x2_t val) {
   #else
     simde_float64x1_private a_[2] = {simde_float64x1_to_private(val.val[0]),
                                      simde_float64x1_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat64m1x2_t dest = __riscv_vlseg2e64_v_f64m1x2(ptr, 1);
       dest = __riscv_vset_v_f64m1_f64m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_f64m1_f64m1x2 (dest, 1, a_[1].sv64);
@@ -131,7 +130,7 @@ simde_vst2_s8(int8_t *ptr, simde_int8x8x2_t val) {
   #else
     simde_int8x8_private a_[2] = {simde_int8x8_to_private(val.val[0]),
                                   simde_int8x8_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint8m1x2_t dest = __riscv_vlseg2e8_v_i8m1x2(ptr, 8);
       dest = __riscv_vset_v_i8m1_i8m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i8m1_i8m1x2 (dest, 1, a_[1].sv64);
@@ -158,7 +157,7 @@ simde_vst2_s16(int16_t *ptr, simde_int16x4x2_t val) {
   #else
     simde_int16x4_private a_[2] = {simde_int16x4_to_private(val.val[0]),
                                    simde_int16x4_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint16m1x2_t dest = __riscv_vlseg2e16_v_i16m1x2(ptr, 4);
       dest = __riscv_vset_v_i16m1_i16m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i16m1_i16m1x2 (dest, 1, a_[1].sv64);
@@ -185,7 +184,7 @@ simde_vst2_s32(int32_t *ptr, simde_int32x2x2_t val) {
   #else
     simde_int32x2_private a_[2] = {simde_int32x2_to_private(val.val[0]),
                                    simde_int32x2_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint32m1x2_t dest = __riscv_vlseg2e32_v_i32m1x2(ptr, 2);
       dest = __riscv_vset_v_i32m1_i32m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i32m1_i32m1x2 (dest, 1, a_[1].sv64);
@@ -212,7 +211,7 @@ simde_vst2_s64(int64_t *ptr, simde_int64x1x2_t val) {
   #else
     simde_int64x1_private a_[2] = {simde_int64x1_to_private(val.val[0]),
                                    simde_int64x1_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint64m1x2_t dest = __riscv_vlseg2e64_v_i64m1x2(ptr, 1);
       dest = __riscv_vset_v_i64m1_i64m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i64m1_i64m1x2 (dest, 1, a_[1].sv64);
@@ -255,7 +254,7 @@ simde_vst2_u8(uint8_t *ptr, simde_uint8x8x2_t val) {
   #else
     simde_uint8x8_private a_[2] = {simde_uint8x8_to_private(val.val[0]),
                                    simde_uint8x8_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x2_t dest = __riscv_vlseg2e8_v_u8m1x2(ptr, 8);
       dest = __riscv_vset_v_u8m1_u8m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u8m1_u8m1x2 (dest, 1, a_[1].sv64);
@@ -282,7 +281,7 @@ simde_vst2_u16(uint16_t *ptr, simde_uint16x4x2_t val) {
   #else
     simde_uint16x4_private a_[2] = {simde_uint16x4_to_private(val.val[0]),
                                     simde_uint16x4_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x2_t dest = __riscv_vlseg2e16_v_u16m1x2(ptr, 4);
       dest = __riscv_vset_v_u16m1_u16m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u16m1_u16m1x2 (dest, 1, a_[1].sv64);
@@ -309,7 +308,7 @@ simde_vst2_u32(uint32_t *ptr, simde_uint32x2x2_t val) {
   #else
     simde_uint32x2_private a_[2] = {simde_uint32x2_to_private(val.val[0]),
                                     simde_uint32x2_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint32m1x2_t dest = __riscv_vlseg2e32_v_u32m1x2(ptr, 2);
       dest = __riscv_vset_v_u32m1_u32m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u32m1_u32m1x2 (dest, 1, a_[1].sv64);
@@ -336,7 +335,7 @@ simde_vst2_u64(uint64_t *ptr, simde_uint64x1x2_t val) {
   #else
     simde_uint64x1_private a_[2] = {simde_uint64x1_to_private(val.val[0]),
                                    simde_uint64x1_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x2_t dest = __riscv_vlseg2e64_v_u64m1x2(ptr, 1);
       dest = __riscv_vset_v_u64m1_u64m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u64m1_u64m1x2 (dest, 1, a_[1].sv64);
@@ -360,8 +359,7 @@ void
 simde_vst2q_f16(simde_float16_t *ptr, simde_float16x8x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     vst2q_f16(ptr, val);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG) \
-    && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
     simde_float16x8_private a_[2] = {simde_float16x8_to_private(val.val[0]),
                                      simde_float16x8_to_private(val.val[1])};
     vfloat16m1x2_t dest = __riscv_vlseg2e16_v_f16m1x2((_Float16 *)ptr, 8);
@@ -385,7 +383,7 @@ void
 simde_vst2q_f32(simde_float32_t *ptr, simde_float32x4x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_f32(ptr, val);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_float32x4_private a_[2] = {simde_float32x4_to_private(val.val[0]),
                                      simde_float32x4_to_private(val.val[1])};
     vfloat32m1x2_t dest = __riscv_vlseg2e32_v_f32m1x2(ptr, 4);
@@ -411,7 +409,7 @@ simde_vst2q_f64(simde_float64_t *ptr, simde_float64x2x2_t val) {
   #else
     simde_float64x2_private a_[2] = {simde_float64x2_to_private(val.val[0]),
                                    simde_float64x2_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat64m1x2_t dest = __riscv_vlseg2e64_v_f64m1x2(ptr, 2);
       dest = __riscv_vset_v_f64m1_f64m1x2 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_f64m1_f64m1x2 (dest, 1, a_[1].sv128);
@@ -435,7 +433,7 @@ void
 simde_vst2q_s8(int8_t *ptr, simde_int8x16x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_s8(ptr, val);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int8x16_private a_[2] = {simde_int8x16_to_private(val.val[0]),
                                   simde_int8x16_to_private(val.val[1])};
     vint8m1x2_t dest = __riscv_vlseg2e8_v_i8m1x2(ptr, 16);
@@ -458,7 +456,7 @@ void
 simde_vst2q_s16(int16_t *ptr, simde_int16x8x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_s16(ptr, val);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int16x8_private a_[2] = {simde_int16x8_to_private(val.val[0]),
                                    simde_int16x8_to_private(val.val[1])};
     vint16m1x2_t dest = __riscv_vlseg2e16_v_i16m1x2(ptr, 8);
@@ -481,7 +479,7 @@ void
 simde_vst2q_s32(int32_t *ptr, simde_int32x4x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_s32(ptr, val);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int32x4_private a_[2] = {simde_int32x4_to_private(val.val[0]),
                                     simde_int32x4_to_private(val.val[1])};
     vint32m1x2_t dest = __riscv_vlseg2e32_v_i32m1x2(ptr, 4);
@@ -504,7 +502,7 @@ void
 simde_vst2q_s64(int64_t *ptr, simde_int64x2x2_t val) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     vst2q_s64(ptr, val);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int64x2_private a_[2] = {simde_int64x2_to_private(val.val[0]),
                                    simde_int64x2_to_private(val.val[1])};
     vint64m1x2_t dest = __riscv_vlseg2e64_v_i64m1x2(ptr, 2);
@@ -531,7 +529,7 @@ void
 simde_vst2q_u8(uint8_t *ptr, simde_uint8x16x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_u8(ptr, val);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint8x16_private a_[2] = {simde_uint8x16_to_private(val.val[0]),
                                    simde_uint8x16_to_private(val.val[1])};
     vuint8m1x2_t dest = __riscv_vlseg2e8_v_u8m1x2(ptr, 16);
@@ -554,7 +552,7 @@ void
 simde_vst2q_u16(uint16_t *ptr, simde_uint16x8x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_u16(ptr, val);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint16x8_private a_[2] = {simde_uint16x8_to_private(val.val[0]),
                                     simde_uint16x8_to_private(val.val[1])};
     vuint16m1x2_t dest = __riscv_vlseg2e16_v_u16m1x2(ptr, 8);
@@ -577,7 +575,7 @@ void
 simde_vst2q_u32(uint32_t *ptr, simde_uint32x4x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_u32(ptr, val);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint32x4_private a_[2] = {simde_uint32x4_to_private(val.val[0]),
                                     simde_uint32x4_to_private(val.val[1])};
     vuint32m1x2_t dest = __riscv_vlseg2e32_v_u32m1x2(ptr, 4);
@@ -603,7 +601,7 @@ simde_vst2q_u64(uint64_t *ptr, simde_uint64x2x2_t val) {
   #else
     simde_uint64x2_private a_[2] = {simde_uint64x2_to_private(val.val[0]),
                                    simde_uint64x2_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x2_t dest = __riscv_vlseg2e64_v_u64m1x2(ptr, 2);
       dest = __riscv_vset_v_u64m1_u64m1x2 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u64m1_u64m1x2 (dest, 1, a_[1].sv128);
@@ -630,7 +628,7 @@ simde_vst2_p8(simde_poly8_t *ptr, simde_poly8x8x2_t val) {
   #else
     simde_poly8x8_private a_[2] = {simde_poly8x8_to_private(val.val[0]),
                                    simde_poly8x8_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x2_t dest = __riscv_vlseg2e8_v_u8m1x2(ptr, 8);
       dest = __riscv_vset_v_u8m1_u8m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u8m1_u8m1x2 (dest, 1, a_[1].sv64);
@@ -657,7 +655,7 @@ simde_vst2_p16(simde_poly16_t *ptr, simde_poly16x4x2_t val) {
   #else
     simde_poly16x4_private a_[2] = {simde_poly16x4_to_private(val.val[0]),
                                     simde_poly16x4_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x2_t dest = __riscv_vlseg2e16_v_u16m1x2(ptr, 4);
       dest = __riscv_vset_v_u16m1_u16m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u16m1_u16m1x2 (dest, 1, a_[1].sv64);
@@ -684,7 +682,7 @@ simde_vst2_p64(simde_poly64_t *ptr, simde_poly64x1x2_t val) {
   #else
     simde_poly64x1_private a_[2] = {simde_poly64x1_to_private(val.val[0]),
                                    simde_poly64x1_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x2_t dest = __riscv_vlseg2e64_v_u64m1x2(ptr, 1);
       dest = __riscv_vset_v_u64m1_u64m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u64m1_u64m1x2 (dest, 1, a_[1].sv64);
@@ -711,7 +709,7 @@ simde_vst2q_p8(simde_poly8_t *ptr, simde_poly8x16x2_t val) {
   #else
     simde_poly8x16_private a_[2] = {simde_poly8x16_to_private(val.val[0]),
                                    simde_poly8x16_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x2_t dest = __riscv_vlseg2e8_v_u8m1x2(ptr, 16);
       dest = __riscv_vset_v_u8m1_u8m1x2 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u8m1_u8m1x2 (dest, 1, a_[1].sv128);
@@ -738,7 +736,7 @@ simde_vst2q_p16(simde_poly16_t *ptr, simde_poly16x8x2_t val) {
   #else
     simde_poly16x8_private a_[2] = {simde_poly16x8_to_private(val.val[0]),
                                    simde_poly16x8_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x2_t dest = __riscv_vlseg2e16_v_u16m1x2(ptr, 8);
       dest = __riscv_vset_v_u16m1_u16m1x2 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u16m1_u16m1x2 (dest, 1, a_[1].sv128);
@@ -765,7 +763,7 @@ simde_vst2q_p64(simde_poly64_t *ptr, simde_poly64x2x2_t val) {
   #else
     simde_poly64x2_private a_[2] = {simde_poly64x2_to_private(val.val[0]),
                                    simde_poly64x2_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x2_t dest = __riscv_vlseg2e64_v_u64m1x2(ptr, 2);
       dest = __riscv_vset_v_u64m1_u64m1x2 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u64m1_u64m1x2 (dest, 1, a_[1].sv128);

--- a/simde/arm/neon/st3.h
+++ b/simde/arm/neon/st3.h
@@ -48,8 +48,7 @@ simde_vst3_f16(simde_float16_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_float16x4x3_t 
     simde_float16x4_private a[3] = { simde_float16x4_to_private(val.val[0]),
                                       simde_float16x4_to_private(val.val[1]),
                                       simde_float16x4_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG) \
-      && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x3_t dest = __riscv_vlseg3e16_v_f16m1x3((_Float16 *)ptr, 4);
       dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 0, a[0].sv64);
       dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 1, a[1].sv64);
@@ -79,7 +78,7 @@ simde_vst3_f32(simde_float32_t ptr[HEDLEY_ARRAY_PARAM(6)], simde_float32x2x3_t v
     simde_float32x2_private a[3] = { simde_float32x2_to_private(val.val[0]),
                                       simde_float32x2_to_private(val.val[1]),
                                       simde_float32x2_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat32m1x3_t dest = __riscv_vlseg3e32_v_f32m1x3(ptr, 2);
       dest = __riscv_vset_v_f32m1_f32m1x3 (dest, 0, a[0].sv64);
       dest = __riscv_vset_v_f32m1_f32m1x3 (dest, 1, a[1].sv64);
@@ -115,7 +114,7 @@ simde_vst3_f64(simde_float64_t ptr[HEDLEY_ARRAY_PARAM(3)], simde_float64x1x3_t v
     simde_float64x1_private a_[3] = { simde_float64x1_to_private(val.val[0]),
                                       simde_float64x1_to_private(val.val[1]),
                                       simde_float64x1_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat64m1x3_t dest = __riscv_vlseg3e64_v_f64m1x3(ptr, 1);
       dest = __riscv_vset_v_f64m1_f64m1x3 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_f64m1_f64m1x3 (dest, 1, a_[1].sv64);
@@ -142,7 +141,7 @@ simde_vst3_s8(int8_t ptr[HEDLEY_ARRAY_PARAM(24)], simde_int8x8x3_t val) {
     simde_int8x8_private a_[3] = { simde_int8x8_to_private(val.val[0]),
                                    simde_int8x8_to_private(val.val[1]),
                                    simde_int8x8_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint8m1x3_t dest = __riscv_vlseg3e8_v_i8m1x3(ptr, 8);
       dest = __riscv_vset_v_i8m1_i8m1x3 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i8m1_i8m1x3 (dest, 1, a_[1].sv64);
@@ -189,7 +188,7 @@ simde_vst3_s16(int16_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_int16x4x3_t val) {
     simde_int16x4_private a_[3] = { simde_int16x4_to_private(val.val[0]),
                                     simde_int16x4_to_private(val.val[1]),
                                     simde_int16x4_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint16m1x3_t dest = __riscv_vlseg3e16_v_i16m1x3(ptr, 4);
       dest = __riscv_vset_v_i16m1_i16m1x3 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i16m1_i16m1x3 (dest, 1, a_[1].sv64);
@@ -236,7 +235,7 @@ simde_vst3_s32(int32_t ptr[HEDLEY_ARRAY_PARAM(6)], simde_int32x2x3_t val) {
     simde_int32x2_private a[3] = { simde_int32x2_to_private(val.val[0]),
                                     simde_int32x2_to_private(val.val[1]),
                                     simde_int32x2_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint32m1x3_t dest = __riscv_vlseg3e32_v_i32m1x3(ptr, 2);
       dest = __riscv_vset_v_i32m1_i32m1x3 (dest, 0, a[0].sv64);
       dest = __riscv_vset_v_i32m1_i32m1x3 (dest, 1, a[1].sv64);
@@ -272,7 +271,7 @@ simde_vst3_s64(int64_t ptr[HEDLEY_ARRAY_PARAM(3)], simde_int64x1x3_t val) {
     simde_int64x1_private a_[3] = { simde_int64x1_to_private(val.val[0]),
                                     simde_int64x1_to_private(val.val[1]),
                                     simde_int64x1_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint64m1x3_t dest = __riscv_vlseg3e64_v_i64m1x3(ptr, 1);
       dest = __riscv_vset_v_i64m1_i64m1x3 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i64m1_i64m1x3 (dest, 1, a_[1].sv64);
@@ -299,7 +298,7 @@ simde_vst3_u8(uint8_t ptr[HEDLEY_ARRAY_PARAM(24)], simde_uint8x8x3_t val) {
     simde_uint8x8_private a_[3] = { simde_uint8x8_to_private(val.val[0]),
                                     simde_uint8x8_to_private(val.val[1]),
                                     simde_uint8x8_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x3_t dest = __riscv_vlseg3e8_v_u8m1x3(ptr, 8);
       dest = __riscv_vset_v_u8m1_u8m1x3 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u8m1_u8m1x3 (dest, 1, a_[1].sv64);
@@ -346,7 +345,7 @@ simde_vst3_u16(uint16_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_uint16x4x3_t val) {
     simde_uint16x4_private a_[3] = { simde_uint16x4_to_private(val.val[0]),
                                      simde_uint16x4_to_private(val.val[1]),
                                      simde_uint16x4_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x3_t dest = __riscv_vlseg3e16_v_u16m1x3(ptr, 4);
       dest = __riscv_vset_v_u16m1_u16m1x3 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u16m1_u16m1x3 (dest, 1, a_[1].sv64);
@@ -393,7 +392,7 @@ simde_vst3_u32(uint32_t ptr[HEDLEY_ARRAY_PARAM(6)], simde_uint32x2x3_t val) {
     simde_uint32x2_private a[3] = { simde_uint32x2_to_private(val.val[0]),
                                      simde_uint32x2_to_private(val.val[1]),
                                      simde_uint32x2_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint32m1x3_t dest = __riscv_vlseg3e32_v_u32m1x3(ptr, 2);
       dest = __riscv_vset_v_u32m1_u32m1x3 (dest, 0, a[0].sv64);
       dest = __riscv_vset_v_u32m1_u32m1x3 (dest, 1, a[1].sv64);
@@ -429,7 +428,7 @@ simde_vst3_u64(uint64_t ptr[HEDLEY_ARRAY_PARAM(3)], simde_uint64x1x3_t val) {
     simde_uint64x1_private a_[3] = { simde_uint64x1_to_private(val.val[0]),
                                      simde_uint64x1_to_private(val.val[1]),
                                      simde_uint64x1_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x3_t dest = __riscv_vlseg3e64_v_u64m1x3(ptr, 1);
       dest = __riscv_vset_v_u64m1_u64m1x3 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u64m1_u64m1x3 (dest, 1, a_[1].sv64);
@@ -456,8 +455,7 @@ simde_vst3q_f16(simde_float16_t ptr[HEDLEY_ARRAY_PARAM(24)], simde_float16x8x3_t
     simde_float16x8_private a_[3] = { simde_float16x8_to_private(val.val[0]),
                                       simde_float16x8_to_private(val.val[1]),
                                       simde_float16x8_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG) \
-      && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x3_t dest = __riscv_vlseg3e16_v_f16m1x3((_Float16 *)ptr, 8);
       dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 1, a_[1].sv128);
@@ -487,7 +485,7 @@ simde_vst3q_f32(simde_float32_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_float32x4x3_t
     simde_float32x4_private a_[3] = { simde_float32x4_to_private(val.val[0]),
                                       simde_float32x4_to_private(val.val[1]),
                                       simde_float32x4_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat32m1x3_t dest = __riscv_vlseg3e32_v_f32m1x3(ptr, 4);
       dest = __riscv_vset_v_f32m1_f32m1x3 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_f32m1_f32m1x3 (dest, 1, a_[1].sv128);
@@ -534,7 +532,7 @@ simde_vst3q_f64(simde_float64_t ptr[HEDLEY_ARRAY_PARAM(6)], simde_float64x2x3_t 
     simde_float64x2_private a[3] = { simde_float64x2_to_private(val.val[0]),
                                       simde_float64x2_to_private(val.val[1]),
                                       simde_float64x2_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat64m1x3_t dest = __riscv_vlseg3e64_v_f64m1x3(ptr, 2);
       dest = __riscv_vset_v_f64m1_f64m1x3 (dest, 0, a[0].sv128);
       dest = __riscv_vset_v_f64m1_f64m1x3 (dest, 1, a[1].sv128);
@@ -570,7 +568,7 @@ simde_vst3q_s8(int8_t ptr[HEDLEY_ARRAY_PARAM(48)], simde_int8x16x3_t val) {
     simde_int8x16_private a_[3] = { simde_int8x16_to_private(val.val[0]),
                                     simde_int8x16_to_private(val.val[1]),
                                     simde_int8x16_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint8m1x3_t dest = __riscv_vlseg3e8_v_i8m1x3(ptr, 16);
       dest = __riscv_vset_v_i8m1_i8m1x3 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_i8m1_i8m1x3 (dest, 1, a_[1].sv128);
@@ -622,7 +620,7 @@ simde_vst3q_s16(int16_t ptr[HEDLEY_ARRAY_PARAM(24)], simde_int16x8x3_t val) {
     simde_int16x8_private a_[3] = { simde_int16x8_to_private(val.val[0]),
                                     simde_int16x8_to_private(val.val[1]),
                                     simde_int16x8_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint16m1x3_t dest = __riscv_vlseg3e16_v_i16m1x3(ptr, 8);
       dest = __riscv_vset_v_i16m1_i16m1x3 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_i16m1_i16m1x3 (dest, 1, a_[1].sv128);
@@ -669,7 +667,7 @@ simde_vst3q_s32(int32_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_int32x4x3_t val) {
     simde_int32x4_private a_[3] = { simde_int32x4_to_private(val.val[0]),
                                     simde_int32x4_to_private(val.val[1]),
                                     simde_int32x4_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint32m1x3_t dest = __riscv_vlseg3e32_v_i32m1x3(ptr, 4);
       dest = __riscv_vset_v_i32m1_i32m1x3 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_i32m1_i32m1x3 (dest, 1, a_[1].sv128);
@@ -716,7 +714,7 @@ simde_vst3q_s64(int64_t ptr[HEDLEY_ARRAY_PARAM(6)], simde_int64x2x3_t val) {
     simde_int64x2_private a[3] = { simde_int64x2_to_private(val.val[0]),
                                     simde_int64x2_to_private(val.val[1]),
                                     simde_int64x2_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint64m1x3_t dest = __riscv_vlseg3e64_v_i64m1x3(ptr, 2);
       dest = __riscv_vset_v_i64m1_i64m1x3 (dest, 0, a[0].sv128);
       dest = __riscv_vset_v_i64m1_i64m1x3 (dest, 1, a[1].sv128);
@@ -784,7 +782,7 @@ simde_vst3q_u8(uint8_t ptr[HEDLEY_ARRAY_PARAM(48)], simde_uint8x16x3_t val) {
       v128_t m2 = wasm_i8x16_shuffle(r2, r1, 0, 1, 18, 3, 4, 21, 6, 7, 24, 9, 10,
                                      27, 12, 13, 30, 15);
       wasm_v128_store(ptr + 32, m2);
-    #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #elif defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x3_t dest = __riscv_vlseg3e8_v_u8m1x3(ptr, 16);
       dest = __riscv_vset_v_u8m1_u8m1x3 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u8m1_u8m1x3 (dest, 1, a_[1].sv128);
@@ -837,7 +835,7 @@ simde_vst3q_u16(uint16_t ptr[HEDLEY_ARRAY_PARAM(24)], simde_uint16x8x3_t val) {
                                      simde_uint16x8_to_private(val.val[1]),
                                      simde_uint16x8_to_private(val.val[2]) };
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x3_t dest = __riscv_vlseg3e16_v_u16m1x3(ptr, 8);
       dest = __riscv_vset_v_u16m1_u16m1x3 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u16m1_u16m1x3 (dest, 1, a_[1].sv128);
@@ -885,7 +883,7 @@ simde_vst3q_u32(uint32_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_uint32x4x3_t val) {
                                      simde_uint32x4_to_private(val.val[1]),
                                      simde_uint32x4_to_private(val.val[2]) };
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint32m1x3_t dest = __riscv_vlseg3e32_v_u32m1x3(ptr, 4);
       dest = __riscv_vset_v_u32m1_u32m1x3 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u32m1_u32m1x3 (dest, 1, a_[1].sv128);
@@ -932,7 +930,7 @@ simde_vst3q_u64(uint64_t ptr[HEDLEY_ARRAY_PARAM(6)], simde_uint64x2x3_t val) {
     simde_uint64x2_private a[3] = { simde_uint64x2_to_private(val.val[0]),
                                      simde_uint64x2_to_private(val.val[1]),
                                      simde_uint64x2_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x3_t dest = __riscv_vlseg3e64_v_u64m1x3(ptr, 2);
       dest = __riscv_vset_v_u64m1_u64m1x3 (dest, 0, a[0].sv128);
       dest = __riscv_vset_v_u64m1_u64m1x3 (dest, 1, a[1].sv128);
@@ -968,7 +966,7 @@ simde_vst3_p8(simde_poly8_t ptr[HEDLEY_ARRAY_PARAM(24)], simde_poly8x8x3_t val) 
     simde_poly8x8_private a_[3] = { simde_poly8x8_to_private(val.val[0]),
                                     simde_poly8x8_to_private(val.val[1]),
                                     simde_poly8x8_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x3_t dest = __riscv_vlseg3e8_v_u8m1x3(ptr, 8);
       dest = __riscv_vset_v_u8m1_u8m1x3 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u8m1_u8m1x3 (dest, 1, a_[1].sv64);
@@ -997,7 +995,7 @@ simde_vst3_p16(simde_poly16_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_poly16x4x3_t va
     simde_poly16x4_private a_[3] = { simde_poly16x4_to_private(val.val[0]),
                                      simde_poly16x4_to_private(val.val[1]),
                                      simde_poly16x4_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x3_t dest = __riscv_vlseg3e16_v_u16m1x3(ptr, 4);
       dest = __riscv_vset_v_u16m1_u16m1x3 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u16m1_u16m1x3 (dest, 1, a_[1].sv64);
@@ -1026,7 +1024,7 @@ simde_vst3_p64(simde_poly64_t ptr[HEDLEY_ARRAY_PARAM(3)], simde_poly64x1x3_t val
     simde_poly64x1_private a_[3] = { simde_poly64x1_to_private(val.val[0]),
                                      simde_poly64x1_to_private(val.val[1]),
                                      simde_poly64x1_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x3_t dest = __riscv_vlseg3e64_v_u64m1x3(ptr, 1);
       dest = __riscv_vset_v_u64m1_u64m1x3 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u64m1_u64m1x3 (dest, 1, a_[1].sv64);
@@ -1053,7 +1051,7 @@ simde_vst3q_p8(simde_poly8_t ptr[HEDLEY_ARRAY_PARAM(48)], simde_poly8x16x3_t val
     simde_poly8x16_private a_[3] = {simde_poly8x16_to_private(val.val[0]),
                                     simde_poly8x16_to_private(val.val[1]),
                                     simde_poly8x16_to_private(val.val[2])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x3_t dest = __riscv_vlseg3e8_v_u8m1x3(ptr, 16);
       dest = __riscv_vset_v_u8m1_u8m1x3 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u8m1_u8m1x3 (dest, 1, a_[1].sv128);
@@ -1083,7 +1081,7 @@ simde_vst3q_p16(simde_poly16_t ptr[HEDLEY_ARRAY_PARAM(24)], simde_poly16x8x3_t v
                                      simde_poly16x8_to_private(val.val[1]),
                                      simde_poly16x8_to_private(val.val[2]) };
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x3_t dest = __riscv_vlseg3e16_v_u16m1x3(ptr, 8);
       dest = __riscv_vset_v_u16m1_u16m1x3 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u16m1_u16m1x3 (dest, 1, a_[1].sv128);
@@ -1112,7 +1110,7 @@ simde_vst3q_p64(simde_poly64_t ptr[HEDLEY_ARRAY_PARAM(6)], simde_poly64x2x3_t va
     simde_poly64x2_private a_[3] = { simde_poly64x2_to_private(val.val[0]),
                                      simde_poly64x2_to_private(val.val[1]),
                                      simde_poly64x2_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x3_t dest = __riscv_vlseg3e64_v_u64m1x3(ptr, 2);
       dest = __riscv_vset_v_u64m1_u64m1x3 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u64m1_u64m1x3 (dest, 1, a_[1].sv128);

--- a/simde/arm/neon/st4.h
+++ b/simde/arm/neon/st4.h
@@ -46,8 +46,7 @@ simde_vst4_f16(simde_float16_t *ptr, simde_float16x4x4_t val) {
   #else
     simde_float16x4_private a_[4] = { simde_float16x4_to_private(val.val[0]), simde_float16x4_to_private(val.val[1]),
                                       simde_float16x4_to_private(val.val[2]), simde_float16x4_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG) \
-      && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x4_t dest = __riscv_vlseg4e16_v_f16m1x4((_Float16 *)ptr, 4);
       dest = __riscv_vset_v_f16m1_f16m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_f16m1_f16m1x4 (dest, 1, a_[1].sv64);
@@ -77,7 +76,7 @@ simde_vst4_f32(simde_float32_t *ptr, simde_float32x2x4_t val) {
   #else
     simde_float32x2_private a_[4] = { simde_float32x2_to_private(val.val[0]), simde_float32x2_to_private(val.val[1]),
                                       simde_float32x2_to_private(val.val[2]), simde_float32x2_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat32m1x4_t dest = __riscv_vlseg4e32_v_f32m1x4(ptr, 2);
       dest = __riscv_vset_v_f32m1_f32m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_f32m1_f32m1x4 (dest, 1, a_[1].sv64);
@@ -106,7 +105,7 @@ simde_vst4_f64(simde_float64_t *ptr, simde_float64x1x4_t val) {
   #else
     simde_float64x1_private a_[4] = { simde_float64x1_to_private(val.val[0]), simde_float64x1_to_private(val.val[1]),
                                       simde_float64x1_to_private(val.val[2]), simde_float64x1_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat64m1x4_t dest = __riscv_vlseg4e64_v_f64m1x4(ptr, 1);
       dest = __riscv_vset_v_f64m1_f64m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_f64m1_f64m1x4 (dest, 1, a_[1].sv64);
@@ -135,7 +134,7 @@ simde_vst4_s8(int8_t *ptr, simde_int8x8x4_t val) {
   #else
     simde_int8x8_private a_[4] = { simde_int8x8_to_private(val.val[0]), simde_int8x8_to_private(val.val[1]),
                                    simde_int8x8_to_private(val.val[2]), simde_int8x8_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint8m1x4_t dest = __riscv_vlseg4e8_v_i8m1x4(ptr, 8);
       dest = __riscv_vset_v_i8m1_i8m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i8m1_i8m1x4 (dest, 1, a_[1].sv64);
@@ -164,7 +163,7 @@ simde_vst4_s16(int16_t *ptr, simde_int16x4x4_t val) {
   #else
     simde_int16x4_private a_[4] = { simde_int16x4_to_private(val.val[0]), simde_int16x4_to_private(val.val[1]),
                                     simde_int16x4_to_private(val.val[2]), simde_int16x4_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint16m1x4_t dest = __riscv_vlseg4e16_v_i16m1x4(ptr, 4);
       dest = __riscv_vset_v_i16m1_i16m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i16m1_i16m1x4 (dest, 1, a_[1].sv64);
@@ -193,7 +192,7 @@ simde_vst4_s32(int32_t *ptr, simde_int32x2x4_t val) {
   #else
     simde_int32x2_private a_[4] = { simde_int32x2_to_private(val.val[0]), simde_int32x2_to_private(val.val[1]),
                                     simde_int32x2_to_private(val.val[2]), simde_int32x2_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint32m1x4_t dest = __riscv_vlseg4e32_v_i32m1x4(ptr, 2);
       dest = __riscv_vset_v_i32m1_i32m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i32m1_i32m1x4 (dest, 1, a_[1].sv64);
@@ -222,7 +221,7 @@ simde_vst4_s64(int64_t *ptr, simde_int64x1x4_t val) {
   #else
     simde_int64x1_private a_[4] = { simde_int64x1_to_private(val.val[0]), simde_int64x1_to_private(val.val[1]),
                                     simde_int64x1_to_private(val.val[2]), simde_int64x1_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint64m1x4_t dest = __riscv_vlseg4e64_v_i64m1x4(ptr, 1);
       dest = __riscv_vset_v_i64m1_i64m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i64m1_i64m1x4 (dest, 1, a_[1].sv64);
@@ -272,7 +271,7 @@ simde_vst4_u8(uint8_t *ptr, simde_uint8x8x4_t val) {
   #else
     simde_uint8x8_private a_[4] = { simde_uint8x8_to_private(val.val[0]), simde_uint8x8_to_private(val.val[1]),
                                     simde_uint8x8_to_private(val.val[2]), simde_uint8x8_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x4_t dest = __riscv_vlseg4e8_v_u8m1x4(ptr, 8);
       dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 1, a_[1].sv64);
@@ -301,7 +300,7 @@ simde_vst4_u16(uint16_t *ptr, simde_uint16x4x4_t val) {
   #else
     simde_uint16x4_private a_[4] = { simde_uint16x4_to_private(val.val[0]), simde_uint16x4_to_private(val.val[1]),
                                      simde_uint16x4_to_private(val.val[2]), simde_uint16x4_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x4_t dest = __riscv_vlseg4e16_v_u16m1x4(ptr, 4);
       dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 1, a_[1].sv64);
@@ -330,7 +329,7 @@ simde_vst4_u32(uint32_t *ptr, simde_uint32x2x4_t val) {
   #else
     simde_uint32x2_private a_[4] = { simde_uint32x2_to_private(val.val[0]), simde_uint32x2_to_private(val.val[1]),
                                      simde_uint32x2_to_private(val.val[2]), simde_uint32x2_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint32m1x4_t dest = __riscv_vlseg4e32_v_u32m1x4(ptr, 2);
       dest = __riscv_vset_v_u32m1_u32m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u32m1_u32m1x4 (dest, 1, a_[1].sv64);
@@ -359,7 +358,7 @@ simde_vst4_u64(uint64_t *ptr, simde_uint64x1x4_t val) {
   #else
     simde_uint64x1_private a_[4] = { simde_uint64x1_to_private(val.val[0]), simde_uint64x1_to_private(val.val[1]),
                                      simde_uint64x1_to_private(val.val[2]), simde_uint64x1_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x4_t dest = __riscv_vlseg4e64_v_u64m1x4(ptr, 1);
       dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 1, a_[1].sv64);
@@ -388,8 +387,7 @@ simde_vst4q_f16(simde_float16_t *ptr, simde_float16x8x4_t val) {
   #else
     simde_float16x8_private a_[4] = { simde_float16x8_to_private(val.val[0]), simde_float16x8_to_private(val.val[1]),
                                       simde_float16x8_to_private(val.val[2]), simde_float16x8_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG) \
-      && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x4_t dest = __riscv_vlseg4e16_v_f16m1x4((_Float16 *)ptr, 8);
       dest = __riscv_vset_v_f16m1_f16m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_f16m1_f16m1x4 (dest, 1, a_[1].sv128);
@@ -419,7 +417,7 @@ simde_vst4q_f32(simde_float32_t *ptr, simde_float32x4x4_t val) {
   #else
     simde_float32x4_private a_[4] = { simde_float32x4_to_private(val.val[0]), simde_float32x4_to_private(val.val[1]),
                                       simde_float32x4_to_private(val.val[2]), simde_float32x4_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat32m1x4_t dest = __riscv_vlseg4e32_v_f32m1x4(ptr, 4);
       dest = __riscv_vset_v_f32m1_f32m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_f32m1_f32m1x4 (dest, 1, a_[1].sv128);
@@ -448,7 +446,7 @@ simde_vst4q_f64(simde_float64_t *ptr, simde_float64x2x4_t val) {
   #else
     simde_float64x2_private a_[4] = { simde_float64x2_to_private(val.val[0]), simde_float64x2_to_private(val.val[1]),
                                       simde_float64x2_to_private(val.val[2]), simde_float64x2_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat64m1x4_t dest = __riscv_vlseg4e64_v_f64m1x4(ptr, 2);
       dest = __riscv_vset_v_f64m1_f64m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_f64m1_f64m1x4 (dest, 1, a_[1].sv128);
@@ -477,7 +475,7 @@ simde_vst4q_s8(int8_t *ptr, simde_int8x16x4_t val) {
   #else
     simde_int8x16_private a_[4] = { simde_int8x16_to_private(val.val[0]), simde_int8x16_to_private(val.val[1]),
                                     simde_int8x16_to_private(val.val[2]), simde_int8x16_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint8m1x4_t dest = __riscv_vlseg4e8_v_i8m1x4(ptr, 16);
       dest = __riscv_vset_v_i8m1_i8m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_i8m1_i8m1x4 (dest, 1, a_[1].sv128);
@@ -506,7 +504,7 @@ simde_vst4q_s16(int16_t *ptr, simde_int16x8x4_t val) {
   #else
     simde_int16x8_private a_[4] = { simde_int16x8_to_private(val.val[0]), simde_int16x8_to_private(val.val[1]),
                                     simde_int16x8_to_private(val.val[2]), simde_int16x8_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
     vint16m1x4_t dest = __riscv_vlseg4e16_v_i16m1x4(ptr, 8);
       dest = __riscv_vset_v_i16m1_i16m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_i16m1_i16m1x4 (dest, 1, a_[1].sv128);
@@ -535,7 +533,7 @@ simde_vst4q_s32(int32_t *ptr, simde_int32x4x4_t val) {
   #else
     simde_int32x4_private a_[4] = { simde_int32x4_to_private(val.val[0]), simde_int32x4_to_private(val.val[1]),
                                     simde_int32x4_to_private(val.val[2]), simde_int32x4_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint32m1x4_t dest = __riscv_vlseg4e32_v_i32m1x4(ptr, 4);
       dest = __riscv_vset_v_i32m1_i32m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_i32m1_i32m1x4 (dest, 1, a_[1].sv128);
@@ -564,7 +562,7 @@ simde_vst4q_s64(int64_t *ptr, simde_int64x2x4_t val) {
   #else
     simde_int64x2_private a_[4] = { simde_int64x2_to_private(val.val[0]), simde_int64x2_to_private(val.val[1]),
                                     simde_int64x2_to_private(val.val[2]), simde_int64x2_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint64m1x4_t dest = __riscv_vlseg4e64_v_i64m1x4(ptr, 2);
       dest = __riscv_vset_v_i64m1_i64m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_i64m1_i64m1x4 (dest, 1, a_[1].sv128);
@@ -594,7 +592,7 @@ simde_vst4q_u8(uint8_t *ptr, simde_uint8x16x4_t val) {
   #else
     simde_uint8x16_private a_[4] = { simde_uint8x16_to_private(val.val[0]), simde_uint8x16_to_private(val.val[1]),
                                      simde_uint8x16_to_private(val.val[2]), simde_uint8x16_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x4_t dest = __riscv_vlseg4e8_v_u8m1x4(ptr, 16);
       dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 1, a_[1].sv128);
@@ -623,7 +621,7 @@ simde_vst4q_u16(uint16_t *ptr, simde_uint16x8x4_t val) {
   #else
     simde_uint16x8_private a_[4] = { simde_uint16x8_to_private(val.val[0]), simde_uint16x8_to_private(val.val[1]),
                                      simde_uint16x8_to_private(val.val[2]), simde_uint16x8_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x4_t dest = __riscv_vlseg4e16_v_u16m1x4(ptr, 8);
       dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 1, a_[1].sv128);
@@ -652,7 +650,7 @@ simde_vst4q_u32(uint32_t *ptr, simde_uint32x4x4_t val) {
   #else
     simde_uint32x4_private a_[4] = { simde_uint32x4_to_private(val.val[0]), simde_uint32x4_to_private(val.val[1]),
                                      simde_uint32x4_to_private(val.val[2]), simde_uint32x4_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint32m1x4_t dest = __riscv_vlseg4e32_v_u32m1x4(ptr, 4);
       dest = __riscv_vset_v_u32m1_u32m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u32m1_u32m1x4 (dest, 1, a_[1].sv128);
@@ -681,7 +679,7 @@ simde_vst4q_u64(uint64_t *ptr, simde_uint64x2x4_t val) {
   #else
     simde_uint64x2_private a_[4] = { simde_uint64x2_to_private(val.val[0]), simde_uint64x2_to_private(val.val[1]),
                                      simde_uint64x2_to_private(val.val[2]), simde_uint64x2_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x4_t dest = __riscv_vlseg4e64_v_u64m1x4(ptr, 2);
       dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 1, a_[1].sv128);
@@ -710,7 +708,7 @@ simde_vst4_p8(simde_poly8_t *ptr, simde_poly8x8x4_t val) {
   #else
     simde_poly8x8_private a_[4] = { simde_poly8x8_to_private(val.val[0]), simde_poly8x8_to_private(val.val[1]),
                                     simde_poly8x8_to_private(val.val[2]), simde_poly8x8_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x4_t dest = __riscv_vlseg4e8_v_u8m1x4(ptr, 8);
       dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 1, a_[1].sv64);
@@ -739,7 +737,7 @@ simde_vst4_p16(simde_poly16_t *ptr, simde_poly16x4x4_t val) {
   #else
     simde_poly16x4_private a_[4] = { simde_poly16x4_to_private(val.val[0]), simde_poly16x4_to_private(val.val[1]),
                                      simde_poly16x4_to_private(val.val[2]), simde_poly16x4_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x4_t dest = __riscv_vlseg4e16_v_u16m1x4(ptr, 4);
       dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 1, a_[1].sv64);
@@ -768,7 +766,7 @@ simde_vst4_p64(simde_poly64_t *ptr, simde_poly64x1x4_t val) {
   #else
     simde_poly64x1_private a_[4] = { simde_poly64x1_to_private(val.val[0]), simde_poly64x1_to_private(val.val[1]),
                                      simde_poly64x1_to_private(val.val[2]), simde_poly64x1_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x4_t dest = __riscv_vlseg4e64_v_u64m1x4(ptr, 1);
       dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 1, a_[1].sv64);
@@ -797,7 +795,7 @@ simde_vst4q_p8(simde_poly8_t *ptr, simde_poly8x16x4_t val) {
   #else
     simde_poly8x16_private a_[4] = { simde_poly8x16_to_private(val.val[0]), simde_poly8x16_to_private(val.val[1]),
                                      simde_poly8x16_to_private(val.val[2]), simde_poly8x16_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x4_t dest = __riscv_vlseg4e8_v_u8m1x4(ptr, 16);
       dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 1, a_[1].sv128);
@@ -826,7 +824,7 @@ simde_vst4q_p16(simde_poly16_t *ptr, simde_poly16x8x4_t val) {
   #else
     simde_poly16x8_private a_[4] = { simde_poly16x8_to_private(val.val[0]), simde_poly16x8_to_private(val.val[1]),
                                      simde_poly16x8_to_private(val.val[2]), simde_poly16x8_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x4_t dest = __riscv_vlseg4e16_v_u16m1x4(ptr, 8);
       dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 1, a_[1].sv128);
@@ -855,7 +853,7 @@ simde_vst4q_p64(simde_poly64_t *ptr, simde_poly64x2x4_t val) {
   #else
     simde_poly64x2_private a_[4] = { simde_poly64x2_to_private(val.val[0]), simde_poly64x2_to_private(val.val[1]),
                                      simde_poly64x2_to_private(val.val[2]), simde_poly64x2_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVLSSEG)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x4_t dest = __riscv_vlseg4e64_v_u64m1x4(ptr, 2);
       dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 1, a_[1].sv128);

--- a/simde/simde-arch.h
+++ b/simde/simde-arch.h
@@ -550,9 +550,6 @@
 #if defined(__riscv_zvfhmin)
 #  define SIMDE_ARCH_RISCV_ZVFHMIN 1
 #endif
-#if defined(__riscv_zvlsseg) || defined(__riscv_v)
-#  define SIMDE_ARCH_RISCV_ZVLSSEG 1
-#endif
 
 /* SPARC
    <https://en.wikipedia.org/wiki/SPARC> */


### PR DESCRIPTION
Previously, we applied this workaround to support CPUs that lack segment load/store instructions. To align with the current standard and because we no longer support simde on those CPUs, I reverted the PR.

This reverts commit 3e5facc1b69b1f97b9e84f8b70cb2ad7720729f6.