### PR TITLE
test: Avoid -ffinite-math-only on floating point comparisons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,12 +299,12 @@ jobs:
           distro: ubuntu-24.04
         - version: 10
           distro: ubuntu-24.04
-          arch_flags: -ffast-math
+          arch_flags: -Ofast
         - version: 11
           distro: ubuntu-24.04
         - version: 11
           distro: ubuntu-24.04
-          arch_flags: -ffast-math
+          arch_flags: -Ofast
         - version: 11
           distro:  ubuntu-24.04-arm
         - version: 11
@@ -314,28 +314,28 @@ jobs:
           distro: ubuntu-24.04
         - version: 12
           distro: ubuntu-24.04
-          arch_flags: -ffast-math
+          arch_flags: -Ofast
         - version: 12
           distro: ubuntu-24.04-arm
         - version: 13
           distro: ubuntu-24.04
         - version: 13
           distro: ubuntu-24.04
-          arch_flags: -ffast-math
+          arch_flags: -Ofast
         - version: 13
           distro: ubuntu-24.04-arm
         - version: 14
           distro: ubuntu-24.04
         - version: 14
           distro: ubuntu-24.04
-          arch_flags: -ffast-math
+          arch_flags: -Ofast
         - version: 14
           distro: ubuntu-24.04-arm
         - version: 15
           distro: ubuntu-24.04
         - version: 15
           distro: ubuntu-24.04
-          arch_flags: -ffast-math
+          arch_flags: -Ofast
         - version: 15
           distro: ubuntu-24.04-arm
         - version: 15
@@ -720,7 +720,7 @@ jobs:
           # grep Features < /proc/cpuinfo | head -n 1 | awk '-F: ' '{print $2}' | sed 's/asimd //;s/evtstrm //;s/pmull //;s/sha1 //;s/crc32 //;s/atomics //;s/fphp //;s/asimd.. //g;s/cpuid //;s/asimd... //g;s/jscvt //;s/fcma //;s/lrcpc //;s/dcpop //;s/sm3 //;s/sha512 //;s/uscat //;s/ilrcpc //;s/pac. //g;s/dcpodp //;s/sveaes //;s/svebitperm //;s/svesha3 //;s/svesm4 //;s/flagm2 //;s/frint //;s/svei8mm //;s/svebf16 //' | tr ' ' '+'
         - version: "14"
           distro: ubuntu-24.04-arm
-          arch_flags: -ffast-math -march=armv8-a+fp+aes+sha2
+          arch_flags: -Ofast -march=armv8-a+fp+aes+sha2
           plain: true
         - version: "15"
           distro: ubuntu-24.04
@@ -758,7 +758,7 @@ jobs:
           arch_flags: -Wno-unsafe-buffer-usage
         - version: "17"
           distro: ubuntu-24.04-arm
-          arch_flags: -ffast-math -Wno-unsafe-buffer-usage
+          arch_flags: -Ofast -Wno-unsafe-buffer-usage
         - version: "17"
           distro: ubuntu-24.04-arm
           arch_flags: -Wno-unsafe-buffer-usage -O2
@@ -776,7 +776,7 @@ jobs:
           arch_flags: -Wno-unsafe-buffer-usage -Wno-switch-default
         - version: "18"
           distro: ubuntu-24.04-arm
-          arch_flags: -ffast-math -Wno-unsafe-buffer-usage -Wno-switch-default -Wno-nan-infinity-disabled
+          arch_flags: -Ofast -Wno-unsafe-buffer-usage -Wno-switch-default -Wno-nan-infinity-disabled
         - version: "18"
           distro: ubuntu-24.04-arm
           arch_flags: -Wno-unsafe-buffer-usage -Wno-switch-default -O2

--- a/test/test.h
+++ b/test/test.h
@@ -126,6 +126,10 @@ simde_test_debug_printf_(const char* format, ...) {
 HEDLEY_DIAGNOSTIC_PUSH
 SIMDE_DIAGNOSTIC_DISABLE_FLOAT_EQUAL_
 
+#if defined(SIMDE_FAST_MATH) && defined(HEDLEY_GCC_VERSION) && HEDLEY_GCC_VERSION_CHECK(4,4,0)
+__attribute__((optimize("-fno-finite-math-only")))
+__attribute__((noinline))
+#endif
 static int
 simde_test_equal_f32(simde_float32 a, simde_float32 b, simde_float32 slop) {
   if (simde_math_isnan(a)) {
@@ -156,6 +160,10 @@ simde_test_equal_f16(simde_float16 a, simde_float16 b, simde_float16 slop) {
   return simde_test_equal_f32(af, bf, slopf);
 }
 
+#if defined(SIMDE_FAST_MATH) && defined(HEDLEY_GCC_VERSION) && HEDLEY_GCC_VERSION_CHECK(4,4,0)
+__attribute__((optimize("-fno-finite-math-only")))
+__attribute__((noinline))
+#endif
 static int
 simde_test_equal_f64(simde_float64 a, simde_float64 b, simde_float64 slop) {
   if (simde_math_isnan(a)) {


### PR DESCRIPTION
With `-ffinite-math-only` (implied by `-ffast-math` and -Ofast), GCC considers all comparisons against infinities to be false and can optimize them away. This breaks several tests that rely on infinities to be compared correctly. To avoid this, we add GCC-specific optimize attribute that disables `-ffinite-math-only` optimization for floating point comarisions used in assertions.