### PR TITLE
x86/sse: fix conditional compilation for Loongarch LSX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,18 @@ jobs:
     - name: Check formatting
       run: .github/workflows/formatting.bash
 
+  conditional-inclusion:
+    runs-on: ubuntu-slim
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        fetch-depth: 2
+        persist-credentials: false
+    - name: Install python3
+      run: sudo apt-get update && sudo apt-get install -y python3
+    - name: Check conditional inclusion for LoongArch
+      run: test/check-loongarch-guards.py
+
   x86:
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
   conditional-inclusion:
     runs-on: ubuntu-slim
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 2
         persist-credentials: false

--- a/simde/x86/avx.h
+++ b/simde/x86/avx.h
@@ -2127,7 +2127,7 @@ simde__m128
 simde_mm_broadcast_ss (simde_float32 const * a) {
   #if defined(SIMDE_X86_AVX_NATIVE)
     return _mm_broadcast_ss(a);
-  #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+  #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
     return (simde__m128)__lsx_vldrepl_w(a, 0);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return simde__m128_from_wasm_v128(wasm_v128_load32_splat(a));
@@ -2671,7 +2671,7 @@ simde_mm_cmp_sd (simde__m128d a, simde__m128d b, const int imm8)
   switch (imm8) {
     case SIMDE_CMP_EQ_OQ:
     case SIMDE_CMP_EQ_OS:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_d(a_.lsx_i64, __lsx_vfcmp_seq_d(a_.lsx_f64, b_.lsx_f64), 0x00);
       #else
         a_.i64[0] = (a_.f64[0] == b_.f64[0]) ? ~INT64_C(0) : INT64_C(0);
@@ -2680,7 +2680,7 @@ simde_mm_cmp_sd (simde__m128d a, simde__m128d b, const int imm8)
 
     case SIMDE_CMP_LT_OQ:
     case SIMDE_CMP_LT_OS:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_d(a_.lsx_i64, __lsx_vfcmp_slt_d(a_.lsx_f64, b_.lsx_f64), 0x00);
       #else
         a_.i64[0] = (a_.f64[0] < b_.f64[0]) ? ~INT64_C(0) : INT64_C(0);
@@ -2689,7 +2689,7 @@ simde_mm_cmp_sd (simde__m128d a, simde__m128d b, const int imm8)
 
     case SIMDE_CMP_LE_OQ:
     case SIMDE_CMP_LE_OS:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_d(a_.lsx_i64, __lsx_vfcmp_sle_d(a_.lsx_f64, b_.lsx_f64), 0x00);
       #else
         a_.i64[0] = (a_.f64[0] <= b_.f64[0]) ? ~INT64_C(0) : INT64_C(0);
@@ -2698,7 +2698,7 @@ simde_mm_cmp_sd (simde__m128d a, simde__m128d b, const int imm8)
 
     case SIMDE_CMP_UNORD_Q:
     case SIMDE_CMP_UNORD_S:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_d(a_.lsx_i64, __lsx_vfcmp_cun_d(a_.lsx_f64, b_.lsx_f64), 0x00);
       #else
         a_.i64[0] = ((a_.f64[0] != a_.f64[0]) || (b_.f64[0] != b_.f64[0])) ? ~INT64_C(0) : INT64_C(0);
@@ -2707,7 +2707,7 @@ simde_mm_cmp_sd (simde__m128d a, simde__m128d b, const int imm8)
 
     case SIMDE_CMP_NEQ_UQ:
     case SIMDE_CMP_NEQ_US:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_d(a_.lsx_i64, __lsx_vfcmp_cune_d(a_.lsx_f64, b_.lsx_f64), 0x00);
       #else
         a_.i64[0] = ((a_.f64[0] == a_.f64[0]) & (b_.f64[0] == b_.f64[0]) & (a_.f64[0] != b_.f64[0])) ? ~INT64_C(0) : INT64_C(0);
@@ -2716,7 +2716,7 @@ simde_mm_cmp_sd (simde__m128d a, simde__m128d b, const int imm8)
 
     case SIMDE_CMP_NEQ_OQ:
     case SIMDE_CMP_NEQ_OS:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_d(a_.lsx_i64, __lsx_vfcmp_cne_d(a_.lsx_f64, b_.lsx_f64), 0x00);
       #else
         a_.i64[0] = ((a_.f64[0] == a_.f64[0]) & (b_.f64[0] == b_.f64[0]) & (a_.f64[0] != b_.f64[0])) ? ~INT64_C(0) : INT64_C(0);
@@ -2725,7 +2725,7 @@ simde_mm_cmp_sd (simde__m128d a, simde__m128d b, const int imm8)
 
     case SIMDE_CMP_NLT_UQ:
     case SIMDE_CMP_NLT_US:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         t_ = __lsx_vfcmp_cult_d(a_.lsx_f64, b_.lsx_f64);
         a_.lsx_i64 = __lsx_vextrins_d(a_.lsx_i64, __lsx_vnor_v(t_, t_), 0x00);
       #else
@@ -2735,7 +2735,7 @@ simde_mm_cmp_sd (simde__m128d a, simde__m128d b, const int imm8)
 
     case SIMDE_CMP_NLE_UQ:
     case SIMDE_CMP_NLE_US:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         t_ = __lsx_vfcmp_cule_d(a_.lsx_f64, b_.lsx_f64);
         a_.lsx_i64 = __lsx_vextrins_d(a_.lsx_i64, __lsx_vnor_v(t_, t_), 0x00);
       #else
@@ -2745,7 +2745,7 @@ simde_mm_cmp_sd (simde__m128d a, simde__m128d b, const int imm8)
 
     case SIMDE_CMP_ORD_Q:
     case SIMDE_CMP_ORD_S:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_d(a_.lsx_i64, __lsx_vfcmp_cor_d(a_.lsx_f64, b_.lsx_f64), 0x00);
       #else
         a_.i64[0] = ((a_.f64[0] == a_.f64[0]) & (b_.f64[0] == b_.f64[0])) ? ~INT64_C(0) : INT64_C(0);
@@ -2754,7 +2754,7 @@ simde_mm_cmp_sd (simde__m128d a, simde__m128d b, const int imm8)
 
     case SIMDE_CMP_EQ_UQ:
     case SIMDE_CMP_EQ_US:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_d(a_.lsx_i64, __lsx_vfcmp_cueq_d(a_.lsx_f64, b_.lsx_f64), 0x00);
       #else
         a_.i64[0] = ((a_.f64[0] != a_.f64[0]) | (b_.f64[0] != b_.f64[0]) | (a_.f64[0] == b_.f64[0])) ? ~INT64_C(0) : INT64_C(0);
@@ -2763,7 +2763,7 @@ simde_mm_cmp_sd (simde__m128d a, simde__m128d b, const int imm8)
 
     case SIMDE_CMP_NGE_UQ:
     case SIMDE_CMP_NGE_US:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_d(a_.lsx_i64, __lsx_vfcmp_cult_d(a_.lsx_f64, b_.lsx_f64), 0x00);
       #else
         a_.i64[0] = !(a_.f64[0] >= b_.f64[0]) ? ~INT64_C(0) : INT64_C(0);
@@ -2772,7 +2772,7 @@ simde_mm_cmp_sd (simde__m128d a, simde__m128d b, const int imm8)
 
     case SIMDE_CMP_NGT_UQ:
     case SIMDE_CMP_NGT_US:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_d(a_.lsx_i64, __lsx_vfcmp_cule_d(a_.lsx_f64, b_.lsx_f64), 0x00);
       #else
         a_.i64[0] = !(a_.f64[0] > b_.f64[0]) ? ~INT64_C(0) : INT64_C(0);
@@ -2786,7 +2786,7 @@ simde_mm_cmp_sd (simde__m128d a, simde__m128d b, const int imm8)
 
     case SIMDE_CMP_GE_OQ:
     case SIMDE_CMP_GE_OS:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         t_ = __lsx_vfcmp_clt_d(a_.lsx_f64, b_.lsx_f64);
         a_.lsx_i64 = __lsx_vextrins_d(a_.lsx_i64, __lsx_vnor_v(t_, t_), 0x00);
       #else
@@ -2796,7 +2796,7 @@ simde_mm_cmp_sd (simde__m128d a, simde__m128d b, const int imm8)
 
     case SIMDE_CMP_GT_OQ:
     case SIMDE_CMP_GT_OS:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_d(a_.lsx_i64, __lsx_vfcmp_clt_d(b_.lsx_f64, a_.lsx_f64), 0x00);
       #else
         a_.i64[0] = (a_.f64[0] > b_.f64[0]) ? ~INT64_C(0) : INT64_C(0);
@@ -2836,7 +2836,7 @@ simde_mm_cmp_ss (simde__m128 a, simde__m128 b, const int imm8)
   switch (imm8) {
     case SIMDE_CMP_EQ_OQ:
     case SIMDE_CMP_EQ_OS:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_w(a_.lsx_i64, __lsx_vfcmp_seq_s(a_.lsx_f32, b_.lsx_f32), 0x00);
       #else
         a_.i32[0] = (a_.f32[0] == b_.f32[0]) ? ~INT32_C(0) : INT32_C(0);
@@ -2845,7 +2845,7 @@ simde_mm_cmp_ss (simde__m128 a, simde__m128 b, const int imm8)
 
     case SIMDE_CMP_LT_OQ:
     case SIMDE_CMP_LT_OS:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_w(a_.lsx_i64, __lsx_vfcmp_slt_s(a_.lsx_f32, b_.lsx_f32), 0x00);
       #else
         a_.i32[0] = (a_.f32[0] < b_.f32[0]) ? ~INT32_C(0) : INT32_C(0);
@@ -2854,7 +2854,7 @@ simde_mm_cmp_ss (simde__m128 a, simde__m128 b, const int imm8)
 
     case SIMDE_CMP_LE_OQ:
     case SIMDE_CMP_LE_OS:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_w(a_.lsx_i64, __lsx_vfcmp_sle_s(a_.lsx_f32, b_.lsx_f32), 0x00);
       #else
         a_.i32[0] = (a_.f32[0] <= b_.f32[0]) ? ~INT32_C(0) : INT32_C(0);
@@ -2863,7 +2863,7 @@ simde_mm_cmp_ss (simde__m128 a, simde__m128 b, const int imm8)
 
     case SIMDE_CMP_UNORD_Q:
     case SIMDE_CMP_UNORD_S:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_w(a_.lsx_i64, __lsx_vfcmp_cun_s(a_.lsx_f32, b_.lsx_f32), 0x00);
       #else
         a_.i32[0] = ((a_.f32[0] != a_.f32[0]) || (b_.f32[0] != b_.f32[0])) ? ~INT32_C(0) : INT32_C(0);
@@ -2872,7 +2872,7 @@ simde_mm_cmp_ss (simde__m128 a, simde__m128 b, const int imm8)
 
     case SIMDE_CMP_NEQ_UQ:
     case SIMDE_CMP_NEQ_US:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_w(a_.lsx_i64, __lsx_vfcmp_cune_s(a_.lsx_f32, b_.lsx_f32), 0x00);
       #else
         a_.i32[0] = ((a_.f32[0] == a_.f32[0]) & (b_.f32[0] == b_.f32[0]) & (a_.f32[0] != b_.f32[0])) ? ~INT32_C(0) : INT32_C(0);
@@ -2881,7 +2881,7 @@ simde_mm_cmp_ss (simde__m128 a, simde__m128 b, const int imm8)
 
     case SIMDE_CMP_NEQ_OQ:
     case SIMDE_CMP_NEQ_OS:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_w(a_.lsx_i64, __lsx_vfcmp_cne_s(a_.lsx_f32, b_.lsx_f32), 0x00);
       #else
         a_.i32[0] = ((a_.f32[0] == a_.f32[0]) & (b_.f32[0] == b_.f32[0]) & (a_.f32[0] != b_.f32[0])) ? ~INT32_C(0) : INT32_C(0);
@@ -2890,7 +2890,7 @@ simde_mm_cmp_ss (simde__m128 a, simde__m128 b, const int imm8)
 
     case SIMDE_CMP_NLT_UQ:
     case SIMDE_CMP_NLT_US:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         t_ = __lsx_vfcmp_cult_s(a_.lsx_f32, b_.lsx_f32);
         a_.lsx_i64 = __lsx_vextrins_w(a_.lsx_i64, __lsx_vnor_v(t_, t_), 0x00);
       #else
@@ -2900,7 +2900,7 @@ simde_mm_cmp_ss (simde__m128 a, simde__m128 b, const int imm8)
 
     case SIMDE_CMP_NLE_UQ:
     case SIMDE_CMP_NLE_US:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         t_ = __lsx_vfcmp_cule_s(a_.lsx_f32, b_.lsx_f32);
         a_.lsx_i64 = __lsx_vextrins_w(a_.lsx_i64, __lsx_vnor_v(t_, t_), 0x00);
       #else
@@ -2910,7 +2910,7 @@ simde_mm_cmp_ss (simde__m128 a, simde__m128 b, const int imm8)
 
     case SIMDE_CMP_ORD_Q:
     case SIMDE_CMP_ORD_S:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_w(a_.lsx_i64, __lsx_vfcmp_cor_s(a_.lsx_f32, b_.lsx_f32), 0x00);
       #else
         a_.i32[0] = ((a_.f32[0] == a_.f32[0]) & (b_.f32[0] == b_.f32[0])) ? ~INT32_C(0) : INT32_C(0);
@@ -2919,7 +2919,7 @@ simde_mm_cmp_ss (simde__m128 a, simde__m128 b, const int imm8)
 
     case SIMDE_CMP_EQ_UQ:
     case SIMDE_CMP_EQ_US:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_w(a_.lsx_i64, __lsx_vfcmp_cueq_s(a_.lsx_f32, b_.lsx_f32), 0x00);
       #else
         a_.i32[0] = ((a_.f32[0] != a_.f32[0]) | (b_.f32[0] != b_.f32[0]) | (a_.f32[0] == b_.f32[0])) ? ~INT32_C(0) : INT32_C(0);
@@ -2928,7 +2928,7 @@ simde_mm_cmp_ss (simde__m128 a, simde__m128 b, const int imm8)
 
     case SIMDE_CMP_NGE_UQ:
     case SIMDE_CMP_NGE_US:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_w(a_.lsx_i64, __lsx_vfcmp_cult_s(a_.lsx_f32, b_.lsx_f32), 0x00);
       #else
         a_.i32[0] = !(a_.f32[0] >= b_.f32[0]) ? ~INT32_C(0) : INT32_C(0);
@@ -2937,7 +2937,7 @@ simde_mm_cmp_ss (simde__m128 a, simde__m128 b, const int imm8)
 
     case SIMDE_CMP_NGT_UQ:
     case SIMDE_CMP_NGT_US:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_w(a_.lsx_i64, __lsx_vfcmp_cule_s(a_.lsx_f32, b_.lsx_f32), 0x00);
       #else
         a_.i32[0] = !(a_.f32[0] > b_.f32[0]) ? ~INT32_C(0) : INT32_C(0);
@@ -2955,7 +2955,7 @@ simde_mm_cmp_ss (simde__m128 a, simde__m128 b, const int imm8)
 
     case SIMDE_CMP_GE_OQ:
     case SIMDE_CMP_GE_OS:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         t_ = __lsx_vfcmp_clt_s(a_.lsx_f32, b_.lsx_f32);
         a_.lsx_i64 = __lsx_vextrins_w(a_.lsx_i64, __lsx_vnor_v(t_, t_), 0x00);
       #else
@@ -2965,7 +2965,7 @@ simde_mm_cmp_ss (simde__m128 a, simde__m128 b, const int imm8)
 
     case SIMDE_CMP_GT_OQ:
     case SIMDE_CMP_GT_OS:
-      #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
         a_.lsx_i64 = __lsx_vextrins_w(a_.lsx_i64, __lsx_vfcmp_clt_s(b_.lsx_f32, a_.lsx_f32), 0x00);
       #else
         a_.i32[0] = (a_.f32[0] > b_.f32[0]) ? ~INT32_C(0) : INT32_C(0);
@@ -4476,7 +4476,7 @@ simde__m256
 simde_mm256_loadu2_m128 (const float hiaddr[HEDLEY_ARRAY_PARAM(4)], const float loaddr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_X86_AVX_NATIVE) && !defined(SIMDE_BUG_GCC_91341) && !defined(SIMDE_BUG_MCST_LCC_MISSING_AVX_LOAD_STORE_M128_FUNCS)
     return _mm256_loadu2_m128(hiaddr, loaddr);
-  #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+  #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
     simde__m256_private r_;
     r_.m128_private[1].lsx_i64 = __lsx_vld(hiaddr, 0);
     r_.m128_private[0].lsx_i64 = __lsx_vld(loaddr, 0);
@@ -4497,7 +4497,7 @@ simde__m256d
 simde_mm256_loadu2_m128d (const double hiaddr[HEDLEY_ARRAY_PARAM(2)], const double loaddr[HEDLEY_ARRAY_PARAM(2)]) {
   #if defined(SIMDE_X86_AVX_NATIVE) && !defined(SIMDE_BUG_GCC_91341) && !defined(SIMDE_BUG_MCST_LCC_MISSING_AVX_LOAD_STORE_M128_FUNCS)
     return _mm256_loadu2_m128d(hiaddr, loaddr);
-  #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+  #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
     simde__m256d_private r_;
     r_.m128d_private[1].lsx_i64 = __lsx_vld(hiaddr, 0);
     r_.m128d_private[0].lsx_i64 = __lsx_vld(loaddr, 0);
@@ -4518,7 +4518,7 @@ simde__m256i
 simde_mm256_loadu2_m128i (const simde__m128i* hiaddr, const simde__m128i* loaddr) {
   #if defined(SIMDE_X86_AVX_NATIVE) && !defined(SIMDE_BUG_GCC_91341) && !defined(SIMDE_BUG_MCST_LCC_MISSING_AVX_LOAD_STORE_M128_FUNCS)
     return _mm256_loadu2_m128i(hiaddr, loaddr);
-  #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+  #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
     simde__m256i_private r_;
     r_.m128i[1] = __lsx_vld(hiaddr, 0);
     r_.m128i[0] = __lsx_vld(loaddr, 0);
@@ -4554,7 +4554,7 @@ simde_mm_maskload_pd (const simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(2)], simde
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       return simde_mm_and_pd(simde_mm_load_pd(mem_addr),
           simde__m128d_from_wasm_v128(wasm_i64x2_shr(mask_.wasm_v128, 63)));
-    #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       mask_shr_.lsx_i64 = __lsx_vsrli_d(mask_.lsx_i64, 63);
     #else
       SIMDE_VECTORIZE
@@ -4621,7 +4621,7 @@ simde_mm_maskload_ps (const simde_float32 mem_addr[HEDLEY_ARRAY_PARAM(4)], simde
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       return simde_mm_and_ps(simde_mm_load_ps(mem_addr),
           simde__m128_from_wasm_v128(wasm_i32x4_shr(mask_.wasm_v128, 31)));
-    #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       mask_shr_.lsx_i64 = __lsx_vsrli_w(mask_.lsx_i64, 31);
     #else
       SIMDE_VECTORIZE
@@ -4678,7 +4678,7 @@ simde_mm_maskstore_pd (simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(2)], simde__m12
     #else
       _mm_maskstore_pd(mem_addr, mask, a);
     #endif
-  #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+  #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
     if (__lsx_vpickve2gr_d(mask, 0) < 0)
       __lsx_vstelm_d(HEDLEY_REINTERPRET_CAST(simde__m128i, a), mem_addr, 0, 0);
     if (__lsx_vpickve2gr_d(mask, 1) < 0)
@@ -4744,7 +4744,7 @@ simde_mm_maskstore_ps (simde_float32 mem_addr[HEDLEY_ARRAY_PARAM(4)], simde__m12
     #else
       _mm_maskstore_ps(mem_addr, mask, a);
     #endif
-  #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+  #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
     __m128i r_ = __lsx_vld(mem_addr, 0); mask = __lsx_vslti_w(mask, 0);
     r_ = __lsx_vbitsel_v(r_, HEDLEY_REINTERPRET_CAST(simde__m128i, a), mask);
     __lsx_vst(r_, mem_addr, 0);
@@ -5280,7 +5280,7 @@ simde_mm_permute_ps (simde__m128 a, const int imm8)
 }
 #if defined(SIMDE_X86_AVX_NATIVE)
 #  define simde_mm_permute_ps(a, imm8) _mm_permute_ps(a, imm8)
-#elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+#elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
 #  define simde_mm_permute_ps(a, imm8) HEDLEY_REINTERPRET_CAST(simde__m128, __lsx_vshuf4i_w(HEDLEY_REINTERPRET_CAST(simde__m128i, a), imm8))
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
 #  define simde_mm_permute_ps(a, imm8) simde__m128_from_wasm_v128(wasm_i32x4_shuffle(simde__m128_to_wasm_v128(a), simde__m128_to_wasm_v128(a), ((imm8) & 3), (((imm8) >> 2) & 3 ), (((imm8) >> 4) & 3), (((imm8) >> 6) & 3)))
@@ -5308,7 +5308,7 @@ simde_mm_permute_pd (simde__m128d a, const int imm8)
 }
 #if defined(SIMDE_X86_AVX_NATIVE)
 #  define simde_mm_permute_pd(a, imm8) _mm_permute_pd(a, imm8)
-#elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+#elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
 #  define simde_mm_permute_pd(a, imm8) HEDLEY_REINTERPRET_CAST(simde__m128d, __lsx_vshuf4i_d(HEDLEY_REINTERPRET_CAST(simde__m128i, a), HEDLEY_REINTERPRET_CAST(simde__m128i, a), (imm8 & 1) | (((imm8 >> 1) & 1) << 2)))
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
 #  define simde_mm_permute_pd(a, imm8) simde__m128d_from_wasm_v128(wasm_i64x2_shuffle(simde__m128d_to_wasm_v128(a), simde__m128d_to_wasm_v128(a), ((imm8) & 1), (((imm8) >> 1) & 1 )))
@@ -5329,7 +5329,7 @@ simde_mm_permutevar_ps (simde__m128 a, simde__m128i b) {
       a_ = simde__m128_to_private(a);
     simde__m128i_private b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
       r_.lsx_i64 = __lsx_vshuf_w(__lsx_vand_v(b_.lsx_i64, __lsx_vreplgr2vr_w(3)), a_.lsx_i64, a_.lsx_i64);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 = wasm_f32x4_make(
@@ -5363,7 +5363,7 @@ simde_mm_permutevar_pd (simde__m128d a, simde__m128i b) {
       a_ = simde__m128d_to_private(a);
     simde__m128i_private b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
       r_.lsx_i64 = __lsx_vshuf_d(__lsx_vsrli_d(__lsx_vand_v(b_.lsx_i64, __lsx_vreplgr2vr_d(2)), 1), a_.lsx_i64, a_.lsx_i64);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.wasm_v128 = wasm_f64x2_make(
@@ -6584,7 +6584,7 @@ simde_mm_testc_ps (simde__m128 a, simde__m128 b) {
       m = wasm_v128_and(m, simde_mm_movehl_ps(m, m));
       m = wasm_v128_and(m, simde_mm_shuffle_epi32(m, SIMDE_MM_SHUFFLE(3, 2, 0, 1)));
       return wasm_i32x4_extract_lane(m, 0);
-    #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       a_.lsx_i64 = __lsx_vandn_v(a_.lsx_i64, b_.lsx_i64);
       a_.lsx_i64 = __lsx_vmskltz_w(a_.lsx_i64);
       return __lsx_vpickve2gr_w(a_.lsx_i64, 0) ? 0 : 1;
@@ -6617,7 +6617,7 @@ simde_mm_testc_pd (simde__m128d a, simde__m128d b) {
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       v128_t m = wasm_u64x2_shr(wasm_v128_or(wasm_v128_not(b_.wasm_v128), a_.wasm_v128), 63);
       return HEDLEY_STATIC_CAST(int, wasm_i64x2_extract_lane(m, 0) & wasm_i64x2_extract_lane(m, 1));
-    #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       a_.lsx_i64 = __lsx_vandn_v(a_.lsx_i64, b_.lsx_i64);
       a_.lsx_i64 = __lsx_vmskltz_d(a_.lsx_i64);
       return __lsx_vpickve2gr_w(a_.lsx_i64, 0) ? 0 : 1;
@@ -6743,7 +6743,7 @@ simde_mm_testz_ps (simde__m128 a, simde__m128 b) {
       m = wasm_v128_and(m, simde_mm_movehl_ps(m, m));
       m = wasm_v128_and(m, simde_mm_shuffle_epi32(m, SIMDE_MM_SHUFFLE(3, 2, 0, 1)));
       return wasm_i32x4_extract_lane(m, 0);
-    #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       a_.lsx_i64 = __lsx_vand_v(a_.lsx_i64, b_.lsx_i64);
       a_.lsx_i64 = __lsx_vmskltz_w(a_.lsx_i64);
       return __lsx_vpickve2gr_w(a_.lsx_i64, 0) ? 0 : 1;
@@ -6776,7 +6776,7 @@ simde_mm_testz_pd (simde__m128d a, simde__m128d b) {
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       v128_t m = wasm_u64x2_shr(wasm_v128_not(wasm_v128_and(a_.wasm_v128, b_.wasm_v128)), 63);
       return HEDLEY_STATIC_CAST(int, wasm_i64x2_extract_lane(m, 0) & wasm_i64x2_extract_lane(m, 1));
-    #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       a_.lsx_i64 = __lsx_vand_v(a_.lsx_i64, b_.lsx_i64);
       a_.lsx_i64 = __lsx_vmskltz_d(a_.lsx_i64);
       return __lsx_vpickve2gr_w(a_.lsx_i64, 0) ? 0 : 1;
@@ -6905,7 +6905,7 @@ simde_mm_testnzc_ps (simde__m128 a, simde__m128 b) {
       m  = wasm_v128_or(m,  simde_mm_shuffle_epi32(m, SIMDE_MM_SHUFFLE(3, 2, 0, 1)));
       m2 = wasm_v128_or(m2, simde_mm_shuffle_epi32(m2, SIMDE_MM_SHUFFLE(3, 2, 0, 1)));
       return wasm_i32x4_extract_lane(m, 0) & wasm_i32x4_extract_lane(m2, 0);
-    #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       __m128i m = __lsx_vandn_v(a_.lsx_i64, b_.lsx_i64);
       __m128i n = __lsx_vand_v(a_.lsx_i64, b_.lsx_i64);
       m = __lsx_vmskltz_w(m); n = __lsx_vmskltz_w(n);
@@ -6942,7 +6942,7 @@ simde_mm_testnzc_pd (simde__m128d a, simde__m128d b) {
       v128_t m2 = wasm_u64x2_shr(wasm_v128_andnot(b_.wasm_v128, a_.wasm_v128), 63);
       return HEDLEY_STATIC_CAST(int, (wasm_i64x2_extract_lane(m, 0)  | wasm_i64x2_extract_lane(m, 1))
                                    & (wasm_i64x2_extract_lane(m2, 0) | wasm_i64x2_extract_lane(m2, 1)));
-    #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       __m128i m = __lsx_vandn_v(a_.lsx_i64, b_.lsx_i64);
       __m128i n = __lsx_vand_v(a_.lsx_i64, b_.lsx_i64);
       m = __lsx_vmskltz_d(m); n = __lsx_vmskltz_d(n);

--- a/simde/x86/avx2.h
+++ b/simde/x86/avx2.h
@@ -600,7 +600,7 @@ simde_mm_blend_epi32(simde__m128i a, simde__m128i b, const int imm8)
 }
 #if defined(SIMDE_X86_AVX2_NATIVE)
 #  define simde_mm_blend_epi32(a, b, imm8) _mm_blend_epi32(a, b, imm8)
-#elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+#elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
 #  define simde_mm_blend_epi32(a, b, imm8)  __lsx_vbitsel_v(a, b, \
   simde_mm_set_epi32(-((imm8 >> 3) & 1), -((imm8 >> 2) & 1), -((imm8 >> 1)& 1), -(imm8 & 1)))
 #elif SIMDE_NATURAL_FLOAT_VECTOR_SIZE_LE(128)
@@ -731,7 +731,7 @@ simde__m128i
 simde_mm_broadcastb_epi8 (simde__m128i a) {
   #if defined(SIMDE_X86_AVX2_NATIVE)
     return _mm_broadcastb_epi8(a);
-  #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+  #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
     return __lsx_vreplvei_b(a, 0);
   #else
     simde__m128i_private r_;
@@ -779,7 +779,7 @@ simde__m128i
 simde_mm_broadcastw_epi16 (simde__m128i a) {
   #if defined(SIMDE_X86_AVX2_NATIVE)
     return _mm_broadcastw_epi16(a);
-  #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+  #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
     return __lsx_vreplvei_h(a, 0);
   #else
     simde__m128i_private r_;
@@ -827,7 +827,7 @@ simde__m128i
 simde_mm_broadcastd_epi32 (simde__m128i a) {
   #if defined(SIMDE_X86_AVX2_NATIVE)
     return _mm_broadcastd_epi32(a);
-  #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+  #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
     return __lsx_vreplvei_w(a, 0);
   #else
     simde__m128i_private r_;
@@ -875,7 +875,7 @@ simde__m128i
 simde_mm_broadcastq_epi64 (simde__m128i a) {
   #if defined(SIMDE_X86_AVX2_NATIVE)
     return _mm_broadcastq_epi64(a);
-  #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+  #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
     return __lsx_vreplvei_d(a, 0);
   #else
     simde__m128i_private r_;
@@ -929,7 +929,7 @@ simde_mm_broadcastss_ps (simde__m128 a) {
     simde__m128_private r_;
     simde__m128_private a_= simde__m128_to_private(a);
 
-    #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
       r_.lsx_i64 = __lsx_vreplvei_w(a_.lsx_i64, 0);
     #elif defined(SIMDE_SHUFFLE_VECTOR_)
       r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.f32, a_.f32, 0, 0, 0, 0);
@@ -3223,7 +3223,7 @@ simde_mm_maskload_epi32 (const int32_t mem_addr[HEDLEY_ARRAY_PARAM(4)], simde__m
 
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       mask_shr_.neon_i32 = vshrq_n_s32(mask_.neon_i32, 31);
-    #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       mask_shr_.lsx_i64 = __lsx_vsrli_w(mask_.lsx_i64, 31);
     #else
       SIMDE_VECTORIZE
@@ -3291,7 +3291,7 @@ simde_mm_maskload_epi64 (const int64_t mem_addr[HEDLEY_ARRAY_PARAM(2)], simde__m
 
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       mask_shr_.neon_i64 = vshrq_n_s64(mask_.neon_i64, 63);
-    #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       mask_shr_.lsx_i64 = __lsx_vsrli_d(mask_.lsx_i64, 63);
     #else
       SIMDE_VECTORIZE
@@ -3355,7 +3355,7 @@ simde_mm_maskstore_epi32 (int32_t mem_addr[HEDLEY_ARRAY_PARAM(4)], simde__m128i 
     simde__m128i_private mask_ = simde__m128i_to_private(mask);
     simde__m128i_private a_ = simde__m128i_to_private(a);
 
-    #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
        mask_.lsx_i64 = __lsx_vslti_w(mask_.lsx_i64, 0);
        a_.lsx_i64  = __lsx_vbitsel_v(__lsx_vld(mem_addr, 0), a_.lsx_i64, mask_.lsx_i64);
        __lsx_vst(a_.lsx_i64, mem_addr, 0);
@@ -3409,7 +3409,7 @@ simde_mm_maskstore_epi64 (int64_t mem_addr[HEDLEY_ARRAY_PARAM(2)], simde__m128i 
     simde__m128i_private mask_ = simde__m128i_to_private(mask);
     simde__m128i_private a_ = simde__m128i_to_private(a);
 
-    #if defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
       if (__lsx_vpickve2gr_d(mask_.lsx_i64, 0) < 0) __lsx_vstelm_d(a_.lsx_i64, mem_addr, 0, 0);
       if (__lsx_vpickve2gr_d(mask_.lsx_i64, 1) < 0) __lsx_vstelm_d(a_.lsx_i64, mem_addr, 8, 1);
     #else
@@ -4983,7 +4983,7 @@ simde_mm_sllv_epi32 (simde__m128i a, simde__m128i b) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_u32 = vshlq_u32(a_.neon_u32, vreinterpretq_s32_u32(b_.neon_u32));
     r_.neon_u32 = vandq_u32(r_.neon_u32, vcltq_u32(b_.neon_u32, vdupq_n_u32(32)));
-  #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+  #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
     r_.lsx_i64 = __lsx_vsll_w(a_.lsx_i64, b_.lsx_i64);
     r_.lsx_i64 = __lsx_vand_v(r_.lsx_i64, __lsx_vslei_wu(b_.lsx_i64, 31));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
@@ -5049,7 +5049,7 @@ simde_mm_sllv_epi64 (simde__m128i a, simde__m128i b) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     r_.neon_u64 = vshlq_u64(a_.neon_u64, vreinterpretq_s64_u64(b_.neon_u64));
     r_.neon_u64 = vandq_u64(r_.neon_u64, vcltq_u64(b_.neon_u64, vdupq_n_u64(64)));
-  #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+  #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
     r_.lsx_i64 = __lsx_vsll_d(a_.lsx_i64, b_.lsx_i64);
     r_.lsx_i64 = __lsx_vand_v(r_.lsx_i64, __lsx_vsle_du(b_.lsx_i64, __lsx_vreplgr2vr_d(63)));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
@@ -5257,7 +5257,7 @@ simde__m128i
 simde_mm_srav_epi32 (simde__m128i a, simde__m128i count) {
   #if defined(SIMDE_X86_AVX2_NATIVE)
     return _mm_srav_epi32(a, count);
-  #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+  #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
     return __lsx_vsra_w(a, __lsx_vmini_wu(count, 31));
   #else
     simde__m128i_private
@@ -5617,7 +5617,7 @@ simde_mm_srlv_epi32 (simde__m128i a, simde__m128i b) {
 }
 #if defined(SIMDE_X86_AVX2_NATIVE)
   #define simde_mm_srlv_epi32(a, b) _mm_srlv_epi32(a, b)
-#elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+#elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
   #define simde_mm_srlv_epi32(a, b) __lsx_vand_v(__lsx_vsrl_w(a, b), __lsx_vslei_wu(b, 31))
 #endif
 #if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
@@ -5675,7 +5675,7 @@ simde_mm_srlv_epi64 (simde__m128i a, simde__m128i b) {
 }
 #if defined(SIMDE_X86_AVX2_NATIVE)
   #define simde_mm_srlv_epi64(a, b) _mm_srlv_epi64(a, b)
-#elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+#elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
   #define simde_mm_srlv_epi64(a, b) __lsx_vand_v(__lsx_vsrl_d(a, b), __lsx_vsle_du(b, __lsx_vreplgr2vr_d(63)))
 #endif
 #if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)

--- a/simde/x86/sse.h
+++ b/simde/x86/sse.h
@@ -2725,7 +2725,7 @@ simde_mm_div_ps (simde__m128 a, simde__m128 b) {
       r_.wasm_v128 =  wasm_f32x4_div(a_.wasm_v128, b_.wasm_v128);
     #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
       r_.altivec_f32 = vec_div(a_.altivec_f32, b_.altivec_f32);
-    #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+    #elif defined(SIMDE_LOONGARCH_LSX_NATIVE)
       r_.lsx_f32 = __lsx_vfdiv_s(a_.lsx_f32, b_.lsx_f32);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.f32 = a_.f32 / b_.f32;

--- a/test/check-loongarch-guards.py
+++ b/test/check-loongarch-guards.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+Check that LoongArch SIMD intrinsic usage matches the preprocessor guard.
+  - If a guarded block contains ONLY __lsx_* intrinsics, it MUST be guarded
+    by SIMDE_LOONGARCH_LSX_NATIVE.
+  - If a guarded block contains __lasx_* intrinsics, with or without __lsx_*,
+    it MUST be guarded by SIMDE_LOONGARCH_LASX_NATIVE.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+TARGET_MACRO = r'SIMDE_LOONGARCH_(?:LSX|LASX)_NATIVE'
+
+# All conditional inclusion directives, including C++23 #elifdef / #elifndef.
+DIRECTIVE_RE = re.compile(
+    r'^\s*#\s*(if|ifdef|ifndef|elifdef|elifndef|elif|else|endif)\b'
+)
+
+# Positive guards from #if / #elif:
+#   #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
+#   #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+# Also tolerates:
+#   #if defined SIMDE_LOONGARCH_LSX_NATIVE
+IF_GUARD_RE = re.compile(
+    r'^\s*#\s*(?:if|elif)\s+defined\s*(?:\(\s*)?(' + TARGET_MACRO + r')\b\s*\)?'
+)
+
+# Positive guards from #ifdef / #elifdef:
+#   #ifdef SIMDE_LOONGARCH_LSX_NATIVE
+#   #elifdef SIMDE_LOONGARCH_LASX_NATIVE
+DEF_GUARD_RE = re.compile(
+    r'^\s*#\s*(?:ifdef|elifdef)\s+(' + TARGET_MACRO + r')\b'
+)
+
+LSX_RE = re.compile(r'\b__lsx_\w+')
+LASX_RE = re.compile(r'\b__lasx_\w+')
+
+
+def positive_guard(line):
+    """
+    Return the target macro name if this line starts a positive target guard.
+
+    Positive guards are:
+      #if defined(SIMDE_LOONGARCH_LSX_NATIVE)
+      #elif defined(SIMDE_LOONGARCH_LASX_NATIVE)
+      #ifdef SIMDE_LOONGARCH_LSX_NATIVE
+      #elifdef SIMDE_LOONGARCH_LASX_NATIVE
+
+    Negative guards such as #ifndef / #elifndef return None.
+    """
+    m = IF_GUARD_RE.match(line)
+    if m:
+        return m.group(1)
+
+    m = DEF_GUARD_RE.match(line)
+    if m:
+        return m.group(1)
+
+    return None
+
+
+def guarded_blocks(lines):
+    """
+    Yield (guard_macro, guard_line, block_start, block_end) tuples.
+
+    block_end is exclusive, matching Python slice semantics.
+    """
+    i = 0
+    while i < len(lines):
+        guard = positive_guard(lines[i])
+        if not guard:
+            i += 1
+            continue
+
+        guard_line = i
+        start = i + 1
+        depth = 1
+        j = start
+
+        while j < len(lines) and depth:
+            dm = DIRECTIVE_RE.match(lines[j])
+            if dm:
+                kind = dm.group(1)
+
+                if kind in {'if', 'ifdef', 'ifndef'}:
+                    depth += 1
+                elif kind == 'endif':
+                    depth -= 1
+                elif depth == 1:
+                    # Same-level branch boundary:
+                    #   #elif
+                    #   #elifdef
+                    #   #elifndef
+                    #   #else
+                    if guard and start < j:
+                        yield guard, guard_line, start, j
+
+                    guard = positive_guard(lines[j])
+                    guard_line = j
+                    start = j + 1
+
+            j += 1
+
+        # If depth == 0, j points just after the matching #endif.
+        # The #endif line itself should not be part of the block.
+        #
+        # If depth != 0, the file ended before #endif; treat EOF as the end.
+        end = j - 1 if depth == 0 else j
+
+        if guard and start < end:
+            yield guard, guard_line, start, end
+
+        i = j
+
+
+def snippet(lines, start, end, context=2):
+    """Return a small line-numbered snippet around [start, end)."""
+    first = max(0, start - context)
+    last = min(len(lines), end + context)
+
+    return '\n'.join(
+        f"{'>>>' if start <= i < end else '   '} {i + 1:5d} | {lines[i]}"
+        for i in range(first, last)
+    )
+
+
+def check_file(path):
+    """Yield errors found in one file."""
+    try:
+        lines = path.read_text(encoding='utf-8', errors='replace').splitlines()
+    except OSError:
+        return
+
+    for guard, guard_line, start, end in guarded_blocks(lines):
+        if any(LASX_RE.search(lines[i]) for i in range(start, end)):
+            expected = 'SIMDE_LOONGARCH_LASX_NATIVE'
+        elif any(LSX_RE.search(lines[i]) for i in range(start, end)):
+            expected = 'SIMDE_LOONGARCH_LSX_NATIVE'
+        else:
+            continue
+
+        if guard != expected:
+            yield (
+                path,
+                guard_line + 1,
+                guard,
+                expected,
+                snippet(lines, guard_line, end),
+            )
+
+
+def main():
+    root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path('simde')
+
+    if not root.is_dir():
+        print(f"ERROR: directory '{root}' not found", file=sys.stderr)
+        return 1
+
+    files = sorted(root.rglob('*.h'))
+    print(f"Checking {len(files)} header files in '{root}/' ...")
+
+    error_count = 0
+
+    for path in files:
+        for file_path, line, guard, expected, snip in check_file(path):
+            error_count += 1
+
+            reason = (
+                'LASX (or mixed LSX+LASX)'
+                if expected == 'SIMDE_LOONGARCH_LASX_NATIVE'
+                else 'LSX-only'
+            )
+
+            print(f"\n{'=' * 72}")
+            print(f'[{error_count}] {file_path}:{line}')
+            print(f'    Guard:    {guard}')
+            print(f'    Expected: {expected}')
+            print(f'    Reason:   Block contains {reason} intrinsics')
+            print(f"    Code:\n{'-' * 72}")
+            print(snip)
+            print('=' * 72)
+
+    if error_count == 0:
+        print('PASSED: All LoongArch intrinsic guards are consistent.')
+        return 0
+
+    print(f'\nFAILED: {error_count} error(s) found')
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This PR fixes a conditional compilation typo in `simde/x86/sse.h`. Previously, the native LoongArch implementation was guarded by `SIMDE_LOONGARCH_LASX_NATIVE`, but it calls `__lsx_vfdiv_s`, which is an **LSX** intrinsic, not LASX. 

According to the [Unofficial LoongArch Intrinsics Guide](https://jia.je/unofficial-loongarch-intrinsics-guide/lsx/float_computation/#__m128-__lsx_vfdiv_s-__m128-a-__m128-b), `__lsx_vfdiv_s` is explicitly part of the LSX instruction set.


Fixes #1394
