### PR TITLE
Fix compilation error for test project

### DIFF
--- a/test/arm/neon/qshl_n.c
+++ b/test/arm/neon/qshl_n.c
@@ -1,4 +1,4 @@
-#define SIMDE_TEST_ARM_NEON_INSN qshl
+#define SIMDE_TEST_ARM_NEON_INSN qshl_n
 
 #include "test-neon.h"
 #include "../../../simde/arm/neon/qshl_n.h"

--- a/test/wasm/simd128/const.c
+++ b/test/wasm/simd128/const.c
@@ -21,7 +21,7 @@
  * SOFTWARE.
  */
 
-#define SIMDE_TEST_WASM_SIMD128_INSN make_const
+#define SIMDE_TEST_WASM_SIMD128_INSN const
 #include "../../../simde/wasm/simd128.h"
 #include "test-simd128.h"
 

--- a/test/x86/avx512/kand.c
+++ b/test/x86/avx512/kand.c
@@ -24,7 +24,7 @@
  *   2023      Michael R. Crusoe <crusoe@debian.org>
  */
 
-#define SIMDE_TEST_X86_AVX512_INSN knand
+#define SIMDE_TEST_X86_AVX512_INSN kand
 
 #include <test/x86/avx512/test-avx512.h>
 #include <simde/x86/avx512/kand.h>


