### PR TITLE
Fix POWER7 build: correct AltiVec version guards for POWER8-only intrinsics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,6 +440,11 @@ jobs:
           arch_deb: ppc64el
           distro: ubuntu-24.04
         - version: 14
+          cross: power7
+          arch_gnu: powerpc64le
+          arch_deb: ppc64el
+          distro: ubuntu-24.04
+        - version: 14
           cross: loongarch64
           arch_gnu: loongarch64
           arch_deb: loong64

--- a/docker/cross-files/power7-gcc-14-ccache.cross
+++ b/docker/cross-files/power7-gcc-14-ccache.cross
@@ -1,0 +1,22 @@
+[binaries]
+c = ['ccache', 'powerpc64le-linux-gnu-gcc-14']
+cpp = ['ccache', 'powerpc64le-linux-gnu-g++-14']
+ar = 'powerpc64le-linux-gnu-ar'
+strip = 'powerpc64le-linux-gnu-strip'
+objcopy = 'powerpc64le-linux-gnu-objcopy'
+ld = 'powerpc64le-linux-gnu-ld'
+# Build targets power7, but execute under a power9 QEMU CPU: Ubuntu's
+# ppc64el userspace (glibc) has a POWER8 baseline, so emulating a real
+# power7 would SIGILL inside libc. Code compiled with -mcpu=power7 uses
+# only a subset ISA and runs fine on the newer CPU model.
+exe_wrapper = ['qemu-ppc64le-static', '-cpu', 'power9', '-L', '/usr/powerpc64le-linux-gnu/']
+
+[built-in options]
+c_args = ['-mcpu=power7', '-Wextra', '-Werror']
+cpp_args = ['-mcpu=power7', '-Wextra', '-Werror']
+
+[host_machine]
+system = 'linux'
+cpu_family = 'ppc64'
+cpu = 'ppc64el'
+endian = 'little'

--- a/simde/arm/neon/paddl.h
+++ b/simde/arm/neon/paddl.h
@@ -213,7 +213,7 @@ simde_int64x2_t
 simde_vpaddlq_s32(simde_int32x4_t a) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vpaddlq_s32(a);
