### PR TITLE
Fixes for LoongArch LSX + fast math

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -11,8 +11,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Check workflow files
-        run: |
-          echo "::add-matcher::.github/actionlint-matcher.json"
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          ./actionlint -color
-        shell: bash
+        uses: kjanat/actionlint@1ab487e641ac26ed42a8a753158033d55eaae2e4 # v1.14.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -666,6 +666,18 @@ jobs:
           arch_deb: loong64
           arch_gnu: loongarch64
           distro: ubuntu-24.04
+        - version: 21
+          cross: loongarch64
+          extra: -fastmath
+          arch_deb: loong64
+          arch_gnu: loongarch64
+          distro: ubuntu-24.04
+        - version: 22
+          cross: loongarch64
+          extra: -fastmath
+          arch_deb: loong64
+          arch_gnu: loongarch64
+          distro: ubuntu-24.04
     runs-on: ${{ matrix.distro }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,13 +462,13 @@ jobs:
           cross: loongarch64
           arch_gnu: loongarch64
           arch_deb: loong64
-          distro: ubuntu-24.04
+          distro: ubuntu-26.04
         - extra: -fastmath
           version: 14
           cross: loongarch64
           arch_gnu: loongarch64
           arch_deb: loong64
-          distro: ubuntu-24.04
+          distro: ubuntu-26.04
         - version: 14
           cross: loongarch64-lsx-only
           arch_gnu: loongarch64
@@ -498,7 +498,8 @@ jobs:
         sudo apt-get -y --no-install-recommends install ccache ninja-build \
           gcc-${{ matrix.version }}-${{ matrix.arch_gnu }}-linux-gnu${{ matrix.arch_gnu_abi }} \
           g++-${{ matrix.version }}-${{ matrix.arch_gnu }}-linux-gnu${{ matrix.arch_gnu_abi }} binfmt-support \
-          qemu-user-static pipx libc6-${{ matrix.arch_deb }}-cross libstdc++-${{ matrix.version }}-dev-${{ matrix.arch_deb }}-cross
+          pipx libc6-${{ matrix.arch_deb }}-cross libstdc++-${{ matrix.version }}-dev-${{ matrix.arch_deb }}-cross
+        sudo apt-get -y --no-install-recommends satisfy 'qemu-user-static | qemu-user-binfmt'
         pipx install meson==1.3.2
     - name: ccache
       uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
@@ -665,19 +666,19 @@ jobs:
           cross: loongarch64
           arch_deb: loong64
           arch_gnu: loongarch64
-          distro: ubuntu-24.04
+          distro: ubuntu-26.04
         - version: 21
           cross: loongarch64
           extra: -fastmath
           arch_deb: loong64
           arch_gnu: loongarch64
-          distro: ubuntu-24.04
+          distro: ubuntu-26.04
         - version: 22
           cross: loongarch64
           extra: -fastmath
           arch_deb: loong64
           arch_gnu: loongarch64
-          distro: ubuntu-24.04
+          distro: ubuntu-26.04
     runs-on: ${{ matrix.distro }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -694,8 +695,9 @@ jobs:
         sudo ./llvm.sh ${{ matrix.version }}
         sudo apt-get -y --no-install-recommends install ccache ninja-build \
           binfmt-support clang-${{ matrix.version }} llvm-${{ matrix.version }} lld-${{ matrix.version }} \
-          qemu-user-static pipx libc6-${{ matrix.arch_deb }}-cross libstdc++-14-dev-${{ matrix.arch_deb }}-cross \
+          pipx libc6-${{ matrix.arch_deb }}-cross libstdc++-14-dev-${{ matrix.arch_deb }}-cross \
           binutils-${{ matrix.arch_gnu }}-linux-gnu${{ matrix.arch_gnu_abi }}
+        sudo apt-get -y --no-install-recommends satisfy 'qemu-user-static | qemu-user-binfmt'
         pipx install meson
     - name: ccache
       uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,6 +463,12 @@ jobs:
           arch_gnu: loongarch64
           arch_deb: loong64
           distro: ubuntu-24.04
+        - extra: -fastmath
+          version: 14
+          cross: loongarch64
+          arch_gnu: loongarch64
+          arch_deb: loong64
+          distro: ubuntu-24.04
         - version: 14
           cross: loongarch64-lsx-only
           arch_gnu: loongarch64

--- a/docker/cross-files/loongarch64-clang-18-ccache.cross
+++ b/docker/cross-files/loongarch64-clang-18-ccache.cross
@@ -5,7 +5,7 @@ ar = 'llvm-ar-18'
 strip = 'llvm-strip-18'
 objcopy = 'llvm-objcopy-18'
 ld = 'llvm-ld-18'
-exe_wrapper = ['qemu-loongarch64-static', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
+exe_wrapper = ['qemu-loongarch64', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
 
 [built-in options]
 c_args = ['--target=loongarch64-linux-gnu', '-march=la464', '-isystem=/usr/loongarch64-linux-gnu/include', '-Wextra', '-Werror', '-mlsx', '-mlasx']

--- a/docker/cross-files/loongarch64-clang-19-ccache.cross
+++ b/docker/cross-files/loongarch64-clang-19-ccache.cross
@@ -6,7 +6,7 @@ strip = 'llvm-strip-19'
 objcopy = 'llvm-objcopy-19'
 c_ld = 'lld'
 cpp_ld = 'lld'
-exe_wrapper = ['qemu-loongarch64-static', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
+exe_wrapper = ['qemu-loongarch64', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
 
 [built-in options]
 c_args = ['--target=loongarch64-linux-gnu', '-march=la464', '-isystem=/usr/loongarch64-linux-gnu/include', '-Wextra', '-Werror', '-mlsx', '-mlasx']

--- a/docker/cross-files/loongarch64-clang-20-ccache.cross
+++ b/docker/cross-files/loongarch64-clang-20-ccache.cross
@@ -6,7 +6,7 @@ strip = 'llvm-strip-20'
 objcopy = 'llvm-objcopy-20'
 c_ld = 'lld'
 cpp_ld = 'lld'
-exe_wrapper = ['qemu-loongarch64-static', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
+exe_wrapper = ['qemu-loongarch64', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
 
 [built-in options]
 c_args = ['--target=loongarch64-linux-gnu', '-march=la464', '-isystem=/usr/loongarch64-linux-gnu/include', '-Wextra', '-Werror', '-mlsx', '-mlasx']

--- a/docker/cross-files/loongarch64-clang-20-fastmath-ccache.cross
+++ b/docker/cross-files/loongarch64-clang-20-fastmath-ccache.cross
@@ -1,0 +1,21 @@
+[binaries]
+c = ['ccache', 'clang-20']
+cpp = ['ccache', 'clang++-20']
+ar = 'llvm-ar-20'
+strip = 'llvm-strip-20'
+objcopy = 'llvm-objcopy-20'
+c_ld = 'lld'
+cpp_ld = 'lld'
+exe_wrapper = ['qemu-loongarch64-static', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
+
+[properties]
+c_args = ['--target=loongarch64-linux-gnu', '-march=la464', '-isystem=/usr/loongarch64-linux-gnu/include', '-Wextra', '-Werror', '-mlsx', '-mlasx', '-O3', '-ffast-math', '-Wno-nan-infinity-disabled']
+cpp_args = ['--target=loongarch64-linux-gnu', '-march=la464', '-isystem=/usr/loongarch64-linux-gnu/include', '-Wextra', '-Werror', '-mlsx', '-mlasx', '-O3', '-ffast-math', '-Wno-nan-infinity-disabled']
+c_link_args = ['--target=loongarch64-linux-gnu']
+cpp_link_args = ['--target=loongarch64-linux-gnu']
+
+[host_machine]
+system = 'linux'
+cpu_family = 'loongarch64'
+cpu = 'la464'
+endian = 'little'

--- a/docker/cross-files/loongarch64-clang-20-fastmath-ccache.cross
+++ b/docker/cross-files/loongarch64-clang-20-fastmath-ccache.cross
@@ -6,7 +6,7 @@ strip = 'llvm-strip-20'
 objcopy = 'llvm-objcopy-20'
 c_ld = 'lld'
 cpp_ld = 'lld'
-exe_wrapper = ['qemu-loongarch64-static', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
+exe_wrapper = ['qemu-loongarch64', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
 
 [properties]
 c_args = ['--target=loongarch64-linux-gnu', '-march=la464', '-isystem=/usr/loongarch64-linux-gnu/include', '-Wextra', '-Werror', '-mlsx', '-mlasx', '-O3', '-ffast-math', '-Wno-nan-infinity-disabled']

--- a/docker/cross-files/loongarch64-clang-21-ccache.cross
+++ b/docker/cross-files/loongarch64-clang-21-ccache.cross
@@ -6,7 +6,7 @@ strip = 'llvm-strip-21'
 objcopy = 'llvm-objcopy-21'
 c_ld = 'lld'
 cpp_ld = 'lld'
-exe_wrapper = ['qemu-loongarch64-static', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
+exe_wrapper = ['qemu-loongarch64', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
 
 [built-in options]
 c_args = ['--target=loongarch64-linux-gnu', '-march=la464', '-isystem=/usr/loongarch64-linux-gnu/include', '-Wextra', '-Werror', '-mlsx', '-mlasx']

--- a/docker/cross-files/loongarch64-clang-21-fastmath-ccache.cross
+++ b/docker/cross-files/loongarch64-clang-21-fastmath-ccache.cross
@@ -1,0 +1,21 @@
+[binaries]
+c = ['ccache', 'clang-21']
+cpp = ['ccache', 'clang++-21']
+ar = 'llvm-ar-21'
+strip = 'llvm-strip-21'
+objcopy = 'llvm-objcopy-21'
+c_ld = 'lld'
+cpp_ld = 'lld'
+exe_wrapper = ['qemu-loongarch64-static', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
+
+[properties]
+c_args = ['--target=loongarch64-linux-gnu', '-march=la464', '-isystem=/usr/loongarch64-linux-gnu/include', '-Wextra', '-Werror', '-mlsx', '-mlasx', '-O3', '-ffast-math', '-Wno-nan-infinity-disabled']
+cpp_args = ['--target=loongarch64-linux-gnu', '-march=la464', '-isystem=/usr/loongarch64-linux-gnu/include', '-Wextra', '-Werror', '-mlsx', '-mlasx', '-O3', '-ffast-math', '-Wno-nan-infinity-disabled']
+c_link_args = ['--target=loongarch64-linux-gnu']
+cpp_link_args = ['--target=loongarch64-linux-gnu']
+
+[host_machine]
+system = 'linux'
+cpu_family = 'loongarch64'
+cpu = 'la464'
+endian = 'little'

--- a/docker/cross-files/loongarch64-clang-21-fastmath-ccache.cross
+++ b/docker/cross-files/loongarch64-clang-21-fastmath-ccache.cross
@@ -6,7 +6,7 @@ strip = 'llvm-strip-21'
 objcopy = 'llvm-objcopy-21'
 c_ld = 'lld'
 cpp_ld = 'lld'
-exe_wrapper = ['qemu-loongarch64-static', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
+exe_wrapper = ['qemu-loongarch64', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
 
 [properties]
 c_args = ['--target=loongarch64-linux-gnu', '-march=la464', '-isystem=/usr/loongarch64-linux-gnu/include', '-Wextra', '-Werror', '-mlsx', '-mlasx', '-O3', '-ffast-math', '-Wno-nan-infinity-disabled']

--- a/docker/cross-files/loongarch64-clang-22-ccache.cross
+++ b/docker/cross-files/loongarch64-clang-22-ccache.cross
@@ -6,7 +6,7 @@ strip = 'llvm-strip-22'
 objcopy = 'llvm-objcopy-22'
 c_ld = 'lld'
 cpp_ld = 'lld'
-exe_wrapper = ['qemu-loongarch64-static', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
+exe_wrapper = ['qemu-loongarch64', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
 
 [built-in options]
 c_args = ['--target=loongarch64-linux-gnu', '-march=la464', '-isystem=/usr/loongarch64-linux-gnu/include', '-Wextra', '-Werror', '-mlsx', '-mlasx']

--- a/docker/cross-files/loongarch64-clang-22-fastmath-ccache.cross
+++ b/docker/cross-files/loongarch64-clang-22-fastmath-ccache.cross
@@ -1,0 +1,21 @@
+[binaries]
+c = ['ccache', 'clang-22']
+cpp = ['ccache', 'clang++-22']
+ar = 'llvm-ar-22'
+strip = 'llvm-strip-22'
+objcopy = 'llvm-objcopy-22'
+c_ld = 'lld'
+cpp_ld = 'lld'
+exe_wrapper = ['qemu-loongarch64-static', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
+
+[properties]
+c_args = ['--target=loongarch64-linux-gnu', '-march=la464', '-isystem=/usr/loongarch64-linux-gnu/include', '-Wextra', '-Werror', '-mlsx', '-mlasx', '-O3', '-ffast-math', '-Wno-nan-infinity-disabled']
+cpp_args = ['--target=loongarch64-linux-gnu', '-march=la464', '-isystem=/usr/loongarch64-linux-gnu/include', '-Wextra', '-Werror', '-mlsx', '-mlasx', '-O3', '-ffast-math', '-Wno-nan-infinity-disabled']
+c_link_args = ['--target=loongarch64-linux-gnu']
+cpp_link_args = ['--target=loongarch64-linux-gnu']
+
+[host_machine]
+system = 'linux'
+cpu_family = 'loongarch64'
+cpu = 'la464'
+endian = 'little'

--- a/docker/cross-files/loongarch64-clang-22-fastmath-ccache.cross
+++ b/docker/cross-files/loongarch64-clang-22-fastmath-ccache.cross
@@ -6,7 +6,7 @@ strip = 'llvm-strip-22'
 objcopy = 'llvm-objcopy-22'
 c_ld = 'lld'
 cpp_ld = 'lld'
-exe_wrapper = ['qemu-loongarch64-static', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
+exe_wrapper = ['qemu-loongarch64', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
 
 [properties]
 c_args = ['--target=loongarch64-linux-gnu', '-march=la464', '-isystem=/usr/loongarch64-linux-gnu/include', '-Wextra', '-Werror', '-mlsx', '-mlasx', '-O3', '-ffast-math', '-Wno-nan-infinity-disabled']

--- a/docker/cross-files/loongarch64-clang-23-ccache.cross
+++ b/docker/cross-files/loongarch64-clang-23-ccache.cross
@@ -6,7 +6,7 @@ strip = 'llvm-strip-23'
 objcopy = 'llvm-objcopy-23'
 c_ld = 'lld'
 cpp_ld = 'lld'
-exe_wrapper = ['qemu-loongarch64-static', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
+exe_wrapper = ['qemu-loongarch64', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
 
 [built-in options]
 c_args = ['--target=loongarch64-linux-gnu', '-march=la464', '-isystem=/usr/loongarch64-linux-gnu/include', '-Wextra', '-Werror', '-mlsx', '-mlasx']

--- a/docker/cross-files/loongarch64-gcc-13-ccache.cross
+++ b/docker/cross-files/loongarch64-gcc-13-ccache.cross
@@ -5,7 +5,7 @@ ar = 'loongarch64-unknown-linux-gnu-ar'
 strip = 'loongarch64-unknown-linux-gnu-strip'
 objcopy = 'loongarch64-unknown-linux-gnu-objcopy'
 ld = 'loongarch64-unknown-linux-gnu-ld'
-exe_wrapper = ['qemu-loongarch64-static', '-L', '/opt/cross-tools/target/usr']
+exe_wrapper = ['qemu-loongarch64', '-L', '/opt/cross-tools/target/usr']
 
 [built-in options]
 c_args = ['-march=loongarch64', '-Wextra', '-Werror']

--- a/docker/cross-files/loongarch64-gcc-13.cross
+++ b/docker/cross-files/loongarch64-gcc-13.cross
@@ -5,7 +5,7 @@ ar = 'loongarch64-unknown-linux-gnu-ar'
 strip = 'loongarch64-unknown-linux-gnu-strip'
 objcopy = 'loongarch64-unknown-linux-gnu-objcopy'
 ld = 'loongarch64-unknown-linux-gnu-ld'
-exe_wrapper = ['qemu-loongarch64-static', '-L', '/opt/cross-tools/target/usr']
+exe_wrapper = ['qemu-loongarch64', '-L', '/opt/cross-tools/target/usr']
 
 [built-in options]
 c_args = ['-march=loongarch64', '-Wextra', '-Werror']

--- a/docker/cross-files/loongarch64-gcc-14-ccache.cross
+++ b/docker/cross-files/loongarch64-gcc-14-ccache.cross
@@ -5,7 +5,7 @@ ar = 'loongarch64-linux-gnu-gcc-ar-14'
 strip = 'loongarch64-linux-gnu-strip'
 objcopy = 'loongarch64-linux-gnu-objcopy'
 ld = 'loongarch64-linux-gnu-ld'
-exe_wrapper = ['qemu-loongarch64-static', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
+exe_wrapper = ['qemu-loongarch64', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
 
 [built-in options]
 c_args = ['-march=loongarch64', '-Wextra', '-Werror', '-mlsx', '-mlasx']

--- a/docker/cross-files/loongarch64-gcc-14-fastmath-ccache.cross
+++ b/docker/cross-files/loongarch64-gcc-14-fastmath-ccache.cross
@@ -1,0 +1,20 @@
+[binaries]
+c = ['ccache', 'loongarch64-linux-gnu-gcc-14']
+cpp = ['ccache', 'loongarch64-linux-gnu-g++-14']
+ar = 'loongarch64-linux-gnu-gcc-ar-14'
+strip = 'loongarch64-linux-gnu-strip'
+objcopy = 'loongarch64-linux-gnu-objcopy'
+ld = 'loongarch64-linux-gnu-ld'
+exe_wrapper = ['qemu-loongarch64-static', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
+
+[properties]
+c_args = ['-march=loongarch64', '-Wextra', '-Werror', '-mlsx', '-mlasx', '-Ofast']
+cpp_args = ['-march=loongarch64', '-Wextra', '-Werror', '-mlsx', '-mlasx', '-Ofast']
+#c_args = ['-march=la464', '-Wextra', '-Werror']
+#cpp_args = ['-march=la464', '-Wextra', '-Werror']
+
+[host_machine]
+system = 'linux'
+cpu_family = 'loongarch64'
+cpu = 'loongarch64'
+endian = 'little'

--- a/docker/cross-files/loongarch64-gcc-14-fastmath-ccache.cross
+++ b/docker/cross-files/loongarch64-gcc-14-fastmath-ccache.cross
@@ -5,7 +5,7 @@ ar = 'loongarch64-linux-gnu-gcc-ar-14'
 strip = 'loongarch64-linux-gnu-strip'
 objcopy = 'loongarch64-linux-gnu-objcopy'
 ld = 'loongarch64-linux-gnu-ld'
-exe_wrapper = ['qemu-loongarch64-static', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
+exe_wrapper = ['qemu-loongarch64', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
 
 [properties]
 c_args = ['-march=loongarch64', '-Wextra', '-Werror', '-mlsx', '-mlasx', '-Ofast']

--- a/docker/cross-files/loongarch64-gcc-15-ccache.cross
+++ b/docker/cross-files/loongarch64-gcc-15-ccache.cross
@@ -5,7 +5,7 @@ ar = 'loongarch64-linux-gnu-gcc-ar-15'
 strip = 'loongarch64-linux-gnu-strip'
 objcopy = 'loongarch64-linux-gnu-objcopy'
 ld = 'loongarch64-linux-gnu-ld'
-exe_wrapper = ['qemu-loongarch64-static', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
+exe_wrapper = ['qemu-loongarch64', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
 
 [built-in options]
 c_args = ['-march=loongarch64', '-Wextra', '-Werror', '-mlsx', '-mlasx']

--- a/docker/cross-files/loongarch64-gcc-16-ccache.cross
+++ b/docker/cross-files/loongarch64-gcc-16-ccache.cross
@@ -5,7 +5,7 @@ ar = 'loongarch64-linux-gnu-gcc-ar-16'
 strip = 'loongarch64-linux-gnu-strip'
 objcopy = 'loongarch64-linux-gnu-objcopy'
 ld = 'loongarch64-linux-gnu-ld'
-exe_wrapper = ['qemu-loongarch64-static', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
+exe_wrapper = ['qemu-loongarch64', '-L', '/usr/loongarch64-linux-gnu/', '-cpu', 'la464']
 
 [built-in options]
 c_args = ['-march=loongarch64', '-Wextra', '-Werror', '-mlsx', '-mlasx']

--- a/test/test.h
+++ b/test/test.h
@@ -126,6 +126,10 @@ simde_test_debug_printf_(const char* format, ...) {
 HEDLEY_DIAGNOSTIC_PUSH
 SIMDE_DIAGNOSTIC_DISABLE_FLOAT_EQUAL_
 
+#if defined(SIMDE_FAST_MATH) && defined(HEDLEY_GCC_VERSION) && HEDLEY_GCC_VERSION_CHECK(4,4,0)
+__attribute__((optimize("-fno-finite-math-only")))
+__attribute__((noinline))
+#endif
 static int
 simde_test_equal_f32(simde_float32 a, simde_float32 b, simde_float32 slop) {
   if (simde_math_isnan(a)) {
@@ -156,6 +160,10 @@ simde_test_equal_f16(simde_float16 a, simde_float16 b, simde_float16 slop) {
   return simde_test_equal_f32(af, bf, slopf);
 }
 
+#if defined(SIMDE_FAST_MATH) && defined(HEDLEY_GCC_VERSION) && HEDLEY_GCC_VERSION_CHECK(4,4,0)
+__attribute__((optimize("-fno-finite-math-only")))
+__attribute__((noinline))
+#endif
 static int
 simde_test_equal_f64(simde_float64 a, simde_float64 b, simde_float64 slop) {
   if (simde_math_isnan(a)) {


### PR DESCRIPTION
Fix a couple of errors I found when testing current simde master on my loongarch64 machine with GCC 14.3.1 and `-Ofast -mlsx -mlasx` in `CFLAGS` and `CXXFLAGS`.