### PR TITLE
tests: skip NANs for relaxed-simd

### DIFF
--- a/test/arm/neon/maxnm.c
+++ b/test/arm/neon/maxnm.c
@@ -70,7 +70,7 @@ test_simde_vmaxnm_f16 (SIMDE_MUNIT_TEST_ARGS) {
     simde_float16 b[4];
     simde_float16 r[4];
   } test_vec[] = {
-    #if !defined(SIMDE_FAST_NANS)
+    #if !defined(SIMDE_FAST_NANS) && !defined(SIMDE_ARCH_WASM_RELAXED_SIMD)
     { {            SIMDE_NANHF, SIMDE_FLOAT16_VALUE(   656.90),            SIMDE_NANHF, SIMDE_FLOAT16_VALUE(   116.96) },
       { SIMDE_FLOAT16_VALUE(   427.79),            SIMDE_NANHF,            SIMDE_NANHF, SIMDE_FLOAT16_VALUE(  -999.94) },
       { SIMDE_FLOAT16_VALUE(   427.79), SIMDE_FLOAT16_VALUE(   656.90),            SIMDE_NANHF, SIMDE_FLOAT16_VALUE(   116.96) } },
@@ -217,7 +217,7 @@ test_simde_vmaxnm_f32 (SIMDE_MUNIT_TEST_ARGS) {
     simde_float32 b[2];
     simde_float32 r[2];
   } test_vec[] = {
-    #if !defined(SIMDE_FAST_NANS)
+    #if !defined(SIMDE_FAST_NANS) && !defined(SIMDE_ARCH_WASM_RELAXED_SIMD)
     { {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   656.90) },
       { SIMDE_FLOAT32_C(   427.79),            SIMDE_MATH_NANF },
       { SIMDE_FLOAT32_C(   427.79), SIMDE_FLOAT32_C(   656.90) } },
@@ -343,7 +343,7 @@ test_simde_vmaxnmq_f32 (SIMDE_MUNIT_TEST_ARGS) {
     simde_float32 b[4];
     simde_float32 r[4];
   } test_vec[] = {
-    #if !defined(SIMDE_FAST_NANS)
+    #if !defined(SIMDE_FAST_NANS) && !defined(SIMDE_ARCH_WASM_RELAXED_SIMD)
     { {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -830.15),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   116.42) },
       { SIMDE_FLOAT32_C(  -786.61),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   704.38) },
       { SIMDE_FLOAT32_C(  -786.61), SIMDE_FLOAT32_C(  -830.15),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   704.38) } },

--- a/test/wasm/simd128/pmax.c
+++ b/test/wasm/simd128/pmax.c
@@ -33,7 +33,7 @@ test_simde_wasm_f32x4_pmax(SIMDE_MUNIT_TEST_ARGS) {
       simde_float32 b[sizeof(simde_v128_t) / sizeof(simde_float32)];
       simde_float32 r[sizeof(simde_v128_t) / sizeof(simde_float32)];
     } test_vec[] = {
-      #if !defined(SIMDE_FAST_MATH)
+      #if !defined(SIMDE_FAST_MATH) && !defined(SIMDE_ARCH_WASM_RELAXED_SIMD)
       { {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -885.39),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   707.75) },
         { SIMDE_FLOAT32_C(   501.91),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   707.75) },
         {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -885.39),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   707.75) } },
@@ -96,7 +96,7 @@ test_simde_wasm_f64x2_pmax(SIMDE_MUNIT_TEST_ARGS) {
       simde_float64 b[sizeof(simde_v128_t) / sizeof(simde_float64)];
       simde_float64 r[sizeof(simde_v128_t) / sizeof(simde_float64)];
     } test_vec[] = {
-      #if !defined(SIMDE_FAST_MATH)
+      #if !defined(SIMDE_FAST_MATH) && !defined(SIMDE_ARCH_WASM_RELAXED_SIMD)
       { {             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(   532.24) },
         { SIMDE_FLOAT64_C(  -760.30),             SIMDE_MATH_NAN },
         {             SIMDE_MATH_NAN, SIMDE_FLOAT64_C(   532.24) } },

--- a/test/x86/sse.c
+++ b/test/x86/sse.c
@@ -3530,7 +3530,7 @@ test_simde_mm_max_ps (SIMDE_MUNIT_TEST_ARGS) {
     const simde_float32 b[4];
     const simde_float32 r[4];
   } test_vec[] = {
-    #if !defined(SIMDE_FAST_NANS)
+    #if !defined(SIMDE_FAST_NANS) && !defined(SIMDE_ARCH_WASM_RELAXED_SIMD)
     { {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   353.79),            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   -20.53) },
       { SIMDE_FLOAT32_C(  -559.69),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   542.61) },
       { SIMDE_FLOAT32_C(  -559.69),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(   542.61) } },
@@ -3788,7 +3788,7 @@ test_simde_mm_min_ps (SIMDE_MUNIT_TEST_ARGS) {
     const simde_float32 b[4];
     const simde_float32 r[4];
   } test_vec[] = {
-    #if !defined(SIMDE_FAST_NANS)
+    #if !defined(SIMDE_FAST_NANS) && !defined(SIMDE_ARCH_WASM_RELAXED_SIMD)
       { {            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(    52.40),            SIMDE_MATH_NANF,       SIMDE_MATH_INFINITYF },
         { SIMDE_FLOAT32_C(    17.29),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -535.67) },
         { SIMDE_FLOAT32_C(    17.29),            SIMDE_MATH_NANF,            SIMDE_MATH_NANF, SIMDE_FLOAT32_C(  -535.67) } },


### PR DESCRIPTION
recent emscripten/clang will use relaxed-simd ops automatically

https://github.com/llvm/llvm-project/pull/162948
