### PR TITLE
x86/clmul: use VEX-encoded 256-bit VPCLMULQDQ on CPUs without AVX-512

### DIFF
--- a/simde/x86/clmul.h
+++ b/simde/x86/clmul.h
@@ -290,10 +290,10 @@ simde_mm256_clmulepi64_epi128 (simde__m256i a, simde__m256i b, const int imm8)
 
   return simde__m256i_from_private(r_);
 }
-#if defined(SIMDE_X86_VPCLMULQDQ_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+#if defined(SIMDE_X86_VPCLMULQDQ_NATIVE) && (defined(SIMDE_X86_AVX512VL_NATIVE) || (defined(SIMDE_X86_AVX_NATIVE) && !defined(SIMDE_X86_AVX512F_NATIVE)))
   #define simde_mm256_clmulepi64_epi128(a, b, imm8) _mm256_clmulepi64_epi128(a, b, imm8)
 #endif
-#if defined(SIMDE_X86_VPCLMULQDQ_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_X86_VPCLMULQDQ_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
   #undef _mm256_clmulepi64_epi128
   #define _mm256_clmulepi64_epi128(a, b, imm8) simde_mm256_clmulepi64_epi128(a, b, imm8)
 #endif
@@ -390,7 +390,7 @@ simde_mm512_clmulepi64_epi128 (simde__m512i a, simde__m512i b, const int imm8)
 #if defined(SIMDE_X86_VPCLMULQDQ_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
   #define simde_mm512_clmulepi64_epi128(a, b, imm8) _mm512_clmulepi64_epi128(a, b, imm8)
 #endif
-#if defined(SIMDE_X86_VPCLMULQDQ_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_X86_VPCLMULQDQ_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
   #undef _mm512_clmulepi64_epi128
   #define _mm512_clmulepi64_epi128(a, b, imm8) simde_mm512_clmulepi64_epi128(a, b, imm8)
 #endif


### PR DESCRIPTION
## Problem

`simde_mm256_clmulepi64_epi128` requires both `SIMDE_X86_VPCLMULQDQ_NATIVE` and `SIMDE_X86_AVX512VL_NATIVE` to use the native intrinsic.

CPUs that support VPCLMULQDQ but lack AVX-512 notably AMD Zen 3 (Ryzen 5000 / EPYC 7003) fall back to the portable carry-less multiply emulation, which is orders of magnitude slower than the single hardware instruction.

## Root cause

The guard follows the Intel Intrinsics Guide, which lists AVX512VL as a CPUID requirement but the Guide only documents the EVEX-encoded form.

Per the Intel SDM and AMD APM the instruction has two encodings:

| Encoding | CPUID requirement |
|----------|-------------------|
| VEX.256  | VPCLMULQDQ + AVX  |
| EVEX.256 | VPCLMULQDQ + AVX512VL |

The C intrinsic is not tied to an encoding: GCC ≥ 9.1 ([PR target/88541](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88541)) and Clang ≥ 10 emit the VEX form when compiling with `-mvpclmulqdq -mavx` and no AVX-512.

## Changes

- **Native dispatch guard (256-bit):** follow the pattern gfni.h already uses for the same VEX/EVEX situation `VPCLMULQDQ && (AVX512VL || (AVX && !AVX512F))`.
  The `!AVX512F` exclusion avoids configurations where a compiler could pick the EVEX encoding without AVX512VL being available.
- **Native alias guards (256- and 512-bit):** `&&` → `||`.
  An alias must be defined whenever *any* required feature is missing; with `&&`, a target having exactly one of the two features got neither the native definition nor the SIMDe alias, breaking `SIMDE_ENABLE_NATIVE_ALIASES` builds.
  This matches the existing convention elsewhere (e.g. sse2.h, gfni.h).
- The 512-bit dispatch guard is unchanged: ZMM operations have no VEX encoding and inherently require AVX512F.

## Verification

With GCC 13, `simde_mm256_clmulepi64_epi128` now compiles to a single `vpclmulqdq` under `-march=znver3` and `-mvpclmulqdq -mavx` (previously: portable fallback), still uses the native intrinsic under `-mvpclmulqdq -mavx512vl`, and correctly falls back with `-mvpclmulqdq -mavx512f` (no VL) and with plain `-mpclmul -mavx2`.

GFNI already handles this correctly, and SIMDe has no 256/512-bit VAES implementations, so this was the only remaining intrinsic affected by the VEX/EVEX distinction.