### PR DESCRIPTION
I am having issues compiling the test project, following the [instructions from the wiki](https://github.com/simd-everywhere/simde/wiki/Development-Environment#x86--x86_64). I am testing under Debian Trixie on x86_64.

I had to make this patch for the compilation to succeed.

```
$ cmake .. -DCMAKE_{C,CXX}_FLAGS='-mavx512bw'
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.


-- The C compiler identification is GNU 14.2.0
-- The CXX compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for clock_gettime
-- Looking for clock_gettime - found
-- Looking for fegetround
-- Looking for fegetround - not found
-- Looking for fegetround
-- Looking for fegetround - found
-- Performing Test CFLAG_fopenmp_simd
-- Performing Test CFLAG_fopenmp_simd - Success
-- Performing Test CFLAG_Wpsabi
-- Performing Test CFLAG_Wpsabi - Success
-- Performing Test CFLAG_w
-- Performing Test CFLAG_w - Success
-- Performing Test CXXFLAG_Wpsabi
-- Performing Test CXXFLAG_Wpsabi - Success
CMake Warning at CMakeLists.txt:201 (message):
  CMake support is deprecated; please use Meson instead.  CMake is only
  present for compilers which Meson doesn't yet support (e.g., xlc) and
  platforms where difficult to run an up-to-date copy of Meson (e.g., Ubuntu
  12.04).


-- Configuring done (4.8s)
-- Generating done (0.2s)
-- Build files have been written to: simde/test/build

~/src/simde_tests/simde/test/build (master)
$ make -j8
[  0%] Building C object CMakeFiles/munit.dir/munit/munit.c.o
[  0%] Building C object CMakeFiles/simde-test-emul.dir/x86/fma.c.o
[  0%] Building C object CMakeFiles/simde-test-emul.dir/x86/avx.c.o
[  0%] Building C object CMakeFiles/simde-test-emul.dir/x86/clmul.c.o
[  0%] Building C object CMakeFiles/simde-test-emul.dir/x86/aes.c.o
[  0%] Building C object CMakeFiles/simde-test-emul.dir/x86/avx2.c.o
[  0%] Building C object CMakeFiles/simde-test-emul.dir/x86/f16c.c.o
[  0%] Building C object CMakeFiles/simde-test-native.dir/x86/aes.c.o
[  0%] Linking C static library libmunit.a
[  0%] Built target munit
[  0%] Building C object CMakeFiles/simde-test-native.dir/x86/avx.c.o
[  0%] Building C object CMakeFiles/simde-test-native.dir/x86/avx2.c.o
[  1%] Building C object CMakeFiles/simde-test-emul.dir/x86/gfni.c.o
[  1%] Building C object CMakeFiles/simde-test-emul.dir/x86/mmx.c.o

<...>

[ 99%] Building CXX object CMakeFiles/simde-test-native.dir/mips/msa/subv.cpp.o
[100%] Linking CXX static library libsimde-test-native.a
[100%] Built target simde-test-native
[100%] Building C object CMakeFiles/run-tests.dir/run-tests.c.o
[100%] Building C object CMakeFiles/run-tests.dir/arm/neon/run-tests.c.o
[100%] Building C object CMakeFiles/run-tests.dir/x86/avx512/run-tests.c.o
[100%] Building C object CMakeFiles/run-tests.dir/arm/run-tests.c.o
[100%] Building C object CMakeFiles/run-tests.dir/arm/sve/run-tests.c.o
[100%] Building C object CMakeFiles/run-tests.dir/wasm/simd128/run-tests.c.o
[100%] Building C object CMakeFiles/run-tests.dir/wasm/run-tests.c.o
[100%] Building C object CMakeFiles/run-tests.dir/x86/run-tests.c.o
[100%] Building C object CMakeFiles/run-tests.dir/wasm/relaxed-simd/run-tests.c.o
[100%] Building C object CMakeFiles/run-tests.dir/mips/run-tests.c.o
[100%] Building C object CMakeFiles/run-tests.dir/mips/msa/run-tests.c.o
[100%] Linking CXX executable run-tests
/usr/bin/ld: CMakeFiles/run-tests.dir/x86/avx512/run-tests.c.o: in function `simde_tests_x86_avx512_get_suite':
simde/test/build/test/x86/avx512/declare-suites.h:49:(.text+0x147b6): undefined reference to `simde_test_x86_avx512_get_suite_kand_native_c'
/usr/bin/ld: simde/test/build/test/x86/avx512/declare-suites.h:49:(.text+0x147e2): undefined reference to `simde_test_x86_avx512_get_suite_kand_native_cpp'
/usr/bin/ld: simde/test/build/test/x86/avx512/declare-suites.h:49:(.text+0x1480e): undefined reference to `simde_test_x86_avx512_get_suite_kand_emul_c'
/usr/bin/ld: simde/test/build/test/x86/avx512/declare-suites.h:49:(.text+0x1483a): undefined reference to `simde_test_x86_avx512_get_suite_kand_emul_cpp'
/usr/bin/ld: CMakeFiles/run-tests.dir/arm/neon/run-tests.c.o: in function `simde_tests_arm_neon_get_suite':
simde/test/build/test/arm/neon/declare-suites.h:190:(.text+0x3354e): undefined reference to `simde_test_arm_neon_get_suite_qshl_n_native_c'
/usr/bin/ld: simde/test/build/test/arm/neon/declare-suites.h:190:(.text+0x3357a): undefined reference to `simde_test_arm_neon_get_suite_qshl_n_native_cpp'
/usr/bin/ld: simde/test/build/test/arm/neon/declare-suites.h:190:(.text+0x335a6): undefined reference to `simde_test_arm_neon_get_suite_qshl_n_emul_c'
/usr/bin/ld: simde/test/build/test/arm/neon/declare-suites.h:190:(.text+0x335d2): undefined reference to `simde_test_arm_neon_get_suite_qshl_n_emul_cpp'
/usr/bin/ld: CMakeFiles/run-tests.dir/wasm/simd128/run-tests.c.o: in function `simde_tests_wasm_simd128_get_suite':
simde/test/build/test/wasm/simd128/declare-suites.h:12:(.text+0xa59b): undefined reference to `simde_test_wasm_simd128_get_suite_const_native_c'
/usr/bin/ld: simde/test/build/test/wasm/simd128/declare-suites.h:12:(.text+0xa5c7): undefined reference to `simde_test_wasm_simd128_get_suite_const_native_cpp'
/usr/bin/ld: simde/test/build/test/wasm/simd128/declare-suites.h:12:(.text+0xa5f3): undefined reference to `simde_test_wasm_simd128_get_suite_const_emul_c'
/usr/bin/ld: simde/test/build/test/wasm/simd128/declare-suites.h:12:(.text+0xa61f): undefined reference to `simde_test_wasm_simd128_get_suite_const_emul_cpp'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/run-tests.dir/build.make:264: run-tests] Error 1
make[1]: *** [CMakeFiles/Makefile2:130: CMakeFiles/run-tests.dir/all] Error 2
make: *** [Makefile:101: all] Error 2
```