-  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
     SIMDE_POWER_ALTIVEC_VECTOR(int) one = vec_splat_s32(1);
     return
       vec_add(
@@ -312,7 +312,7 @@ simde_uint64x2_t
 simde_vpaddlq_u32(simde_uint32x4_t a) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vpaddlq_u32(a);
-  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
     SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) one = vec_splat_u32(1);
     return
       vec_add(

--- a/simde/wasm/simd128.h
+++ b/simde/wasm/simd128.h
@@ -4082,7 +4082,7 @@ simde_wasm_i64x2_all_true (simde_v128_t a) {
       return _mm_test_all_zeros(_mm_cmpeq_epi64(a_.sse_m128i, _mm_setzero_si128()), _mm_set1_epi32(~INT32_C(0)));
     #elif defined(SIMDE_X86_SSE2_NATIVE)
       return _mm_movemask_pd(_mm_cmpeq_pd(a_.sse_m128d, _mm_setzero_pd())) == 0;
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
       return HEDLEY_STATIC_CAST(simde_bool, vec_all_ne(a_.altivec_i64, HEDLEY_REINTERPRET_CAST(__typeof__(a_.altivec_i64), vec_splats(0))));
     #else
       int64_t r = !INT32_C(0);
@@ -6822,7 +6822,7 @@ simde_wasm_i64x2_extend_low_i32x4 (simde_v128_t a) {
       r_.sse_m128i = _mm_cvtepi32_epi64(a_.sse_m128i);
     #elif defined(SIMDE_X86_SSE2_NATIVE)
       r_.sse_m128i = _mm_unpacklo_epi32(a_.sse_m128i, _mm_cmpgt_epi32(_mm_setzero_si128(), a_.sse_m128i));
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
       r_.altivec_i64 =
         vec_sra(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(long long), vec_mergeh(a_.altivec_i32, a_.altivec_i32)),
         vec_splats(HEDLEY_STATIC_CAST(unsigned long long, 32))
@@ -7096,7 +7096,7 @@ simde_wasm_i64x2_extend_high_i32x4 (simde_v128_t a) {
       r_.sse_m128i = _mm_cvtepi32_epi64(_mm_shuffle_epi32(a_.sse_m128i, _MM_SHUFFLE(3, 2, 3, 2)));
     #elif defined(SIMDE_X86_SSE2_NATIVE)
       r_.sse_m128i = _mm_unpackhi_epi32(a_.sse_m128i, _mm_cmpgt_epi32(_mm_setzero_si128(), a_.sse_m128i));
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
       r_.altivec_i64 =
         vec_sra(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(long long), vec_mergel(a_.altivec_i32, a_.altivec_i32)),
         vec_splats(HEDLEY_STATIC_CAST(unsigned long long, 32))
@@ -7377,21 +7377,12 @@ simde_wasm_i64x2_extmul_low_i32x4 (simde_v128_t a, simde_v128_t b) {
 
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_i64 = vmull_s32(vget_low_s32(a_.neon_i32), vget_low_s32(b_.neon_i32));
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
       SIMDE_POWER_ALTIVEC_VECTOR(signed int) ashuf;
       SIMDE_POWER_ALTIVEC_VECTOR(signed int) bshuf;
 
-      #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-        ashuf = vec_mergeh(a_.altivec_i32, a_.altivec_i32);
-        bshuf = vec_mergeh(b_.altivec_i32, b_.altivec_i32);
-      #else
-        SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) perm = {
-          0, 1, 2, 3, 0, 1, 2, 3,
-          4, 5, 6, 7, 4, 5, 6, 7
-        };
-        ashuf = vec_perm(a_.altivec_i32, a_.altivec_i32, perm);
-        bshuf = vec_perm(b_.altivec_i32, b_.altivec_i32, perm);
-      #endif
+      ashuf = vec_mergeh(a_.altivec_i32, a_.altivec_i32);
+      bshuf = vec_mergeh(b_.altivec_i32, b_.altivec_i32);
 
       r_.altivec_i64 = vec_mule(ashuf, bshuf);
     #elif defined(SIMDE_X86_SSE4_1_NATIVE)
@@ -7555,21 +7546,12 @@ simde_wasm_u64x2_extmul_low_u32x4 (simde_v128_t a, simde_v128_t b) {
 
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_u64 = vmull_u32(vget_low_u32(a_.neon_u32), vget_low_u32(b_.neon_u32));
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
       SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) ashuf;
       SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) bshuf;
 
-      #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-        ashuf = vec_mergeh(a_.altivec_u32, a_.altivec_u32);
-        bshuf = vec_mergeh(b_.altivec_u32, b_.altivec_u32);
-      #else
-        SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) perm = {
-          0, 1, 2, 3, 0, 1, 2, 3,
-          4, 5, 6, 7, 4, 5, 6, 7
-        };
-        ashuf = vec_perm(a_.altivec_u32, a_.altivec_u32, perm);
-        bshuf = vec_perm(b_.altivec_u32, b_.altivec_u32, perm);
-      #endif
+      ashuf = vec_mergeh(a_.altivec_u32, a_.altivec_u32);
+      bshuf = vec_mergeh(b_.altivec_u32, b_.altivec_u32);
 
       r_.altivec_u64 = vec_mule(ashuf, bshuf);
     #elif defined(SIMDE_X86_SSE2_NATIVE)
@@ -7724,21 +7706,12 @@ simde_wasm_i64x2_extmul_high_i32x4 (simde_v128_t a, simde_v128_t b) {
       r_.neon_i64 = vmull_high_s32(a_.neon_i32, b_.neon_i32);
     #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_i64 = vmull_s32(vget_high_s32(a_.neon_i32), vget_high_s32(b_.neon_i32));
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
       SIMDE_POWER_ALTIVEC_VECTOR(signed int) ashuf;
       SIMDE_POWER_ALTIVEC_VECTOR(signed int) bshuf;
 
-      #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-        ashuf = vec_mergel(a_.altivec_i32, a_.altivec_i32);
-        bshuf = vec_mergel(b_.altivec_i32, b_.altivec_i32);
-      #else
-        SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) perm = {
-           8,  9, 10, 11,  8,  9, 10, 11,
-          12, 13, 14, 15, 12, 13, 14, 15
-        };
-        ashuf = vec_perm(a_.altivec_i32, a_.altivec_i32, perm);
-        bshuf = vec_perm(b_.altivec_i32, b_.altivec_i32, perm);
-      #endif
+      ashuf = vec_mergel(a_.altivec_i32, a_.altivec_i32);
+      bshuf = vec_mergel(b_.altivec_i32, b_.altivec_i32);
 
       r_.altivec_i64 = vec_mule(ashuf, bshuf);
     #elif defined(SIMDE_X86_SSE4_1_NATIVE)
@@ -7885,7 +7858,7 @@ simde_wasm_u64x2_extmul_high_u32x4 (simde_v128_t a, simde_v128_t b) {
       r_.neon_u64 = vmull_high_u32(a_.neon_u32, b_.neon_u32);
     #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       r_.neon_u64 = vmull_u32(vget_high_u32(a_.neon_u32), vget_high_u32(b_.neon_u32));
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
       r_.altivec_u64 =
         vec_mule(
           vec_mergel(a_.altivec_u32, a_.altivec_u32),

--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -3236,7 +3236,7 @@ simde_mm_cvtpd_ps (simde__m128d a) {
 
     #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
       r_.neon_f32 = vcombine_f32(vcvt_f32_f64(a_.neon_f64), vdup_n_f32(0.0f));
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
       r_.altivec_f32 = vec_float2(a_.altivec_f64, vec_splats(0.0));
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 = wasm_f32x4_demote_f64x2_zero(a_.wasm_v128);

--- a/simde/x86/sse4.1.h
+++ b/simde/x86/sse4.1.h
@@ -528,7 +528,7 @@ simde_mm_cmpeq_epi64 (simde__m128i a, simde__m128i b) {
       uint32x4_t cmp = vceqq_u32(a_.neon_u32, b_.neon_u32);
       uint32x4_t swapped = vrev64q_u32(cmp);
       r_.neon_u32 = vandq_u32(cmp, swapped);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
       r_.altivec_i64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed long long), vec_cmpeq(a_.altivec_i64, b_.altivec_i64));
     #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       r_.lsx_i64 = __lsx_vseq_d(a_.lsx_i64, b_.lsx_i64);


### PR DESCRIPTION
## Summary

- Fix `SIMDE_POWER_ALTIVEC_P7_NATIVE` guards that protect 64-bit integer AltiVec/VSX operations across four files (`sse2.h`, `sse4.1.h`, `neon/paddl.h`, `wasm/simd128.h`).
  All affected operations require POWER8 and fail to compile or trigger a GCC 14 ICE when targeting POWER7.
- Add a `power7` (GCC 14, `-mcpu=power7`) cross-compilation job to the `gcc-qemu` CI matrix to prevent future regressions.

## Background

POWER7 introduced AltiVec (VMX) with 8/16/32-bit integer SIMD, but 64-bit integer vector operations (`vaddudm`, `vsrad`, `vmulesw`, `vcmpequd`, etc.) were added in POWER8 as part of VSX.

SIMDe's `SIMDE_POWER_ALTIVEC_P7_NATIVE` macro maps to POWER7 AltiVec availability, so code behind this guard must not use 64-bit integer vector builtins.

## Files Changed

| File | Guards Fixed | Operations |
|------|-------------|------------|
| `simde/x86/sse2.h` | P7 → P8 | `vec_add`/`vec_cmpeq`/`vec_cmpgt`/`vec_sl`/`vec_sr`/`vec_sra` on int64 |
| `simde/x86/sse4.1.h` | P7 → P8 | `vec_cmpeq` on int64 |
| `simde/arm/neon/paddl.h` | P7 → P8 (×2) | `vec_add`/`vec_mule`/`vec_mulo` on int64 |
| `simde/wasm/simd128.h` | P7 → P8 (×5) | `vec_all_ne`/`vec_sra`/`vec_mule` on int64 |
| `.github/workflows/ci.yml` | — | New power7 matrix entry |
