### PR TITLE
Enhance simde/x86/gfni.h

### DIFF
--- a/simde/x86/gfni.h
+++ b/simde/x86/gfni.h
@@ -954,28 +954,6 @@ simde_x_mm_gf2p8inverse_epi8 (simde__m128i x) {
   #elif defined(SIMDE_X_GFNI_HAVE_SHUFFLE)
     return simde_x_mm_gf2p8inverse_tower(x);
   #else
-  #if defined(SIMDE_X86_SSE4_1_NATIVE)
-    /* N.B. CM: this fallback may not be faster */
-    simde__m128i r, u, t, test;
-    const simde__m128i sixteens = simde_mm_set1_epi8(16);
-    const simde__m128i masked_x = simde_mm_and_si128(x, simde_mm_set1_epi8(0x0F));
-
-    test = simde_mm_set1_epi8(INT8_MIN /* 0x80 */);
-    x = simde_mm_xor_si128(x, test);
-    r = simde_mm_shuffle_epi8(simde_x_gf2p8inverse_lut.m128i[0], masked_x);
-
-    #if !defined(__INTEL_COMPILER)
-      SIMDE_VECTORIZE
-    #endif
-    for (int i = 1 ; i < 16 ; i++) {
-      t = simde_mm_shuffle_epi8(simde_x_gf2p8inverse_lut.m128i[i], masked_x);
-      test = simde_mm_add_epi8(test, sixteens);
-      u = simde_mm_cmplt_epi8(x, test);
-      r = simde_mm_blendv_epi8(t, r, u);
-    }
-
-    return r;
-  #else
     simde__m128i_private
       r_,
       x_ = simde__m128i_to_private(x);
@@ -989,34 +967,11 @@ simde_x_mm_gf2p8inverse_epi8 (simde__m128i x) {
 
     return simde__m128i_from_private(r_);
   #endif
-  #endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m256i
 simde_x_mm256_gf2p8inverse_epi8 (simde__m256i x) {
-  #if defined(SIMDE_X86_AVX2_NATIVE)
-    /* N.B. CM: this fallback may not be faster */
-    simde__m256i r, u, t, test;
-    const simde__m256i sixteens = simde_mm256_set1_epi8(16);
-    const simde__m256i masked_x = simde_mm256_and_si256(x, simde_mm256_set1_epi8(0x0F));
-
-    test = simde_mm256_set1_epi8(INT8_MIN /* 0x80 */);
-    x = simde_mm256_xor_si256(x, test);
-    r = simde_mm256_shuffle_epi8(simde_mm256_broadcastsi128_si256(simde_x_gf2p8inverse_lut.m128i[0]), masked_x);
-
-    #if !defined(__INTEL_COMPILER)
-      SIMDE_VECTORIZE
-    #endif
-    for (int i = 1 ; i < 16 ; i++) {
-      t = simde_mm256_shuffle_epi8(simde_mm256_broadcastsi128_si256(simde_x_gf2p8inverse_lut.m128i[i]), masked_x);
-      test = simde_mm256_add_epi8(test, sixteens);
-      u = simde_mm256_cmpgt_epi8(test, x);
-      r = simde_mm256_blendv_epi8(t, r, u);
-    }
-
-    return r;
-  #else
     simde__m256i_private
       r_,
       x_ = simde__m256i_to_private(x);
@@ -1029,33 +984,11 @@ simde_x_mm256_gf2p8inverse_epi8 (simde__m256i x) {
     }
 
     return simde__m256i_from_private(r_);
-  #endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m512i
 simde_x_mm512_gf2p8inverse_epi8 (simde__m512i x) {
-  /* N.B. CM: TODO: later add VBMI version using just two _mm512_permutex2var_epi8 and friends */
-  /* But except for Cannon Lake all processors with VBMI also have GFNI */
-  #if defined(SIMDE_X86_AVX512BW_NATIVE)
-    /* N.B. CM: this fallback may not be faster */
-    simde__m512i r, test;
-    const simde__m512i sixteens = simde_mm512_set1_epi8(16);
-    const simde__m512i masked_x = simde_mm512_and_si512(x, simde_mm512_set1_epi8(0x0F));
-
-    r = simde_mm512_shuffle_epi8(simde_mm512_broadcast_i32x4(simde_x_gf2p8inverse_lut.m128i[0]), masked_x);
-    test = sixteens;
-
-    #if !defined(__INTEL_COMPILER)
-      SIMDE_VECTORIZE
-    #endif
-    for (int i = 1 ; i < 16 ; i++) {
-      r = simde_mm512_mask_shuffle_epi8(r, simde_mm512_cmpge_epu8_mask(x, test), simde_mm512_broadcast_i32x4(simde_x_gf2p8inverse_lut.m128i[i]), masked_x);
-      test = simde_mm512_add_epi8(test, sixteens);
-    }
-
-    return r;
-  #else
     simde__m512i_private
       r_,
       x_ = simde__m512i_to_private(x);
@@ -1068,7 +1001,6 @@ simde_x_mm512_gf2p8inverse_epi8 (simde__m512i x) {
     }
 
     return simde__m512i_from_private(r_);
-  #endif
 }
 
 #define simde_x_mm_gf2p8matrix_multiply_inverse_epi64_epi8(x, A) simde_x_mm_gf2p8matrix_multiply_epi64_epi8(simde_x_mm_gf2p8inverse_epi8(x), A)

--- a/simde/x86/gfni.h
+++ b/simde/x86/gfni.h
@@ -531,6 +531,20 @@ simde_x_mm_gf2p8affineinv_tower_const (simde__m128i x, uint64_t M, int b) {
   return simde_mm_xor_si128(simde_mm_shuffle_epi8(fused_lo, iL),
                             simde_mm_shuffle_epi8(fused_hi, iH));
 }
+
+/* GF(2^8) multiply via the tower field (Karatsuba over GF(2^4)). */
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_gf2p8mul_tower (simde__m128i a, simde__m128i b) {
+  simde__m128i aL = simde_x_mm_gf2p8_tower_lo(a), aH = simde_x_mm_gf2p8_tower_hi(a);
+  simde__m128i bL = simde_x_mm_gf2p8_tower_lo(b), bH = simde_x_mm_gf2p8_tower_hi(b);
+  simde__m128i p = simde_x_mm_gf2p4_mul(aL, bL);
+  simde__m128i q = simde_x_mm_gf2p4_mul(aH, bH);
+  simde__m128i r = simde_x_mm_gf2p4_mul(simde_mm_xor_si128(aH, aL), simde_mm_xor_si128(bH, bL));
+  simde__m128i oH = simde_mm_xor_si128(r, p);
+  simde__m128i oL = simde_mm_xor_si128(p, simde_mm_shuffle_epi8(simde_x_gf2p4_mulnu.m128i, q));
+  return simde_x_mm_gf2p8_tower_join(oH, oL);
+}
 #endif /* SIMDE_X_GFNI_HAVE_SHUFFLE */
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -1592,6 +1606,8 @@ simde__m128i simde_mm_gf2p8mul_epi8 (simde__m128i a, simde__m128i b) {
 
     return simde_mm_xor_si128(simde_mm256_extracti128_si256(r2, 1),
                               simde_mm256_extracti128_si256(r2, 0));
+    #elif defined(SIMDE_X_GFNI_HAVE_SHUFFLE)
+      return simde_x_mm_gf2p8mul_tower(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     simde__m128i r, t;
     const simde__m128i zero = simde_mm_setzero_si128();

--- a/simde/x86/gfni.h
+++ b/simde/x86/gfni.h
@@ -399,6 +399,33 @@ simde_x_mm_gf2p8_tower_join (simde__m128i h, simde__m128i l) {
                             simde_mm_shuffle_epi8(simde_x_gf2p4_from_h.m128i, h));
 }
 
+/* Fused tower-affine tables for constant-M SHUFFLE path: apply M to the
+ * tower inverse's intermediate results directly, eliminating tower_join. */
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_gf2p8_fused_tower_lo (uint64_t M, uint8_t c) {
+  #define SIMDE_X_GFNI_FROW(n) HEDLEY_STATIC_CAST(int8_t, simde_x_gf2p8_apply_matrix_byte(M, simde_x_gf2p4_from_l.u8[(n)]) ^ (c))
+  simde__m128i r = simde_mm_set_epi8(
+    SIMDE_X_GFNI_FROW(15), SIMDE_X_GFNI_FROW(14), SIMDE_X_GFNI_FROW(13), SIMDE_X_GFNI_FROW(12),
+    SIMDE_X_GFNI_FROW(11), SIMDE_X_GFNI_FROW(10), SIMDE_X_GFNI_FROW( 9), SIMDE_X_GFNI_FROW( 8),
+    SIMDE_X_GFNI_FROW( 7), SIMDE_X_GFNI_FROW( 6), SIMDE_X_GFNI_FROW( 5), SIMDE_X_GFNI_FROW( 4),
+    SIMDE_X_GFNI_FROW( 3), SIMDE_X_GFNI_FROW( 2), SIMDE_X_GFNI_FROW( 1), SIMDE_X_GFNI_FROW( 0));
+  #undef SIMDE_X_GFNI_FROW
+  return r;
+}
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_gf2p8_fused_tower_hi (uint64_t M) {
+  #define SIMDE_X_GFNI_FROW(n) HEDLEY_STATIC_CAST(int8_t, simde_x_gf2p8_apply_matrix_byte(M, simde_x_gf2p4_from_h.u8[(n)]))
+  simde__m128i r = simde_mm_set_epi8(
+    SIMDE_X_GFNI_FROW(15), SIMDE_X_GFNI_FROW(14), SIMDE_X_GFNI_FROW(13), SIMDE_X_GFNI_FROW(12),
+    SIMDE_X_GFNI_FROW(11), SIMDE_X_GFNI_FROW(10), SIMDE_X_GFNI_FROW( 9), SIMDE_X_GFNI_FROW( 8),
+    SIMDE_X_GFNI_FROW( 7), SIMDE_X_GFNI_FROW( 6), SIMDE_X_GFNI_FROW( 5), SIMDE_X_GFNI_FROW( 4),
+    SIMDE_X_GFNI_FROW( 3), SIMDE_X_GFNI_FROW( 2), SIMDE_X_GFNI_FROW( 1), SIMDE_X_GFNI_FROW( 0));
+  #undef SIMDE_X_GFNI_FROW
+  return r;
+}
+
 /* GF(2^8) inverse via the GF((2^4)^2) tower field (no AES needed). */
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
@@ -447,6 +474,62 @@ simde_x_mm_gf2p8inverse_tower (simde__m128i x) {
   iL = simde_mm_andnot_si128(z, iL);
 
   return simde_x_mm_gf2p8_tower_join(iH, iL);
+}
+
+/* affineinv with constant M via the fused tower path (SHUFFLE without AES).
+ * Computes tower inverse then applies M directly to (iH, iL) instead of
+ * tower_join, using the compile-time fused tables. */
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_gf2p8affineinv_tower_const (simde__m128i x, uint64_t M, int b) {
+  const simde__m128i zero = simde_mm_setzero_si128();
+  simde__m128i aL = simde_x_mm_gf2p8_tower_lo(x);
+  simde__m128i aH = simde_x_mm_gf2p8_tower_hi(x);
+
+  /* Inline delta multiply: compute log(aH), cache it and z_aH for later reuse. */
+  simde__m128i log_aH = simde_mm_shuffle_epi8(simde_x_gf2p4_log.m128i, aH);
+  simde__m128i z_aH = simde_mm_cmpeq_epi8(aH, zero);
+  simde__m128i log_aL = simde_mm_shuffle_epi8(simde_x_gf2p4_log.m128i, aL);
+  simde__m128i idx = simde_mm_add_epi8(log_aH, log_aL);
+  simde__m128i ge = simde_mm_cmpgt_epi8(idx, simde_mm_set1_epi8(14));
+  idx = simde_mm_sub_epi8(idx, simde_mm_and_si128(ge, simde_mm_set1_epi8(15)));
+  simde__m128i mul_aHaL = simde_mm_shuffle_epi8(simde_x_gf2p4_exp.m128i, idx);
+  simde__m128i z = simde_mm_or_si128(z_aH, simde_mm_cmpeq_epi8(aL, zero));
+  mul_aHaL = simde_mm_andnot_si128(z, mul_aHaL);
+
+  /* delta = a_H^2 . nu ^ a_H . a_L ^ a_L^2 (3-way XOR -> EOR3 on ARM SHA3) */
+  simde__m128i delta = simde_x_gfni_xor3(
+    simde_mm_shuffle_epi8(simde_x_gf2p4_mulnusq.m128i, aH),
+    mul_aHaL,
+    simde_mm_shuffle_epi8(simde_x_gf2p4_sqr.m128i, aL));
+
+  /* Negated-log inversion: log(x^-1) = log(x) XOR 0x0F in GF(2^4)* (order 15). */
+  simde__m128i neg_log_delta = simde_mm_xor_si128(
+    simde_mm_shuffle_epi8(simde_x_gf2p4_log.m128i, delta),
+    simde_mm_set1_epi8(0x0F));
+
+  /* iH = aH * delta^-1, reusing cached log_aH, zero mask checks aH only. */
+  idx = simde_mm_add_epi8(log_aH, neg_log_delta);
+  ge = simde_mm_cmpgt_epi8(idx, simde_mm_set1_epi8(14));
+  idx = simde_mm_sub_epi8(idx, simde_mm_and_si128(ge, simde_mm_set1_epi8(15)));
+  simde__m128i iH = simde_mm_shuffle_epi8(simde_x_gf2p4_exp.m128i, idx);
+  iH = simde_mm_andnot_si128(z_aH, iH);
+
+  /* iL = (aH ^ aL) * delta^-1, zero mask checks (aH ^ aL) only. */
+  simde__m128i aHxaL = simde_mm_xor_si128(aH, aL);
+  simde__m128i log_aHxaL = simde_mm_shuffle_epi8(simde_x_gf2p4_log.m128i, aHxaL);
+  idx = simde_mm_add_epi8(log_aHxaL, neg_log_delta);
+  ge = simde_mm_cmpgt_epi8(idx, simde_mm_set1_epi8(14));
+  idx = simde_mm_sub_epi8(idx, simde_mm_and_si128(ge, simde_mm_set1_epi8(15)));
+  simde__m128i iL = simde_mm_shuffle_epi8(simde_x_gf2p4_exp.m128i, idx);
+  z = simde_mm_cmpeq_epi8(aHxaL, zero);
+  iL = simde_mm_andnot_si128(z, iL);
+
+  /* Fused output: apply M to (iH, iL) directly instead of tower_join then M. */
+  const simde__m128i fused_lo = simde_x_gf2p8_fused_tower_lo(M, HEDLEY_STATIC_CAST(uint8_t, b));
+  const simde__m128i fused_hi = simde_x_gf2p8_fused_tower_hi(M);
+  return simde_mm_xor_si128(simde_mm_shuffle_epi8(fused_lo, iL),
+                            simde_mm_shuffle_epi8(fused_hi, iH));
 }
 #endif /* SIMDE_X_GFNI_HAVE_SHUFFLE */
 
@@ -1114,6 +1197,12 @@ simde_mm_gf2p8affineinv_epi64_epi8 (simde__m128i x, simde__m128i A, int b)
     if (SIMDE_CHECK_CONSTANT_(cA_.u64[0]) && SIMDE_CHECK_CONSTANT_(cA_.u64[1]) && (cA_.u64[0] == cA_.u64[1]) && SIMDE_CHECK_CONSTANT_(b)) {
       return simde_x_mm_gf2p8affineinv_const(x, cA_.u64[0], b);
     }
+  #elif defined(SIMDE_X_GFNI_HAVE_SHUFFLE) && defined(SIMDE_CHECK_CONSTANT_)
+    /* constant matrix: fused tower path (SHUFFLE without AES) */
+    simde__m128i_private cA_ = simde__m128i_to_private(A);
+    if (SIMDE_CHECK_CONSTANT_(cA_.u64[0]) && SIMDE_CHECK_CONSTANT_(cA_.u64[1]) && (cA_.u64[0] == cA_.u64[1]) && SIMDE_CHECK_CONSTANT_(b)) {
+      return simde_x_mm_gf2p8affineinv_tower_const(x, cA_.u64[0], b);
+    }
   #endif
   return simde_mm_xor_si128(simde_x_mm_gf2p8matrix_multiply_inverse_epi64_epi8(x, A), simde_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, b)));
 }
@@ -1137,6 +1226,16 @@ simde_mm256_gf2p8affineinv_epi64_epi8 (simde__m256i x, simde__m256i A, int b)
       simde__m256i_private r_, x_ = simde__m256i_to_private(x);
       r_.m128i[0] = simde_x_mm_gf2p8affineinv_const(x_.m128i[0], cA_.u64[0], b);
       r_.m128i[1] = simde_x_mm_gf2p8affineinv_const(x_.m128i[1], cA_.u64[0], b);
+      return simde__m256i_from_private(r_);
+    }
+  #elif defined(SIMDE_X_GFNI_HAVE_SHUFFLE) && defined(SIMDE_CHECK_CONSTANT_)
+    simde__m256i_private cA_ = simde__m256i_to_private(A);
+    if (SIMDE_CHECK_CONSTANT_(cA_.u64[0]) && SIMDE_CHECK_CONSTANT_(cA_.u64[1]) &&
+        SIMDE_CHECK_CONSTANT_(cA_.u64[2]) && SIMDE_CHECK_CONSTANT_(cA_.u64[3]) && SIMDE_CHECK_CONSTANT_(b) &&
+        (cA_.u64[0] == cA_.u64[1]) && (cA_.u64[0] == cA_.u64[2]) && (cA_.u64[0] == cA_.u64[3])) {
+      simde__m256i_private r_, x_ = simde__m256i_to_private(x);
+      r_.m128i[0] = simde_x_mm_gf2p8affineinv_tower_const(x_.m128i[0], cA_.u64[0], b);
+      r_.m128i[1] = simde_x_mm_gf2p8affineinv_tower_const(x_.m128i[1], cA_.u64[0], b);
       return simde__m256i_from_private(r_);
     }
   #endif
@@ -1165,6 +1264,19 @@ simde_mm512_gf2p8affineinv_epi64_epi8 (simde__m512i x, simde__m512i A, int b)
       simde__m512i_private r_, x_ = simde__m512i_to_private(x);
       for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++)
         r_.m128i[i] = simde_x_mm_gf2p8affineinv_const(x_.m128i[i], cA_.u64[0], b);
+      return simde__m512i_from_private(r_);
+    }
+  #elif defined(SIMDE_X_GFNI_HAVE_SHUFFLE) && defined(SIMDE_CHECK_CONSTANT_)
+    simde__m512i_private cA_ = simde__m512i_to_private(A);
+    if (SIMDE_CHECK_CONSTANT_(cA_.u64[0]) && SIMDE_CHECK_CONSTANT_(cA_.u64[1]) &&
+        SIMDE_CHECK_CONSTANT_(cA_.u64[2]) && SIMDE_CHECK_CONSTANT_(cA_.u64[3]) &&
+        SIMDE_CHECK_CONSTANT_(cA_.u64[4]) && SIMDE_CHECK_CONSTANT_(cA_.u64[5]) &&
+        SIMDE_CHECK_CONSTANT_(cA_.u64[6]) && SIMDE_CHECK_CONSTANT_(cA_.u64[7]) && SIMDE_CHECK_CONSTANT_(b) &&
+        (cA_.u64[0] == cA_.u64[1]) && (cA_.u64[0] == cA_.u64[2]) && (cA_.u64[0] == cA_.u64[3]) &&
+        (cA_.u64[0] == cA_.u64[4]) && (cA_.u64[0] == cA_.u64[5]) && (cA_.u64[0] == cA_.u64[6]) && (cA_.u64[0] == cA_.u64[7])) {
+      simde__m512i_private r_, x_ = simde__m512i_to_private(x);
+      for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++)
+        r_.m128i[i] = simde_x_mm_gf2p8affineinv_tower_const(x_.m128i[i], cA_.u64[0], b);
       return simde__m512i_from_private(r_);
     }
   #endif

--- a/simde/x86/gfni.h
+++ b/simde/x86/gfni.h
@@ -900,26 +900,6 @@ simde_x_mm256_gf2p8matrix_multiply_epi64_epi8 (simde__m256i x, simde__m256i A) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m512i
 simde_x_mm512_gf2p8matrix_multiply_epi64_epi8 (simde__m512i x, simde__m512i A) {
-  #if defined(SIMDE_X86_AVX512BW_NATIVE)
-    simde__m512i r, a, p;
-    const simde__m512i byte_select = simde_x_mm512_set_epu64(UINT64_C(0x0707070707070707), UINT64_C(0x0606060606060606), UINT64_C(0x0505050505050505), UINT64_C(0x0404040404040404),
-                                                             UINT64_C(0x0303030303030303), UINT64_C(0x0202020202020202), UINT64_C(0x0101010101010101), UINT64_C(0X0000000000000000));
-    a = simde_mm512_shuffle_epi8(A, simde_mm512_broadcast_i32x4(simde_x_mm_set_epu64x(UINT64_C(0x08090A0B0C0D0E0F), UINT64_C(0x0001020304050607))));
-    r = simde_mm512_setzero_si512();
-
-    #if !defined(__INTEL_COMPILER)
-      SIMDE_VECTORIZE
-    #endif
-    for (int i = 0 ; i < 8 ; i++) {
-      p = simde_mm512_set1_epi64(HEDLEY_STATIC_CAST(int64_t, simde_mm512_movepi8_mask(a)));
-      p = simde_mm512_maskz_shuffle_epi8(simde_mm512_movepi8_mask(x), p, byte_select);
-      r = simde_mm512_xor_si512(r, p);
-      a = simde_mm512_add_epi8(a, a);
-      x = simde_mm512_add_epi8(x, x);
-    }
-
-    return r;
-  #else
     simde__m512i_private
       r_,
       x_ = simde__m512i_to_private(x),
@@ -933,7 +913,6 @@ simde_x_mm512_gf2p8matrix_multiply_epi64_epi8 (simde__m512i x, simde__m512i A) {
     }
 
     return simde__m512i_from_private(r_);
-  #endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -1391,153 +1370,6 @@ simde__m128i simde_mm_gf2p8mul_epi8 (simde__m128i a, simde__m128i b) {
     lo = lo ^ vec_perm(reduceLutHi, reduceLutHi, vec_rli(hi, 4));
     lo = lo ^ vec_perm(reduceLutLo, reduceLutLo, hi);
     return simde__m128i_from_altivec_u8(lo);
-  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-    SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) x, y, r, t, m;
-    x = simde__m128i_to_altivec_u8(a);
-    y = simde__m128i_to_altivec_u8(b);
-
-    const SIMDE_POWER_ALTIVEC_VECTOR(signed char) zero = vec_splat_s8(0);
-
-    m = vec_splat_u8(0x01);
-
-    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) fgp = vec_splats(HEDLEY_STATIC_CAST(unsigned char, SIMDE_X86_GFNI_FGP));
-    t = vec_and(y, m);
-    t = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), vec_cmpeq(t, m));
-    r = vec_and(x, t);
-
-    #if !defined(__INTEL_COMPILER)
-      SIMDE_VECTORIZE
-    #endif
-    for (int i = 0 ; i < 7 ; i++) {
-      t = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), vec_cmplt(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), x), zero));
-      x = vec_add(x, x);
-      t = vec_and(fgp, t);
-      x = vec_xor(x, t);
-      m = vec_add(m, m);
-      t = vec_and(y, m);
-      t = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), vec_cmpeq(t, m));
-      t = vec_and(x, t);
-      r = vec_xor(r, t);
-    }
-
-    return simde__m128i_from_altivec_u8(r);
-  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-    v128_t x, y, r, t, m;
-    x = simde__m128i_to_wasm_v128(a);
-    y = simde__m128i_to_wasm_v128(b);
-
-    m = wasm_i8x16_splat(0x01);
-
-    const v128_t fgp = wasm_i8x16_splat(SIMDE_X86_GFNI_FGP);
-
-    t = wasm_v128_and(y, m);
-    t = wasm_i8x16_eq(t, m);
-    r = wasm_v128_and(x, t);
-
-    #if !defined(__INTEL_COMPILER)
-      SIMDE_VECTORIZE
-    #endif
-    for (int i = 0 ; i < 7 ; i++) {
-      t = wasm_i8x16_shr(x, 7);
-      x = wasm_i8x16_add(x, x);
-      t = wasm_v128_and(fgp, t);
-      x = wasm_v128_xor(x, t);
-      m = wasm_i8x16_add(m, m);
-      t = wasm_v128_and(y, m);
-      t = wasm_i8x16_eq(t, m);
-      t = wasm_v128_and(x, t);
-      r = wasm_v128_xor(r, t);
-    }
-
-    return simde__m128i_from_wasm_v128(r);
-  #elif defined(SIMDE_X86_AVX512BW_NATIVE)
-    simde__m512i r4, t4, u4;
-    simde__mmask64 ma, mb;
-
-    simde__m512i a4 = simde_mm512_broadcast_i32x4(a);
-    const simde__m512i zero = simde_mm512_setzero_si512();
-    simde__mmask16 m8 = simde_mm512_cmpeq_epi32_mask(zero, zero);
-
-    const simde__m512i b4 = simde_mm512_broadcast_i32x4(b);
-
-    simde__m512i bits = simde_mm512_set_epi64(0x4040404040404040,
-                                              0x4040404040404040,
-                                              0x1010101010101010,
-                                              0x1010101010101010,
-                                              0x0404040404040404,
-                                              0x0404040404040404,
-                                              0x0101010101010101,
-                                              0x0101010101010101);
-
-    const simde__m512i fgp = simde_mm512_set1_epi8(SIMDE_X86_GFNI_FGP);
-
-    for (int i = 0 ; i < 3 ; i++) {
-      m8 = simde_kshiftli_mask16(m8, 4);
-
-      ma = simde_mm512_cmplt_epi8_mask(a4, zero);
-      u4 = simde_mm512_add_epi8(a4, a4);
-      t4 = simde_mm512_maskz_mov_epi8(ma, fgp);
-      u4 = simde_mm512_xor_epi32(u4, t4);
-
-      ma = simde_mm512_cmplt_epi8_mask(u4, zero);
-      u4 = simde_mm512_add_epi8(u4, u4);
-      t4 = simde_mm512_maskz_mov_epi8(ma, fgp);
-      a4 = simde_mm512_mask_xor_epi32(a4, m8, u4, t4);
-    }
-
-    mb = simde_mm512_test_epi8_mask(b4, bits);
-    bits = simde_mm512_add_epi8(bits, bits);
-    ma = simde_mm512_cmplt_epi8_mask(a4, zero);
-    r4 = simde_mm512_maskz_mov_epi8(mb, a4);
-    mb = simde_mm512_test_epi8_mask(b4, bits);
-    a4 = simde_mm512_add_epi8(a4, a4);
-    t4 = simde_mm512_maskz_mov_epi8(ma, fgp);
-    a4 = simde_mm512_xor_si512(a4, t4);
-    t4 = simde_mm512_maskz_mov_epi8(mb, a4);
-    r4 = simde_mm512_xor_si512(r4, t4);
-
-    r4 = simde_mm512_xor_si512(r4, simde_mm512_shuffle_i32x4(r4, r4, (1 << 6) + (0 << 4) + (3 << 2) + 2));
-    r4 = simde_mm512_xor_si512(r4, simde_mm512_shuffle_i32x4(r4, r4, (0 << 6) + (3 << 4) + (2 << 2) + 1));
-
-    return simde_mm512_extracti32x4_epi32(r4, 0);
-  #elif defined(SIMDE_X86_AVX2_NATIVE)
-    simde__m256i r2, t2;
-    simde__m256i a2 = simde_mm256_broadcastsi128_si256(a);
-    const simde__m256i zero = simde_mm256_setzero_si256();
-    const simde__m256i fgp = simde_mm256_set1_epi8(SIMDE_X86_GFNI_FGP);
-    const simde__m256i ones = simde_mm256_set1_epi8(0x01);
-    simde__m256i b2 = simde_mm256_set_m128i(simde_mm_srli_epi64(b, 4), b);
-
-    for (int i = 0 ; i < 4 ; i++) {
-      t2 = simde_mm256_cmpgt_epi8(zero, a2);
-      t2 = simde_mm256_and_si256(fgp, t2);
-      a2 = simde_mm256_add_epi8(a2, a2);
-      a2 = simde_mm256_xor_si256(a2, t2);
-    }
-
-    a2 = simde_mm256_inserti128_si256(a2, a, 0);
-
-    t2 = simde_mm256_and_si256(b2, ones);
-    t2 = simde_mm256_cmpeq_epi8(t2, ones);
-    r2 = simde_mm256_and_si256(a2, t2);
-
-    #if !defined(__INTEL_COMPILER)
-      SIMDE_VECTORIZE
-    #endif
-    for (int i = 0 ; i < 3 ; i++) {
-      t2 = simde_mm256_cmpgt_epi8(zero, a2);
-      t2 = simde_mm256_and_si256(fgp, t2);
-      a2 = simde_mm256_add_epi8(a2, a2);
-      a2 = simde_mm256_xor_si256(a2, t2);
-      b2 = simde_mm256_srli_epi64(b2, 1);
-      t2 = simde_mm256_and_si256(b2, ones);
-      t2 = simde_mm256_cmpeq_epi8(t2, ones);
-      t2 = simde_mm256_and_si256(a2, t2);
-      r2 = simde_mm256_xor_si256(r2, t2);
-    }
-
-    return simde_mm_xor_si128(simde_mm256_extracti128_si256(r2, 1),
-                              simde_mm256_extracti128_si256(r2, 0));
     #elif defined(SIMDE_X_GFNI_HAVE_SHUFFLE)
       return simde_x_mm_gf2p8mul_tower(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
@@ -1607,73 +1439,6 @@ simde__m256i
 simde_mm256_gf2p8mul_epi8 (simde__m256i a, simde__m256i b) {
   #if defined(SIMDE_X86_GFNI_NATIVE) && (defined(SIMDE_X86_AVX512VL_NATIVE) || (defined(SIMDE_X86_AVX_NATIVE) && !defined(SIMDE_X86_AVX512F_NATIVE)))
     return _mm256_gf2p8mul_epi8(a, b);
-  #elif !defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
-    simde__mmask64 ma, mb;
-    simde__m512i r, t, s;
-    simde__m512i a2 = simde_mm512_broadcast_i64x4(a);
-    const simde__m512i zero = simde_mm512_setzero_si512();
-
-    const simde__m512i fgp = simde_mm512_set1_epi8(SIMDE_X86_GFNI_FGP);
-
-    s = simde_mm512_set1_epi8(0x01);
-
-    for (int i = 0 ; i < 4 ; i++) {
-      ma = simde_mm512_cmplt_epi8_mask(a2, zero);
-      a2 = simde_mm512_add_epi8(a2, a2);
-      t = simde_mm512_xor_si512(a2, fgp);
-      a2 = simde_mm512_mask_mov_epi8(a2, ma, t);
-    }
-
-    simde__m512i b2 = simde_mm512_inserti64x4(zero, simde_mm256_srli_epi64(b, 4), 1);
-    b2 = simde_mm512_inserti64x4(b2, b, 0);
-    a2 = simde_mm512_inserti64x4(a2, a, 0);
-
-    mb = simde_mm512_test_epi8_mask(b2, s);
-    r = simde_mm512_maskz_mov_epi8(mb, a2);
-
-    #if !defined(__INTEL_COMPILER)
-      SIMDE_VECTORIZE
-    #endif
-    for (int i = 0 ; i < 3 ; i++) {
-      ma = simde_mm512_cmplt_epi8_mask(a2, zero);
-      s = simde_mm512_add_epi8(s, s);
-      mb = simde_mm512_test_epi8_mask(b2, s);
-      a2 = simde_mm512_add_epi8(a2, a2);
-      t = simde_mm512_maskz_mov_epi8(ma, fgp);
-      a2 = simde_mm512_xor_si512(a2, t);
-      t = simde_mm512_maskz_mov_epi8(mb, a2);
-      r = simde_mm512_xor_si512(r, t);
-    }
-
-    return simde_mm256_xor_si256(simde_mm512_extracti64x4_epi64(r, 1),
-                                 simde_mm512_extracti64x4_epi64(r, 0));
-  #elif !defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX2_NATIVE)
-    simde__m256i r, t;
-    const simde__m256i zero = simde_mm256_setzero_si256();
-    const simde__m256i ones = simde_mm256_set1_epi8(0x01);
-
-    const simde__m256i fgp = simde_mm256_set1_epi8(SIMDE_X86_GFNI_FGP);
-
-    t = simde_mm256_and_si256(b, ones);
-    t = simde_mm256_cmpeq_epi8(t, ones);
-    r = simde_mm256_and_si256(a, t);
-
-    #if !defined(__INTEL_COMPILER)
-      SIMDE_VECTORIZE
-    #endif
-    for (int i = 0 ; i < 7 ; i++) {
-      t = simde_mm256_cmpgt_epi8(zero, a);
-      t = simde_mm256_and_si256(fgp, t);
-      a = simde_mm256_add_epi8(a, a);
-      a = simde_mm256_xor_si256(a, t);
-      b = simde_mm256_srli_epi64(b, 1);
-      t = simde_mm256_and_si256(b, ones);
-      t = simde_mm256_cmpeq_epi8(t, ones);
-      t = simde_mm256_and_si256(a, t);
-      r = simde_mm256_xor_si256(r, t);
-    }
-
-    return r;
   #else
     simde__m256i_private
       r_,
@@ -1700,33 +1465,6 @@ simde__m512i
 simde_mm512_gf2p8mul_epi8 (simde__m512i a, simde__m512i b) {
   #if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
     return _mm512_gf2p8mul_epi8(a, b);
-  #elif !defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
-    simde__m512i r, s, t;
-    simde__mmask64 ma, mb;
-    const simde__m512i zero = simde_mm512_setzero_si512();
-
-    const simde__m512i fgp = simde_mm512_set1_epi8(SIMDE_X86_GFNI_FGP);
-
-    s = simde_mm512_set1_epi8(0x01);
-
-    mb = simde_mm512_test_epi8_mask(b, s);
-    r = simde_mm512_maskz_mov_epi8(mb, a);
-
-    #if !defined(__INTEL_COMPILER)
-      SIMDE_VECTORIZE
-    #endif
-    for (int i = 0 ; i < 7 ; i++) {
-      ma = simde_mm512_cmplt_epi8_mask(a, zero);
-      s = simde_mm512_add_epi8(s, s);
-      mb = simde_mm512_test_epi8_mask(b, s);
-      a = simde_mm512_add_epi8(a, a);
-      t = simde_mm512_maskz_mov_epi8(ma, fgp);
-      a = simde_mm512_xor_si512(a, t);
-      t = simde_mm512_maskz_mov_epi8(mb, a);
-      r = simde_mm512_xor_si512(r, t);
-    }
-
-    return r;
   #else
     simde__m512i_private
       r_,

--- a/simde/x86/gfni.h
+++ b/simde/x86/gfni.h
@@ -239,6 +239,19 @@ simde_x_gf2p8_matrix_nibble_hi (uint64_t M) {
   return r;
 }
 
+#if defined(SIMDE_X_GFNI_HAVE_AES)
+/* AES-borrow inverse: inv(a) = A_aes^-1 . (SubBytes(a) ^ 0x63).
+ * SubBytes(a) = InvShiftRows(AESENCLAST(a, 0)). A_aes^-1 is the fixed inverse
+ * AES affine matrix; applied by nibble decomposition with the 0x63 affine
+ * constant folded into the low-nibble table. */
+static const union { uint8_t u8[16]; simde__m128i m128i; } simde_x_gf2p8_inv_undo_sr = { {
+  0, 13, 10, 7, 4, 1, 14, 11, 8, 5, 2, 15, 12, 9, 6, 3 } };
+static const union { uint8_t u8[16]; simde__m128i m128i; } simde_x_gf2p8_inv_tlo = { {
+  0x05, 0x4f, 0x91, 0xdb, 0x2c, 0x66, 0xb8, 0xf2, 0x57, 0x1d, 0xc3, 0x89, 0x7e, 0x34, 0xea, 0xa0 } };
+static const union { uint8_t u8[16]; simde__m128i m128i; } simde_x_gf2p8_inv_thi = { {
+  0x00, 0xa4, 0x49, 0xed, 0x92, 0x36, 0xdb, 0x7f, 0x25, 0x81, 0x6c, 0xc8, 0xb7, 0x13, 0xfe, 0x5a } };
+#endif /* SIMDE_X_GFNI_HAVE_AES */
+
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_x_mm_gf2p8matrix_multiply_epi64_epi8 (simde__m128i x, simde__m128i A) {
@@ -631,6 +644,19 @@ simde_x_mm512_gf2p8matrix_multiply_epi64_epi8 (simde__m512i x, simde__m512i A) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_x_mm_gf2p8inverse_epi8 (simde__m128i x) {
+  #if defined(SIMDE_X_GFNI_HAVE_AES)
+    /* Borrow the AES S-box: AESENCLAST(x, 0) = SubBytes(ShiftRows(x)). Undo
+     * ShiftRows, then inv(x) = A_aes^-1 . (SubBytes(x) ^ 0x63), applied by
+     * nibble decomposition with the 0x63 affine constant folded into the low
+     * table. */
+    simde__m128i s = simde_mm_aesenclast_si128(x, simde_mm_setzero_si128());
+    s = simde_mm_shuffle_epi8(s, simde_x_gf2p8_inv_undo_sr.m128i);
+    const simde__m128i nmask = simde_mm_set1_epi8(0x0F);
+    const simde__m128i lo = simde_mm_and_si128(s, nmask);
+    const simde__m128i hi = simde_mm_and_si128(simde_mm_srli_epi16(s, 4), nmask);
+    return simde_mm_xor_si128(simde_mm_shuffle_epi8(simde_x_gf2p8_inv_tlo.m128i, lo),
+                              simde_mm_shuffle_epi8(simde_x_gf2p8_inv_thi.m128i, hi));
+  #else
   #if defined(SIMDE_X86_SSE4_1_NATIVE)
     /* N.B. CM: this fallback may not be faster */
     simde__m128i r, u, t, test;
@@ -665,6 +691,7 @@ simde_x_mm_gf2p8inverse_epi8 (simde__m128i x) {
     }
 
     return simde__m128i_from_private(r_);
+  #endif
   #endif
 }
 

--- a/simde/x86/gfni.h
+++ b/simde/x86/gfni.h
@@ -41,6 +41,7 @@
 #include "ssse3.h"
 #include "avx.h"
 #include "avx2.h"
+#include "aes.h"
 #include "avx512/types.h"
 #include "avx512/add.h"
 #include "avx512/and.h"
@@ -74,6 +75,21 @@ SIMDE_BEGIN_DECLS_
 
 /* The field generator polynomial is 0x11B but we make the 0x100 bit implicit to fit inside 8 bits */
 #define SIMDE_X86_GFNI_FGP 0x1B
+
+/* Feature groups used by the algorithms below.
+ * SIMDE_X_GFNI_HAVE_AES: a hardware AES S-box is reachable through
+ *   simde_mm_aesenclast_si128 (x86 AES-NI, or ARMv8 crypto). We borrow it to
+ *   compute the GF(2^8) inverse.
+ * SIMDE_X_GFNI_HAVE_SHUFFLE: a byte-shuffle (PSHUFB / TBL / vec_perm / swizzle)
+ *   is available, so the nibble-decomposition and GF((2^4)^2) tower-field
+ *   algorithms can run. These are all expressed through simde_mm_shuffle_epi8
+ *   et al. so a single implementation covers every backend. */
+#if defined(SIMDE_X86_AES_NATIVE) || (defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARCH_ARM_CRYPTO))
+  #define SIMDE_X_GFNI_HAVE_AES
+#endif
+#if defined(SIMDE_X86_SSSE3_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE) || defined(SIMDE_WASM_SIMD128_NATIVE) || defined(SIMDE_MIPS_MSA_NATIVE)
+  #define SIMDE_X_GFNI_HAVE_SHUFFLE
+#endif
 
 /* Computing the inverse of a GF element is expensive so use this LUT for an FGP of 0x11B */
 

--- a/simde/x86/gfni.h
+++ b/simde/x86/gfni.h
@@ -91,8 +91,10 @@ SIMDE_BEGIN_DECLS_
   #define SIMDE_X_GFNI_HAVE_SHUFFLE
 #endif
 
-/* Computing the inverse of a GF element is expensive so use this LUT for an FGP of 0x11B */
-
+/* Computing the inverse of a GF element is expensive so use this LUT for an FGP
+ * of 0x11B. Only the scalar fallback needs it; the AES-borrow and tower-field
+ * paths compute the inverse without a 256-byte table. */
+#if !defined(SIMDE_X_GFNI_HAVE_AES) && !defined(SIMDE_X_GFNI_HAVE_SHUFFLE)
 static const union {
   uint8_t      u8[256];
   simde__m128i m128i[16];
@@ -116,6 +118,7 @@ static const union {
    0x5b, 0x23, 0x38, 0x34, 0x68, 0x46, 0x03, 0x8c, 0xdd, 0x9c, 0x7d, 0xa0, 0xcd, 0x1a, 0x41, 0x1c
   }
 };
+#endif /* scalar inverse LUT */
 
 /* GFNI matrix (qword) for "multiply by the GF(2^8) constant k": column j is
  * k (x) 2^j. Lets a constant-operand GF(2^8) multiply degenerate to an affine
@@ -310,6 +313,142 @@ simde_x_mm_gf2p8affineinv_const (simde__m128i x, uint64_t M, int b) {
   }
 }
 #endif /* SIMDE_X_GFNI_HAVE_AES */
+
+#if defined(SIMDE_X_GFNI_HAVE_SHUFFLE)
+/* Tower field GF(2^8) ~= GF(2^4)[u]/(u^2 + u + nu), nu = 0xB in GF(2^4) with
+ * reduction polynomial 0x13. A byte maps to (a_H, a_L), two GF(2^4) nibbles,
+ * via the (linear) basis change below; the inverse map recombines them. */
+static const union { uint8_t u8[16]; simde__m128i m128i; } simde_x_gf2p4_to_lo   = { {
+  0x00, 0x01, 0x0b, 0x0a, 0x03, 0x02, 0x08, 0x09, 0x09, 0x08, 0x02, 0x03, 0x0a, 0x0b, 0x01, 0x00 } };
+static const union { uint8_t u8[16]; simde__m128i m128i; } simde_x_gf2p4_to_hi   = { {
+  0x00, 0x0b, 0x06, 0x0d, 0x03, 0x08, 0x05, 0x0e, 0x01, 0x0a, 0x07, 0x0c, 0x02, 0x09, 0x04, 0x0f } };
+static const union { uint8_t u8[16]; simde__m128i m128i; } simde_x_gf2p4_toh_lo  = { {
+  0x00, 0x00, 0x02, 0x02, 0x04, 0x04, 0x06, 0x06, 0x04, 0x04, 0x06, 0x06, 0x00, 0x00, 0x02, 0x02 } };
+static const union { uint8_t u8[16]; simde__m128i m128i; } simde_x_gf2p4_toh_hi  = { {
+  0x00, 0x03, 0x0d, 0x0e, 0x03, 0x00, 0x0e, 0x0d, 0x0e, 0x0d, 0x03, 0x00, 0x0d, 0x0e, 0x00, 0x03 } };
+static const union { uint8_t u8[16]; simde__m128i m128i; } simde_x_gf2p4_from_l  = { {
+  0x00, 0x01, 0x5c, 0x5d, 0xe0, 0xe1, 0xbc, 0xbd, 0x50, 0x51, 0x0c, 0x0d, 0xb0, 0xb1, 0xec, 0xed } };
+static const union { uint8_t u8[16]; simde__m128i m128i; } simde_x_gf2p4_from_h  = { {
+  0x00, 0x12, 0x0f, 0x1d, 0x59, 0x4b, 0x56, 0x44, 0xd7, 0xc5, 0xd8, 0xca, 0x8e, 0x9c, 0x81, 0x93 } };
+static const union { uint8_t u8[16]; simde__m128i m128i; } simde_x_gf2p4_sqr     = { {
+  0x00, 0x01, 0x04, 0x05, 0x03, 0x02, 0x07, 0x06, 0x0c, 0x0d, 0x08, 0x09, 0x0f, 0x0e, 0x0b, 0x0a } };
+static const union { uint8_t u8[16]; simde__m128i m128i; } simde_x_gf2p4_mulnu   = { {
+  0x00, 0x0b, 0x05, 0x0e, 0x0a, 0x01, 0x0f, 0x04, 0x07, 0x0c, 0x02, 0x09, 0x0d, 0x06, 0x08, 0x03 } };
+static const union { uint8_t u8[16]; simde__m128i m128i; } simde_x_gf2p4_mulnusq = { {
+  0x00, 0x0b, 0x0a, 0x01, 0x0e, 0x05, 0x04, 0x0f, 0x0d, 0x06, 0x07, 0x0c, 0x03, 0x08, 0x09, 0x02 } };
+static const union { uint8_t u8[16]; simde__m128i m128i; } simde_x_gf2p4_inv     = { {
+  0x00, 0x01, 0x09, 0x0e, 0x0d, 0x0b, 0x07, 0x06, 0x0f, 0x02, 0x0c, 0x05, 0x0a, 0x04, 0x03, 0x08 } };
+static const union { uint8_t u8[16]; simde__m128i m128i; } simde_x_gf2p4_log     = { {
+  0x00, 0x00, 0x01, 0x04, 0x02, 0x08, 0x05, 0x0a, 0x03, 0x0e, 0x09, 0x07, 0x06, 0x0d, 0x0b, 0x0c } };
+static const union { uint8_t u8[16]; simde__m128i m128i; } simde_x_gf2p4_exp     = { {
+  0x01, 0x02, 0x04, 0x08, 0x03, 0x06, 0x0c, 0x0b, 0x05, 0x0a, 0x07, 0x0e, 0x0f, 0x0d, 0x09, 0x00 } };
+#endif /* SIMDE_X_GFNI_HAVE_SHUFFLE */
+
+#if defined(SIMDE_X_GFNI_HAVE_SHUFFLE)
+/* 3-way XOR. Uses ARMv8.2 SHA3 EOR3 when available (one instruction), else two
+ * XORs. On x86 this is just two VPXOR. */
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_gfni_xor3 (simde__m128i a, simde__m128i b, simde__m128i c) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_ARCH_ARM_SHA3)
+    return simde__m128i_from_neon_u8(veor3q_u8(simde__m128i_to_neon_u8(a), simde__m128i_to_neon_u8(b), simde__m128i_to_neon_u8(c)));
+  #else
+    return simde_mm_xor_si128(simde_mm_xor_si128(a, b), c);
+  #endif
+}
+
+/* GF(2^4) multiply (both operands in the low nibble of each byte) via log/exp,
+ * with the exponent reduced mod 15 and a zero mask for the 0 operands. */
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_gf2p4_mul (simde__m128i a, simde__m128i b) {
+  const simde__m128i zero = simde_mm_setzero_si128();
+  simde__m128i la = simde_mm_shuffle_epi8(simde_x_gf2p4_log.m128i, a);
+  simde__m128i lb = simde_mm_shuffle_epi8(simde_x_gf2p4_log.m128i, b);
+  simde__m128i idx = simde_mm_add_epi8(la, lb);
+  simde__m128i ge = simde_mm_cmpgt_epi8(idx, simde_mm_set1_epi8(14));
+  idx = simde_mm_sub_epi8(idx, simde_mm_and_si128(ge, simde_mm_set1_epi8(15)));
+  simde__m128i r = simde_mm_shuffle_epi8(simde_x_gf2p4_exp.m128i, idx);
+  simde__m128i z = simde_mm_or_si128(simde_mm_cmpeq_epi8(a, zero), simde_mm_cmpeq_epi8(b, zero));
+  return simde_mm_andnot_si128(z, r);
+}
+
+/* Basis change between the standard byte and the tower (a_H, a_L) nibbles. */
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_gf2p8_tower_lo (simde__m128i x) {
+  const simde__m128i nmask = simde_mm_set1_epi8(0x0F);
+  const simde__m128i xlo = simde_mm_and_si128(x, nmask);
+  const simde__m128i xhi = simde_mm_and_si128(simde_mm_srli_epi16(x, 4), nmask);
+  return simde_mm_xor_si128(simde_mm_shuffle_epi8(simde_x_gf2p4_to_lo.m128i, xlo),
+                            simde_mm_shuffle_epi8(simde_x_gf2p4_to_hi.m128i, xhi));
+}
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_gf2p8_tower_hi (simde__m128i x) {
+  const simde__m128i nmask = simde_mm_set1_epi8(0x0F);
+  const simde__m128i xlo = simde_mm_and_si128(x, nmask);
+  const simde__m128i xhi = simde_mm_and_si128(simde_mm_srli_epi16(x, 4), nmask);
+  return simde_mm_xor_si128(simde_mm_shuffle_epi8(simde_x_gf2p4_toh_lo.m128i, xlo),
+                            simde_mm_shuffle_epi8(simde_x_gf2p4_toh_hi.m128i, xhi));
+}
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_gf2p8_tower_join (simde__m128i h, simde__m128i l) {
+  return simde_mm_xor_si128(simde_mm_shuffle_epi8(simde_x_gf2p4_from_l.m128i, l),
+                            simde_mm_shuffle_epi8(simde_x_gf2p4_from_h.m128i, h));
+}
+
+/* GF(2^8) inverse via the GF((2^4)^2) tower field (no AES needed). */
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_gf2p8inverse_tower (simde__m128i x) {
+  const simde__m128i zero = simde_mm_setzero_si128();
+  simde__m128i aL = simde_x_mm_gf2p8_tower_lo(x);
+  simde__m128i aH = simde_x_mm_gf2p8_tower_hi(x);
+
+  /* Inline delta multiply: compute log(aH), cache it and z_aH for later reuse. */
+  simde__m128i log_aH = simde_mm_shuffle_epi8(simde_x_gf2p4_log.m128i, aH);
+  simde__m128i z_aH = simde_mm_cmpeq_epi8(aH, zero);
+  simde__m128i log_aL = simde_mm_shuffle_epi8(simde_x_gf2p4_log.m128i, aL);
+  simde__m128i idx = simde_mm_add_epi8(log_aH, log_aL);
+  simde__m128i ge = simde_mm_cmpgt_epi8(idx, simde_mm_set1_epi8(14));
+  idx = simde_mm_sub_epi8(idx, simde_mm_and_si128(ge, simde_mm_set1_epi8(15)));
+  simde__m128i mul_aHaL = simde_mm_shuffle_epi8(simde_x_gf2p4_exp.m128i, idx);
+  simde__m128i z = simde_mm_or_si128(z_aH, simde_mm_cmpeq_epi8(aL, zero));
+  mul_aHaL = simde_mm_andnot_si128(z, mul_aHaL);
+
+  /* delta = a_H^2 . nu ^ a_H . a_L ^ a_L^2 (3-way XOR -> EOR3 on ARM SHA3) */
+  simde__m128i delta = simde_x_gfni_xor3(
+    simde_mm_shuffle_epi8(simde_x_gf2p4_mulnusq.m128i, aH),
+    mul_aHaL,
+    simde_mm_shuffle_epi8(simde_x_gf2p4_sqr.m128i, aL));
+
+  /* Negated-log inversion: log(x^-1) = log(x) XOR 0x0F in GF(2^4)* (order 15). */
+  simde__m128i neg_log_delta = simde_mm_xor_si128(
+    simde_mm_shuffle_epi8(simde_x_gf2p4_log.m128i, delta),
+    simde_mm_set1_epi8(0x0F));
+
+  /* iH = aH * delta^-1, reusing cached log_aH, zero mask checks aH only. */
+  idx = simde_mm_add_epi8(log_aH, neg_log_delta);
+  ge = simde_mm_cmpgt_epi8(idx, simde_mm_set1_epi8(14));
+  idx = simde_mm_sub_epi8(idx, simde_mm_and_si128(ge, simde_mm_set1_epi8(15)));
+  simde__m128i iH = simde_mm_shuffle_epi8(simde_x_gf2p4_exp.m128i, idx);
+  iH = simde_mm_andnot_si128(z_aH, iH);
+
+  /* iL = (aH ^ aL) * delta^-1, zero mask checks (aH ^ aL) only. */
+  simde__m128i aHxaL = simde_mm_xor_si128(aH, aL);
+  simde__m128i log_aHxaL = simde_mm_shuffle_epi8(simde_x_gf2p4_log.m128i, aHxaL);
+  idx = simde_mm_add_epi8(log_aHxaL, neg_log_delta);
+  ge = simde_mm_cmpgt_epi8(idx, simde_mm_set1_epi8(14));
+  idx = simde_mm_sub_epi8(idx, simde_mm_and_si128(ge, simde_mm_set1_epi8(15)));
+  simde__m128i iL = simde_mm_shuffle_epi8(simde_x_gf2p4_exp.m128i, idx);
+  z = simde_mm_cmpeq_epi8(aHxaL, zero);
+  iL = simde_mm_andnot_si128(z, iL);
+
+  return simde_x_mm_gf2p8_tower_join(iH, iL);
+}
+#endif /* SIMDE_X_GFNI_HAVE_SHUFFLE */
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
@@ -715,6 +854,8 @@ simde_x_mm_gf2p8inverse_epi8 (simde__m128i x) {
     const simde__m128i hi = simde_mm_and_si128(simde_mm_srli_epi16(s, 4), nmask);
     return simde_mm_xor_si128(simde_mm_shuffle_epi8(simde_x_gf2p8_inv_tlo.m128i, lo),
                               simde_mm_shuffle_epi8(simde_x_gf2p8_inv_thi.m128i, hi));
+  #elif defined(SIMDE_X_GFNI_HAVE_SHUFFLE)
+    return simde_x_mm_gf2p8inverse_tower(x);
   #else
   #if defined(SIMDE_X86_SSE4_1_NATIVE)
     /* N.B. CM: this fallback may not be faster */

--- a/simde/x86/gfni.h
+++ b/simde/x86/gfni.h
@@ -117,9 +117,67 @@ static const union {
   }
 };
 
+/* Apply one GF(2) affine matrix row-set (a GFNI qword, no constant) to a single
+ * byte. Identical to the scalar reference in the matrix-multiply fallback, so
+ * it can generate the nibble tables for a compile-time-constant matrix. */
+SIMDE_FUNCTION_ATTRIBUTES
+uint8_t
+simde_x_gf2p8_apply_matrix_byte (uint64_t A, uint8_t v) {
+  const uint64_t ones = UINT64_C(0x0101010101010101);
+  const uint64_t mask = UINT64_C(0x0102040810204080);
+  uint64_t q = simde_endian_bswap64_le(A);
+  q &= HEDLEY_STATIC_CAST(uint64_t, v) * ones;
+  q ^= q >> 4; q ^= q >> 2; q ^= q >> 1;
+  q &= ones; q *= 255; q &= mask;
+  q |= q >> 32; q |= q >> 16; q |= q >> 8;
+  return HEDLEY_STATIC_CAST(uint8_t, q);
+}
+
+/* Per-nibble tables for a (compile-time-constant) GF(2) affine matrix M.
+ * M.x == shuffle(lo_table, x & 0xF) ^ shuffle(hi_table, x >> 4). When M is a
+ * constant these fold to constant vectors at compile time. */
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_gf2p8_matrix_nibble_lo (uint64_t M) {
+  #define SIMDE_X_GFNI_MROW(n) HEDLEY_STATIC_CAST(int8_t, simde_x_gf2p8_apply_matrix_byte(M, HEDLEY_STATIC_CAST(uint8_t, (n))))
+  simde__m128i r = simde_mm_set_epi8(
+    SIMDE_X_GFNI_MROW(15), SIMDE_X_GFNI_MROW(14), SIMDE_X_GFNI_MROW(13), SIMDE_X_GFNI_MROW(12),
+    SIMDE_X_GFNI_MROW(11), SIMDE_X_GFNI_MROW(10), SIMDE_X_GFNI_MROW( 9), SIMDE_X_GFNI_MROW( 8),
+    SIMDE_X_GFNI_MROW( 7), SIMDE_X_GFNI_MROW( 6), SIMDE_X_GFNI_MROW( 5), SIMDE_X_GFNI_MROW( 4),
+    SIMDE_X_GFNI_MROW( 3), SIMDE_X_GFNI_MROW( 2), SIMDE_X_GFNI_MROW( 1), SIMDE_X_GFNI_MROW( 0));
+  #undef SIMDE_X_GFNI_MROW
+  return r;
+}
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_gf2p8_matrix_nibble_hi (uint64_t M) {
+  #define SIMDE_X_GFNI_MROW(n) HEDLEY_STATIC_CAST(int8_t, simde_x_gf2p8_apply_matrix_byte(M, HEDLEY_STATIC_CAST(uint8_t, (n) << 4)))
+  simde__m128i r = simde_mm_set_epi8(
+    SIMDE_X_GFNI_MROW(15), SIMDE_X_GFNI_MROW(14), SIMDE_X_GFNI_MROW(13), SIMDE_X_GFNI_MROW(12),
+    SIMDE_X_GFNI_MROW(11), SIMDE_X_GFNI_MROW(10), SIMDE_X_GFNI_MROW( 9), SIMDE_X_GFNI_MROW( 8),
+    SIMDE_X_GFNI_MROW( 7), SIMDE_X_GFNI_MROW( 6), SIMDE_X_GFNI_MROW( 5), SIMDE_X_GFNI_MROW( 4),
+    SIMDE_X_GFNI_MROW( 3), SIMDE_X_GFNI_MROW( 2), SIMDE_X_GFNI_MROW( 1), SIMDE_X_GFNI_MROW( 0));
+  #undef SIMDE_X_GFNI_MROW
+  return r;
+}
+
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_x_mm_gf2p8matrix_multiply_epi64_epi8 (simde__m128i x, simde__m128i A) {
+  #if defined(SIMDE_CHECK_CONSTANT_) && defined(SIMDE_X_GFNI_HAVE_SHUFFLE)
+    /* If the matrix is a compile-time constant (the same for both 64-bit
+     * lanes) we can resolve M.x as M_lo[x & 0xF] ^ M_hi[x >> 4] with two byte
+     * shuffles; the per-nibble tables fold to constants at compile time. */
+    simde__m128i_private cA_ = simde__m128i_to_private(A);
+    if (SIMDE_CHECK_CONSTANT_(cA_.u64[0]) && SIMDE_CHECK_CONSTANT_(cA_.u64[1]) && (cA_.u64[0] == cA_.u64[1])) {
+      const simde__m128i mlo = simde_x_gf2p8_matrix_nibble_lo(cA_.u64[0]);
+      const simde__m128i mhi = simde_x_gf2p8_matrix_nibble_hi(cA_.u64[0]);
+      const simde__m128i nmask = simde_mm_set1_epi8(0x0F);
+      const simde__m128i lo = simde_mm_and_si128(x, nmask);
+      const simde__m128i hi = simde_mm_and_si128(simde_mm_srli_epi16(x, 4), nmask);
+      return simde_mm_xor_si128(simde_mm_shuffle_epi8(mlo, lo), simde_mm_shuffle_epi8(mhi, hi));
+    }
+  #endif
   #if defined(SIMDE_X86_SSSE3_NATIVE)
     const __m128i byte_select = _mm_setr_epi8(0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1);
     const __m128i zero = _mm_setzero_si128();
@@ -403,6 +461,19 @@ simde_x_mm_gf2p8matrix_multiply_epi64_epi8 (simde__m128i x, simde__m128i A) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m256i
 simde_x_mm256_gf2p8matrix_multiply_epi64_epi8 (simde__m256i x, simde__m256i A) {
+  #if defined(SIMDE_CHECK_CONSTANT_) && defined(SIMDE_X86_AVX2_NATIVE)
+    simde__m256i_private cA_ = simde__m256i_to_private(A);
+    if (SIMDE_CHECK_CONSTANT_(cA_.u64[0]) && SIMDE_CHECK_CONSTANT_(cA_.u64[1]) &&
+        SIMDE_CHECK_CONSTANT_(cA_.u64[2]) && SIMDE_CHECK_CONSTANT_(cA_.u64[3]) &&
+        (cA_.u64[0] == cA_.u64[1]) && (cA_.u64[0] == cA_.u64[2]) && (cA_.u64[0] == cA_.u64[3])) {
+      const simde__m256i mlo = simde_mm256_broadcastsi128_si256(simde_x_gf2p8_matrix_nibble_lo(cA_.u64[0]));
+      const simde__m256i mhi = simde_mm256_broadcastsi128_si256(simde_x_gf2p8_matrix_nibble_hi(cA_.u64[0]));
+      const simde__m256i nmask = simde_mm256_set1_epi8(0x0F);
+      const simde__m256i lo = simde_mm256_and_si256(x, nmask);
+      const simde__m256i hi = simde_mm256_and_si256(simde_mm256_srli_epi16(x, 4), nmask);
+      return simde_mm256_xor_si256(simde_mm256_shuffle_epi8(mlo, lo), simde_mm256_shuffle_epi8(mhi, hi));
+    }
+  #endif
   #if defined(SIMDE_X86_AVX2_NATIVE)
     simde__m256i r, a, p;
     const simde__m256i byte_select = simde_x_mm256_set_epu64x(UINT64_C(0x0303030303030303), UINT64_C(0x0202020202020202),

--- a/simde/x86/gfni.h
+++ b/simde/x86/gfni.h
@@ -117,6 +117,84 @@ static const union {
   }
 };
 
+/* GFNI matrix (qword) for "multiply by the GF(2^8) constant k": column j is
+ * k (x) 2^j. Lets a constant-operand GF(2^8) multiply degenerate to an affine
+ * transform (then to nibble decomposition). */
+/* Fully precomputed so that, for a compile-time-constant multiplier k, the
+ * matrix simde_x_gf2p8_mul_matrix_lut[k] folds to a literal (verified:
+ * __builtin_constant_p(lut[const]) is true). That lets the constant-operand
+ * GF(2^8) multiply collapse to matrix_multiply's compile-time nibble path
+ * (two shuffles at run time) instead of rebuilding the matrix per call.
+ * Generated for FGP 0x1B; entry k is the GF(2)-affine matrix of "multiply by k". */
+#if defined(SIMDE_CHECK_CONSTANT_) && defined(SIMDE_X_GFNI_HAVE_SHUFFLE)
+static const uint64_t simde_x_gf2p8_mul_matrix_lut[256] = {
+    UINT64_C(0x0000000000000000),UINT64_C(0x0102040810204080),UINT64_C(0x8081028488102040),UINT64_C(0x8183068c983060c0),
+    UINT64_C(0x40c08142c4881020),UINT64_C(0x41c2854ad4a850a0),UINT64_C(0xc04183c64c983060),UINT64_C(0xc14387ce5cb870e0),
+    UINT64_C(0x2060c0a162c48810),UINT64_C(0x2162c4a972e4c890),UINT64_C(0xa0e1c225ead4a850),UINT64_C(0xa1e3c62dfaf4e8d0),
+    UINT64_C(0x60a041e3a64c9830),UINT64_C(0x61a245ebb66cd8b0),UINT64_C(0xe02143672e5cb870),UINT64_C(0xe123476f3e7cf8f0),
+    UINT64_C(0x103060d0b162c488),UINT64_C(0x113264d8a1428408),UINT64_C(0x90b162543972e4c8),UINT64_C(0x91b3665c2952a448),
+    UINT64_C(0x50f0e19275ead4a8),UINT64_C(0x51f2e59a65ca9428),UINT64_C(0xd071e316fdfaf4e8),UINT64_C(0xd173e71eeddab468),
+    UINT64_C(0x3050a071d3a64c98),UINT64_C(0x3152a479c3860c18),UINT64_C(0xb0d1a2f55bb66cd8),UINT64_C(0xb1d3a6fd4b962c58),
+    UINT64_C(0x70902133172e5cb8),UINT64_C(0x7192253b070e1c38),UINT64_C(0xf01123b79f3e7cf8),UINT64_C(0xf11327bf8f1e3c78),
+    UINT64_C(0x889830e858b162c4),UINT64_C(0x899a34e048912244),UINT64_C(0x0819326cd0a14284),UINT64_C(0x091b3664c0810204),
+    UINT64_C(0xc858b1aa9c3972e4),UINT64_C(0xc95ab5a28c193264),UINT64_C(0x48d9b32e142952a4),UINT64_C(0x49dbb72604091224),
+    UINT64_C(0xa8f8f0493a75ead4),UINT64_C(0xa9faf4412a55aa54),UINT64_C(0x2879f2cdb265ca94),UINT64_C(0x297bf6c5a2458a14),
+    UINT64_C(0xe838710bfefdfaf4),UINT64_C(0xe93a7503eeddba74),UINT64_C(0x68b9738f76eddab4),UINT64_C(0x69bb778766cd9a34),
+    UINT64_C(0x98a85038e9d3a64c),UINT64_C(0x99aa5430f9f3e6cc),UINT64_C(0x182952bc61c3860c),UINT64_C(0x192b56b471e3c68c),
+    UINT64_C(0xd868d17a2d5bb66c),UINT64_C(0xd96ad5723d7bf6ec),UINT64_C(0x58e9d3fea54b962c),UINT64_C(0x59ebd7f6b56bd6ac),
+    UINT64_C(0xb8c890998b172e5c),UINT64_C(0xb9ca94919b376edc),UINT64_C(0x3849921d03070e1c),UINT64_C(0x394b961513274e9c),
+    UINT64_C(0xf80811db4f9f3e7c),UINT64_C(0xf90a15d35fbf7efc),UINT64_C(0x7889135fc78f1e3c),UINT64_C(0x798b1757d7af5ebc),
+    UINT64_C(0xc44c98f42c58b162),UINT64_C(0xc54e9cfc3c78f1e2),UINT64_C(0x44cd9a70a4489122),UINT64_C(0x45cf9e78b468d1a2),
+    UINT64_C(0x848c19b6e8d0a142),UINT64_C(0x858e1dbef8f0e1c2),UINT64_C(0x040d1b3260c08102),UINT64_C(0x050f1f3a70e0c182),
+    UINT64_C(0xe42c58554e9c3972),UINT64_C(0xe52e5c5d5ebc79f2),UINT64_C(0x64ad5ad1c68c1932),UINT64_C(0x65af5ed9d6ac59b2),
+    UINT64_C(0xa4ecd9178a142952),UINT64_C(0xa5eedd1f9a3469d2),UINT64_C(0x246ddb9302040912),UINT64_C(0x256fdf9b12244992),
+    UINT64_C(0xd47cf8249d3a75ea),UINT64_C(0xd57efc2c8d1a356a),UINT64_C(0x54fdfaa0152a55aa),UINT64_C(0x55fffea8050a152a),
+    UINT64_C(0x94bc796659b265ca),UINT64_C(0x95be7d6e4992254a),UINT64_C(0x143d7be2d1a2458a),UINT64_C(0x153f7feac182050a),
+    UINT64_C(0xf41c3885fffefdfa),UINT64_C(0xf51e3c8defdebd7a),UINT64_C(0x749d3a0177eeddba),UINT64_C(0x759f3e0967ce9d3a),
+    UINT64_C(0xb4dcb9c73b76edda),UINT64_C(0xb5debdcf2b56ad5a),UINT64_C(0x345dbb43b366cd9a),UINT64_C(0x355fbf4ba3468d1a),
+    UINT64_C(0x4cd4a81c74e9d3a6),UINT64_C(0x4dd6ac1464c99326),UINT64_C(0xcc55aa98fcf9f3e6),UINT64_C(0xcd57ae90ecd9b366),
+    UINT64_C(0x0c14295eb061c386),UINT64_C(0x0d162d56a0418306),UINT64_C(0x8c952bda3871e3c6),UINT64_C(0x8d972fd22851a346),
+    UINT64_C(0x6cb468bd162d5bb6),UINT64_C(0x6db66cb5060d1b36),UINT64_C(0xec356a399e3d7bf6),UINT64_C(0xed376e318e1d3b76),
+    UINT64_C(0x2c74e9ffd2a54b96),UINT64_C(0x2d76edf7c2850b16),UINT64_C(0xacf5eb7b5ab56bd6),UINT64_C(0xadf7ef734a952b56),
+    UINT64_C(0x5ce4c8ccc58b172e),UINT64_C(0x5de6ccc4d5ab57ae),UINT64_C(0xdc65ca484d9b376e),UINT64_C(0xdd67ce405dbb77ee),
+    UINT64_C(0x1c24498e0103070e),UINT64_C(0x1d264d861123478e),UINT64_C(0x9ca54b0a8913274e),UINT64_C(0x9da74f02993367ce),
+    UINT64_C(0x7c84086da74f9f3e),UINT64_C(0x7d860c65b76fdfbe),UINT64_C(0xfc050ae92f5fbf7e),UINT64_C(0xfd070ee13f7ffffe),
+    UINT64_C(0x3c44892f63c78f1e),UINT64_C(0x3d468d2773e7cf9e),UINT64_C(0xbcc58babebd7af5e),UINT64_C(0xbdc78fa3fbf7efde),
+    UINT64_C(0x62a64cfa962c58b1),UINT64_C(0x63a448f2860c1831),UINT64_C(0xe2274e7e1e3c78f1),UINT64_C(0xe3254a760e1c3871),
+    UINT64_C(0x2266cdb852a44891),UINT64_C(0x2364c9b042840811),UINT64_C(0xa2e7cf3cdab468d1),UINT64_C(0xa3e5cb34ca942851),
+    UINT64_C(0x42c68c5bf4e8d0a1),UINT64_C(0x43c48853e4c89021),UINT64_C(0xc2478edf7cf8f0e1),UINT64_C(0xc3458ad76cd8b061),
+    UINT64_C(0x02060d193060c081),UINT64_C(0x0304091120408001),UINT64_C(0x82870f9db870e0c1),UINT64_C(0x83850b95a850a041),
+    UINT64_C(0x72962c2a274e9c39),UINT64_C(0x73942822376edcb9),UINT64_C(0xf2172eaeaf5ebc79),UINT64_C(0xf3152aa6bf7efcf9),
+    UINT64_C(0x3256ad68e3c68c19),UINT64_C(0x3354a960f3e6cc99),UINT64_C(0xb2d7afec6bd6ac59),UINT64_C(0xb3d5abe47bf6ecd9),
+    UINT64_C(0x52f6ec8b458a1429),UINT64_C(0x53f4e88355aa54a9),UINT64_C(0xd277ee0fcd9a3469),UINT64_C(0xd375ea07ddba74e9),
+    UINT64_C(0x12366dc981020409),UINT64_C(0x133469c191224489),UINT64_C(0x92b76f4d09122449),UINT64_C(0x93b56b45193264c9),
+    UINT64_C(0xea3e7c12ce9d3a75),UINT64_C(0xeb3c781adebd7af5),UINT64_C(0x6abf7e96468d1a35),UINT64_C(0x6bbd7a9e56ad5ab5),
+    UINT64_C(0xaafefd500a152a55),UINT64_C(0xabfcf9581a356ad5),UINT64_C(0x2a7fffd482050a15),UINT64_C(0x2b7dfbdc92254a95),
+    UINT64_C(0xca5ebcb3ac59b265),UINT64_C(0xcb5cb8bbbc79f2e5),UINT64_C(0x4adfbe3724499225),UINT64_C(0x4bddba3f3469d2a5),
+    UINT64_C(0x8a9e3df168d1a245),UINT64_C(0x8b9c39f978f1e2c5),UINT64_C(0x0a1f3f75e0c18205),UINT64_C(0x0b1d3b7df0e1c285),
+    UINT64_C(0xfa0e1cc27ffffefd),UINT64_C(0xfb0c18ca6fdfbe7d),UINT64_C(0x7a8f1e46f7efdebd),UINT64_C(0x7b8d1a4ee7cf9e3d),
+    UINT64_C(0xbace9d80bb77eedd),UINT64_C(0xbbcc9988ab57ae5d),UINT64_C(0x3a4f9f043367ce9d),UINT64_C(0x3b4d9b0c23478e1d),
+    UINT64_C(0xda6edc631d3b76ed),UINT64_C(0xdb6cd86b0d1b366d),UINT64_C(0x5aefdee7952b56ad),UINT64_C(0x5beddaef850b162d),
+    UINT64_C(0x9aae5d21d9b366cd),UINT64_C(0x9bac5929c993264d),UINT64_C(0x1a2f5fa551a3468d),UINT64_C(0x1b2d5bad4183060d),
+    UINT64_C(0xa6ead40eba74e9d3),UINT64_C(0xa7e8d006aa54a953),UINT64_C(0x266bd68a3264c993),UINT64_C(0x2769d28222448913),
+    UINT64_C(0xe62a554c7efcf9f3),UINT64_C(0xe72851446edcb973),UINT64_C(0x66ab57c8f6ecd9b3),UINT64_C(0x67a953c0e6cc9933),
+    UINT64_C(0x868a14afd8b061c3),UINT64_C(0x878810a7c8902143),UINT64_C(0x060b162b50a04183),UINT64_C(0x0709122340800103),
+    UINT64_C(0xc64a95ed1c3871e3),UINT64_C(0xc74891e50c183163),UINT64_C(0x46cb9769942851a3),UINT64_C(0x47c9936184081123),
+    UINT64_C(0xb6dab4de0b162d5b),UINT64_C(0xb7d8b0d61b366ddb),UINT64_C(0x365bb65a83060d1b),UINT64_C(0x3759b25293264d9b),
+    UINT64_C(0xf61a359ccf9e3d7b),UINT64_C(0xf7183194dfbe7dfb),UINT64_C(0x769b3718478e1d3b),UINT64_C(0x7799331057ae5dbb),
+    UINT64_C(0x96ba747f69d2a54b),UINT64_C(0x97b8707779f2e5cb),UINT64_C(0x163b76fbe1c2850b),UINT64_C(0x173972f3f1e2c58b),
+    UINT64_C(0xd67af53dad5ab56b),UINT64_C(0xd778f135bd7af5eb),UINT64_C(0x56fbf7b9254a952b),UINT64_C(0x57f9f3b1356ad5ab),
+    UINT64_C(0x2e72e4e6e2c58b17),UINT64_C(0x2f70e0eef2e5cb97),UINT64_C(0xaef3e6626ad5ab57),UINT64_C(0xaff1e26a7af5ebd7),
+    UINT64_C(0x6eb265a4264d9b37),UINT64_C(0x6fb061ac366ddbb7),UINT64_C(0xee336720ae5dbb77),UINT64_C(0xef316328be7dfbf7),
+    UINT64_C(0x0e12244780010307),UINT64_C(0x0f10204f90214387),UINT64_C(0x8e9326c308112347),UINT64_C(0x8f9122cb183163c7),
+    UINT64_C(0x4ed2a50544891327),UINT64_C(0x4fd0a10d54a953a7),UINT64_C(0xce53a781cc993367),UINT64_C(0xcf51a389dcb973e7),
+    UINT64_C(0x3e42843653a74f9f),UINT64_C(0x3f40803e43870f1f),UINT64_C(0xbec386b2dbb76fdf),UINT64_C(0xbfc182bacb972f5f),
+    UINT64_C(0x7e820574972f5fbf),UINT64_C(0x7f80017c870f1f3f),UINT64_C(0xfe0307f01f3f7fff),UINT64_C(0xff0103f80f1f3f7f),
+    UINT64_C(0x1e2244973163c78f),UINT64_C(0x1f20409f2143870f),UINT64_C(0x9ea34613b973e7cf),UINT64_C(0x9fa1421ba953a74f),
+    UINT64_C(0x5ee2c5d5f5ebd7af),UINT64_C(0x5fe0c1dde5cb972f),UINT64_C(0xde63c7517dfbf7ef),UINT64_C(0xdf61c3596ddbb76f)
+};
+#endif /* SIMDE_CHECK_CONSTANT_ && SIMDE_X_GFNI_HAVE_SHUFFLE */
+
 /* Apply one GF(2) affine matrix row-set (a GFNI qword, no constant) to a single
  * byte. Identical to the scalar reference in the matrix-multiply fallback, so
  * it can generate the nibble tables for a compile-time-constant matrix. */
@@ -904,7 +982,26 @@ SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i simde_mm_gf2p8mul_epi8 (simde__m128i a, simde__m128i b) {
   #if defined(SIMDE_X86_GFNI_NATIVE) && (defined(SIMDE_X86_AVX512VL_NATIVE) || !defined(SIMDE_X86_AVX512F_NATIVE))
     return _mm_gf2p8mul_epi8(a, b);
-  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #else
+    #if defined(SIMDE_CHECK_CONSTANT_) && defined(SIMDE_X_GFNI_HAVE_SHUFFLE)
+      {
+        /* If b is a compile-time constant broadcast of a single byte, multiplying
+        * by it is a GF(2) affine transform, so it degenerates to a matrix
+        * multiply (which itself uses the nibble path).
+        * Gated on SIMDE_X_GFNI_HAVE_SHUFFLE: without a byte-shuffle the matrix
+        * multiply falls back to a movemask loop that is slower than the
+        * schoolbook GF multiply below. */
+        simde__m128i_private simde_x_gfni_bc_ = simde__m128i_to_private(b);
+        if (SIMDE_CHECK_CONSTANT_(simde_x_gfni_bc_.u64[0]) && (simde_x_gfni_bc_.u64[0] == simde_x_gfni_bc_.u64[1]) &&
+            (simde_x_gfni_bc_.u64[0] == HEDLEY_STATIC_CAST(uint64_t, simde_x_gfni_bc_.u8[0]) * UINT64_C(0x0101010101010101))) {
+          if (simde_x_gfni_bc_.u8[0] == 0x00) return simde_mm_setzero_si128();  /* a (x) 0 = 0 */
+          if (simde_x_gfni_bc_.u8[0] == 0x01) return a;                         /* a (x) 1 = a */
+          return simde_x_mm_gf2p8matrix_multiply_epi64_epi8(a,
+            simde_mm_set1_epi64x(HEDLEY_STATIC_CAST(int64_t, simde_x_gf2p8_mul_matrix_lut[simde_x_gfni_bc_.u8[0]])));
+        }
+      }
+    #endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     const poly8x16_t pa = vreinterpretq_p8_u8(simde__m128i_to_neon_u8(a));
     const poly8x16_t pb = vreinterpretq_p8_u8(simde__m128i_to_neon_u8(b));
     const uint8x16_t lo = vreinterpretq_u8_p16(vmull_p8(vget_low_p8(pa), vget_low_p8(pb)));
@@ -1177,6 +1274,7 @@ simde__m128i simde_mm_gf2p8mul_epi8 (simde__m128i a, simde__m128i b) {
     }
 
     return simde__m128i_from_private(r_);
+  #endif
   #endif
 }
 #if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)

--- a/simde/x86/gfni.h
+++ b/simde/x86/gfni.h
@@ -252,6 +252,65 @@ static const union { uint8_t u8[16]; simde__m128i m128i; } simde_x_gf2p8_inv_thi
   0x00, 0xa4, 0x49, 0xed, 0x92, 0x36, 0xdb, 0x7f, 0x25, 0x81, 0x6c, 0xc8, 0xb7, 0x13, 0xfe, 0x5a } };
 #endif /* SIMDE_X_GFNI_HAVE_AES */
 
+#if defined(SIMDE_X_GFNI_HAVE_AES)
+/* GFNI qwords (SIMDe convention) for the AES affine matrix and its inverse. */
+#define SIMDE_X_GFNI_AAES_FWD UINT64_C(0xF1E3C78F1F3E7CF8)
+#define SIMDE_X_GFNI_AAES_INV UINT64_C(0xA44992254A942952)
+
+/* Apply M' = M . A_aes^-1 to one byte (composition of two GFNI matrices). */
+SIMDE_FUNCTION_ATTRIBUTES
+uint8_t
+simde_x_gf2p8_apply_mprime (uint64_t M, uint8_t v) {
+  return simde_x_gf2p8_apply_matrix_byte(M, simde_x_gf2p8_apply_matrix_byte(SIMDE_X_GFNI_AAES_INV, v));
+}
+
+/* Fused-affineinv nibble tables: result = M'_lo_c'[s&0xF] ^ M'_hi[s>>4] where
+ * s = SubBytes(x), M' = M . A_aes^-1, c' = M'.0x63 ^ c folded into the low table.
+ * Gives M.inv(x) ^ c directly. Fold to constants when M, c are compile-time. */
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_gf2p8_affineinv_nibble_lo (uint64_t M, uint8_t c) {
+  uint8_t cp = HEDLEY_STATIC_CAST(uint8_t, simde_x_gf2p8_apply_mprime(M, 0x63) ^ c);
+  #define SIMDE_X_GFNI_IROW(n) HEDLEY_STATIC_CAST(int8_t, simde_x_gf2p8_apply_mprime(M, HEDLEY_STATIC_CAST(uint8_t, (n))) ^ cp)
+  simde__m128i r = simde_mm_set_epi8(
+    SIMDE_X_GFNI_IROW(15), SIMDE_X_GFNI_IROW(14), SIMDE_X_GFNI_IROW(13), SIMDE_X_GFNI_IROW(12),
+    SIMDE_X_GFNI_IROW(11), SIMDE_X_GFNI_IROW(10), SIMDE_X_GFNI_IROW( 9), SIMDE_X_GFNI_IROW( 8),
+    SIMDE_X_GFNI_IROW( 7), SIMDE_X_GFNI_IROW( 6), SIMDE_X_GFNI_IROW( 5), SIMDE_X_GFNI_IROW( 4),
+    SIMDE_X_GFNI_IROW( 3), SIMDE_X_GFNI_IROW( 2), SIMDE_X_GFNI_IROW( 1), SIMDE_X_GFNI_IROW( 0));
+  #undef SIMDE_X_GFNI_IROW
+  return r;
+}
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_gf2p8_affineinv_nibble_hi (uint64_t M) {
+  #define SIMDE_X_GFNI_IROW(n) HEDLEY_STATIC_CAST(int8_t, simde_x_gf2p8_apply_mprime(M, HEDLEY_STATIC_CAST(uint8_t, (n) << 4)))
+  simde__m128i r = simde_mm_set_epi8(
+    SIMDE_X_GFNI_IROW(15), SIMDE_X_GFNI_IROW(14), SIMDE_X_GFNI_IROW(13), SIMDE_X_GFNI_IROW(12),
+    SIMDE_X_GFNI_IROW(11), SIMDE_X_GFNI_IROW(10), SIMDE_X_GFNI_IROW( 9), SIMDE_X_GFNI_IROW( 8),
+    SIMDE_X_GFNI_IROW( 7), SIMDE_X_GFNI_IROW( 6), SIMDE_X_GFNI_IROW( 5), SIMDE_X_GFNI_IROW( 4),
+    SIMDE_X_GFNI_IROW( 3), SIMDE_X_GFNI_IROW( 2), SIMDE_X_GFNI_IROW( 1), SIMDE_X_GFNI_IROW( 0));
+  #undef SIMDE_X_GFNI_IROW
+  return r;
+}
+
+/* affineinv with a compile-time-constant matrix M and constant c, via the AES
+ * S-box. M=A_aes & c=0x63 collapses to plain SubBytes (2 instructions). */
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_gf2p8affineinv_const (simde__m128i x, uint64_t M, int b) {
+  simde__m128i s = simde_mm_shuffle_epi8(simde_mm_aesenclast_si128(x, simde_mm_setzero_si128()), simde_x_gf2p8_inv_undo_sr.m128i);
+  if ((M == SIMDE_X_GFNI_AAES_FWD) && (b == 0x63))
+    return s;
+  {
+    const simde__m128i mlo = simde_x_gf2p8_affineinv_nibble_lo(M, HEDLEY_STATIC_CAST(uint8_t, b));
+    const simde__m128i mhi = simde_x_gf2p8_affineinv_nibble_hi(M);
+    const simde__m128i nmask = simde_mm_set1_epi8(0x0F);
+    return simde_mm_xor_si128(simde_mm_shuffle_epi8(mlo, simde_mm_and_si128(s, nmask)),
+                              simde_mm_shuffle_epi8(mhi, simde_mm_and_si128(simde_mm_srli_epi16(s, 4), nmask)));
+  }
+}
+#endif /* SIMDE_X_GFNI_HAVE_AES */
+
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_x_mm_gf2p8matrix_multiply_epi64_epi8 (simde__m128i x, simde__m128i A) {
@@ -907,6 +966,14 @@ SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_mm_gf2p8affineinv_epi64_epi8 (simde__m128i x, simde__m128i A, int b)
     SIMDE_REQUIRE_CONSTANT_RANGE(b, 0, 255) {
+  #if defined(SIMDE_X_GFNI_HAVE_AES) && defined(SIMDE_CHECK_CONSTANT_)
+    /* constant matrix: fuse M into the post-AES nibble tables (one AES + nibble);
+     * M=A_aes & c=0x63 collapses to plain SubBytes. */
+    simde__m128i_private cA_ = simde__m128i_to_private(A);
+    if (SIMDE_CHECK_CONSTANT_(cA_.u64[0]) && SIMDE_CHECK_CONSTANT_(cA_.u64[1]) && (cA_.u64[0] == cA_.u64[1]) && SIMDE_CHECK_CONSTANT_(b)) {
+      return simde_x_mm_gf2p8affineinv_const(x, cA_.u64[0], b);
+    }
+  #endif
   return simde_mm_xor_si128(simde_x_mm_gf2p8matrix_multiply_inverse_epi64_epi8(x, A), simde_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, b)));
 }
 #if defined(SIMDE_X86_GFNI_NATIVE)
@@ -921,6 +988,17 @@ SIMDE_FUNCTION_ATTRIBUTES
 simde__m256i
 simde_mm256_gf2p8affineinv_epi64_epi8 (simde__m256i x, simde__m256i A, int b)
     SIMDE_REQUIRE_CONSTANT_RANGE(b, 0, 255) {
+  #if defined(SIMDE_X_GFNI_HAVE_AES) && defined(SIMDE_CHECK_CONSTANT_)
+    simde__m256i_private cA_ = simde__m256i_to_private(A);
+    if (SIMDE_CHECK_CONSTANT_(cA_.u64[0]) && SIMDE_CHECK_CONSTANT_(cA_.u64[1]) &&
+        SIMDE_CHECK_CONSTANT_(cA_.u64[2]) && SIMDE_CHECK_CONSTANT_(cA_.u64[3]) && SIMDE_CHECK_CONSTANT_(b) &&
+        (cA_.u64[0] == cA_.u64[1]) && (cA_.u64[0] == cA_.u64[2]) && (cA_.u64[0] == cA_.u64[3])) {
+      simde__m256i_private r_, x_ = simde__m256i_to_private(x);
+      r_.m128i[0] = simde_x_mm_gf2p8affineinv_const(x_.m128i[0], cA_.u64[0], b);
+      r_.m128i[1] = simde_x_mm_gf2p8affineinv_const(x_.m128i[1], cA_.u64[0], b);
+      return simde__m256i_from_private(r_);
+    }
+  #endif
   return simde_mm256_xor_si256(simde_x_mm256_gf2p8matrix_multiply_inverse_epi64_epi8(x, A), simde_mm256_set1_epi8(HEDLEY_STATIC_CAST(int8_t, b)));
 }
 #if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
@@ -935,6 +1013,20 @@ SIMDE_FUNCTION_ATTRIBUTES
 simde__m512i
 simde_mm512_gf2p8affineinv_epi64_epi8 (simde__m512i x, simde__m512i A, int b)
     SIMDE_REQUIRE_CONSTANT_RANGE(b, 0, 255) {
+  #if defined(SIMDE_X_GFNI_HAVE_AES) && defined(SIMDE_CHECK_CONSTANT_)
+    simde__m512i_private cA_ = simde__m512i_to_private(A);
+    if (SIMDE_CHECK_CONSTANT_(cA_.u64[0]) && SIMDE_CHECK_CONSTANT_(cA_.u64[1]) &&
+        SIMDE_CHECK_CONSTANT_(cA_.u64[2]) && SIMDE_CHECK_CONSTANT_(cA_.u64[3]) &&
+        SIMDE_CHECK_CONSTANT_(cA_.u64[4]) && SIMDE_CHECK_CONSTANT_(cA_.u64[5]) &&
+        SIMDE_CHECK_CONSTANT_(cA_.u64[6]) && SIMDE_CHECK_CONSTANT_(cA_.u64[7]) && SIMDE_CHECK_CONSTANT_(b) &&
+        (cA_.u64[0] == cA_.u64[1]) && (cA_.u64[0] == cA_.u64[2]) && (cA_.u64[0] == cA_.u64[3]) &&
+        (cA_.u64[0] == cA_.u64[4]) && (cA_.u64[0] == cA_.u64[5]) && (cA_.u64[0] == cA_.u64[6]) && (cA_.u64[0] == cA_.u64[7])) {
+      simde__m512i_private r_, x_ = simde__m512i_to_private(x);
+      for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++)
+        r_.m128i[i] = simde_x_mm_gf2p8affineinv_const(x_.m128i[i], cA_.u64[0], b);
+      return simde__m512i_from_private(r_);
+    }
+  #endif
   return simde_mm512_xor_si512(simde_x_mm512_gf2p8matrix_multiply_inverse_epi64_epi8(x, A), simde_mm512_set1_epi8(HEDLEY_STATIC_CAST(int8_t, b)));
 }
 #if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)

--- a/simde/x86/gfni.h
+++ b/simde/x86/gfni.h
@@ -677,6 +677,17 @@ SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_mm_gf2p8affine_epi64_epi8 (simde__m128i x, simde__m128i A, int b)
     SIMDE_REQUIRE_CONSTANT_RANGE(b, 0, 255) {
+  #if defined(SIMDE_CHECK_CONSTANT_) && defined(SIMDE_X_GFNI_HAVE_SHUFFLE)
+    /* constant matrix: nibble decomposition with c folded into the low table. */
+    simde__m128i_private cA_ = simde__m128i_to_private(A);
+    if (SIMDE_CHECK_CONSTANT_(cA_.u64[0]) && SIMDE_CHECK_CONSTANT_(cA_.u64[1]) && (cA_.u64[0] == cA_.u64[1])) {
+      const simde__m128i mlo = simde_mm_xor_si128(simde_x_gf2p8_matrix_nibble_lo(cA_.u64[0]), simde_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, b)));
+      const simde__m128i mhi = simde_x_gf2p8_matrix_nibble_hi(cA_.u64[0]);
+      const simde__m128i nmask = simde_mm_set1_epi8(0x0F);
+      return simde_mm_xor_si128(simde_mm_shuffle_epi8(mlo, simde_mm_and_si128(x, nmask)),
+                                simde_mm_shuffle_epi8(mhi, simde_mm_and_si128(simde_mm_srli_epi16(x, 4), nmask)));
+    }
+  #endif
   return simde_mm_xor_si128(simde_x_mm_gf2p8matrix_multiply_epi64_epi8(x, A), simde_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, b)));
 }
 #if defined(SIMDE_X86_GFNI_NATIVE)
@@ -691,6 +702,18 @@ SIMDE_FUNCTION_ATTRIBUTES
 simde__m256i
 simde_mm256_gf2p8affine_epi64_epi8 (simde__m256i x, simde__m256i A, int b)
     SIMDE_REQUIRE_CONSTANT_RANGE(b, 0, 255) {
+  #if defined(SIMDE_CHECK_CONSTANT_) && defined(SIMDE_X86_AVX2_NATIVE)
+    simde__m256i_private cA_ = simde__m256i_to_private(A);
+    if (SIMDE_CHECK_CONSTANT_(cA_.u64[0]) && SIMDE_CHECK_CONSTANT_(cA_.u64[1]) &&
+        SIMDE_CHECK_CONSTANT_(cA_.u64[2]) && SIMDE_CHECK_CONSTANT_(cA_.u64[3]) &&
+        (cA_.u64[0] == cA_.u64[1]) && (cA_.u64[0] == cA_.u64[2]) && (cA_.u64[0] == cA_.u64[3])) {
+      const simde__m256i mlo = simde_mm256_xor_si256(simde_mm256_broadcastsi128_si256(simde_x_gf2p8_matrix_nibble_lo(cA_.u64[0])), simde_mm256_set1_epi8(HEDLEY_STATIC_CAST(int8_t, b)));
+      const simde__m256i mhi = simde_mm256_broadcastsi128_si256(simde_x_gf2p8_matrix_nibble_hi(cA_.u64[0]));
+      const simde__m256i nmask = simde_mm256_set1_epi8(0x0F);
+      return simde_mm256_xor_si256(simde_mm256_shuffle_epi8(mlo, simde_mm256_and_si256(x, nmask)),
+                                   simde_mm256_shuffle_epi8(mhi, simde_mm256_and_si256(simde_mm256_srli_epi16(x, 4), nmask)));
+    }
+  #endif
   return simde_mm256_xor_si256(simde_x_mm256_gf2p8matrix_multiply_epi64_epi8(x, A), simde_mm256_set1_epi8(HEDLEY_STATIC_CAST(int8_t, b)));
 }
 #if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)

--- a/simde/x86/gfni.h
+++ b/simde/x86/gfni.h
@@ -547,6 +547,180 @@ simde_x_mm_gf2p8mul_tower (simde__m128i a, simde__m128i b) {
 }
 #endif /* SIMDE_X_GFNI_HAVE_SHUFFLE */
 
+#if defined(SIMDE_X_GFNI_HAVE_SHUFFLE) && defined(SIMDE_X86_AVX2_NATIVE)
+/* 256-bit (AVX2) versions of the tower-field helpers. Same algorithms as the
+ * 128-bit ones above, with the 16-byte tables broadcast to both lanes. On
+ * full-width cores a ymm shuffle costs the same as an xmm one, so these double
+ * the throughput of the wide multiply/inverse operations versus splitting into
+ * two 128-bit halves. */
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_gf2p4_mul (simde__m256i a, simde__m256i b) {
+  const simde__m256i zero = simde_mm256_setzero_si256();
+  const simde__m256i logt = simde_mm256_broadcastsi128_si256(simde_x_gf2p4_log.m128i);
+  simde__m256i la = simde_mm256_shuffle_epi8(logt, a);
+  simde__m256i lb = simde_mm256_shuffle_epi8(logt, b);
+  simde__m256i idx = simde_mm256_add_epi8(la, lb);
+  simde__m256i ge = simde_mm256_cmpgt_epi8(idx, simde_mm256_set1_epi8(14));
+  idx = simde_mm256_sub_epi8(idx, simde_mm256_and_si256(ge, simde_mm256_set1_epi8(15)));
+  simde__m256i r = simde_mm256_shuffle_epi8(simde_mm256_broadcastsi128_si256(simde_x_gf2p4_exp.m128i), idx);
+  simde__m256i z = simde_mm256_or_si256(simde_mm256_cmpeq_epi8(a, zero), simde_mm256_cmpeq_epi8(b, zero));
+  return simde_mm256_andnot_si256(z, r);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_gf2p8_tower_lo (simde__m256i x) {
+  const simde__m256i nmask = simde_mm256_set1_epi8(0x0F);
+  const simde__m256i xlo = simde_mm256_and_si256(x, nmask);
+  const simde__m256i xhi = simde_mm256_and_si256(simde_mm256_srli_epi16(x, 4), nmask);
+  return simde_mm256_xor_si256(
+    simde_mm256_shuffle_epi8(simde_mm256_broadcastsi128_si256(simde_x_gf2p4_to_lo.m128i), xlo),
+    simde_mm256_shuffle_epi8(simde_mm256_broadcastsi128_si256(simde_x_gf2p4_to_hi.m128i), xhi));
+}
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_gf2p8_tower_hi (simde__m256i x) {
+  const simde__m256i nmask = simde_mm256_set1_epi8(0x0F);
+  const simde__m256i xlo = simde_mm256_and_si256(x, nmask);
+  const simde__m256i xhi = simde_mm256_and_si256(simde_mm256_srli_epi16(x, 4), nmask);
+  return simde_mm256_xor_si256(
+    simde_mm256_shuffle_epi8(simde_mm256_broadcastsi128_si256(simde_x_gf2p4_toh_lo.m128i), xlo),
+    simde_mm256_shuffle_epi8(simde_mm256_broadcastsi128_si256(simde_x_gf2p4_toh_hi.m128i), xhi));
+}
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_gf2p8_tower_join (simde__m256i h, simde__m256i l) {
+  return simde_mm256_xor_si256(
+    simde_mm256_shuffle_epi8(simde_mm256_broadcastsi128_si256(simde_x_gf2p4_from_l.m128i), l),
+    simde_mm256_shuffle_epi8(simde_mm256_broadcastsi128_si256(simde_x_gf2p4_from_h.m128i), h));
+}
+
+/* GF(2^8) inverse via the tower field, 256-bit. Mirrors the 128-bit version
+ * including the cached log(aH) / zero-mask reuse. */
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_gf2p8inverse_tower (simde__m256i x) {
+  const simde__m256i zero = simde_mm256_setzero_si256();
+  const simde__m256i logt = simde_mm256_broadcastsi128_si256(simde_x_gf2p4_log.m128i);
+  const simde__m256i expt = simde_mm256_broadcastsi128_si256(simde_x_gf2p4_exp.m128i);
+  simde__m256i aL = simde_x_mm256_gf2p8_tower_lo(x);
+  simde__m256i aH = simde_x_mm256_gf2p8_tower_hi(x);
+
+  /* Inline delta multiply: compute log(aH), cache it and z_aH for later reuse. */
+  simde__m256i log_aH = simde_mm256_shuffle_epi8(logt, aH);
+  simde__m256i z_aH = simde_mm256_cmpeq_epi8(aH, zero);
+  simde__m256i log_aL = simde_mm256_shuffle_epi8(logt, aL);
+  simde__m256i idx = simde_mm256_add_epi8(log_aH, log_aL);
+  simde__m256i ge = simde_mm256_cmpgt_epi8(idx, simde_mm256_set1_epi8(14));
+  idx = simde_mm256_sub_epi8(idx, simde_mm256_and_si256(ge, simde_mm256_set1_epi8(15)));
+  simde__m256i mul_aHaL = simde_mm256_shuffle_epi8(expt, idx);
+  simde__m256i z = simde_mm256_or_si256(z_aH, simde_mm256_cmpeq_epi8(aL, zero));
+  mul_aHaL = simde_mm256_andnot_si256(z, mul_aHaL);
+
+  /* delta = a_H^2 . nu ^ a_H . a_L ^ a_L^2 */
+  simde__m256i delta = simde_mm256_xor_si256(simde_mm256_xor_si256(
+    simde_mm256_shuffle_epi8(simde_mm256_broadcastsi128_si256(simde_x_gf2p4_mulnusq.m128i), aH),
+    mul_aHaL),
+    simde_mm256_shuffle_epi8(simde_mm256_broadcastsi128_si256(simde_x_gf2p4_sqr.m128i), aL));
+
+  /* Negated-log inversion: log(x^-1) = log(x) XOR 0x0F in GF(2^4)* (order 15). */
+  simde__m256i neg_log_delta = simde_mm256_xor_si256(
+    simde_mm256_shuffle_epi8(logt, delta), simde_mm256_set1_epi8(0x0F));
+
+  /* iH = aH * delta^-1, reusing cached log_aH, zero mask checks aH only. */
+  idx = simde_mm256_add_epi8(log_aH, neg_log_delta);
+  ge = simde_mm256_cmpgt_epi8(idx, simde_mm256_set1_epi8(14));
+  idx = simde_mm256_sub_epi8(idx, simde_mm256_and_si256(ge, simde_mm256_set1_epi8(15)));
+  simde__m256i iH = simde_mm256_shuffle_epi8(expt, idx);
+  iH = simde_mm256_andnot_si256(z_aH, iH);
+
+  /* iL = (aH ^ aL) * delta^-1, zero mask checks (aH ^ aL) only. */
+  simde__m256i aHxaL = simde_mm256_xor_si256(aH, aL);
+  simde__m256i log_aHxaL = simde_mm256_shuffle_epi8(logt, aHxaL);
+  idx = simde_mm256_add_epi8(log_aHxaL, neg_log_delta);
+  ge = simde_mm256_cmpgt_epi8(idx, simde_mm256_set1_epi8(14));
+  idx = simde_mm256_sub_epi8(idx, simde_mm256_and_si256(ge, simde_mm256_set1_epi8(15)));
+  simde__m256i iL = simde_mm256_shuffle_epi8(expt, idx);
+  z = simde_mm256_cmpeq_epi8(aHxaL, zero);
+  iL = simde_mm256_andnot_si256(z, iL);
+
+  return simde_x_mm256_gf2p8_tower_join(iH, iL);
+}
+
+/* affineinv with constant M via the fused tower path, 256-bit. Mirrors the
+ * 128-bit version: tower inverse guts, then M applied to (iH, iL) directly
+ * through the compile-time fused tables (broadcast to both lanes). */
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_gf2p8affineinv_tower_const (simde__m256i x, uint64_t M, int b) {
+  const simde__m256i zero = simde_mm256_setzero_si256();
+  const simde__m256i logt = simde_mm256_broadcastsi128_si256(simde_x_gf2p4_log.m128i);
+  const simde__m256i expt = simde_mm256_broadcastsi128_si256(simde_x_gf2p4_exp.m128i);
+  simde__m256i aL = simde_x_mm256_gf2p8_tower_lo(x);
+  simde__m256i aH = simde_x_mm256_gf2p8_tower_hi(x);
+
+  /* Inline delta multiply: compute log(aH), cache it and z_aH for later reuse. */
+  simde__m256i log_aH = simde_mm256_shuffle_epi8(logt, aH);
+  simde__m256i z_aH = simde_mm256_cmpeq_epi8(aH, zero);
+  simde__m256i log_aL = simde_mm256_shuffle_epi8(logt, aL);
+  simde__m256i idx = simde_mm256_add_epi8(log_aH, log_aL);
+  simde__m256i ge = simde_mm256_cmpgt_epi8(idx, simde_mm256_set1_epi8(14));
+  idx = simde_mm256_sub_epi8(idx, simde_mm256_and_si256(ge, simde_mm256_set1_epi8(15)));
+  simde__m256i mul_aHaL = simde_mm256_shuffle_epi8(expt, idx);
+  simde__m256i z = simde_mm256_or_si256(z_aH, simde_mm256_cmpeq_epi8(aL, zero));
+  mul_aHaL = simde_mm256_andnot_si256(z, mul_aHaL);
+
+  /* delta = a_H^2 . nu ^ a_H . a_L ^ a_L^2 */
+  simde__m256i delta = simde_mm256_xor_si256(simde_mm256_xor_si256(
+    simde_mm256_shuffle_epi8(simde_mm256_broadcastsi128_si256(simde_x_gf2p4_mulnusq.m128i), aH),
+    mul_aHaL),
+    simde_mm256_shuffle_epi8(simde_mm256_broadcastsi128_si256(simde_x_gf2p4_sqr.m128i), aL));
+
+  /* Negated-log inversion: log(x^-1) = log(x) XOR 0x0F in GF(2^4)* (order 15). */
+  simde__m256i neg_log_delta = simde_mm256_xor_si256(
+    simde_mm256_shuffle_epi8(logt, delta), simde_mm256_set1_epi8(0x0F));
+
+  /* iH = aH * delta^-1, reusing cached log_aH, zero mask checks aH only. */
+  idx = simde_mm256_add_epi8(log_aH, neg_log_delta);
+  ge = simde_mm256_cmpgt_epi8(idx, simde_mm256_set1_epi8(14));
+  idx = simde_mm256_sub_epi8(idx, simde_mm256_and_si256(ge, simde_mm256_set1_epi8(15)));
+  simde__m256i iH = simde_mm256_shuffle_epi8(expt, idx);
+  iH = simde_mm256_andnot_si256(z_aH, iH);
+
+  /* iL = (aH ^ aL) * delta^-1, zero mask checks (aH ^ aL) only. */
+  simde__m256i aHxaL = simde_mm256_xor_si256(aH, aL);
+  simde__m256i log_aHxaL = simde_mm256_shuffle_epi8(logt, aHxaL);
+  idx = simde_mm256_add_epi8(log_aHxaL, neg_log_delta);
+  ge = simde_mm256_cmpgt_epi8(idx, simde_mm256_set1_epi8(14));
+  idx = simde_mm256_sub_epi8(idx, simde_mm256_and_si256(ge, simde_mm256_set1_epi8(15)));
+  simde__m256i iL = simde_mm256_shuffle_epi8(expt, idx);
+  z = simde_mm256_cmpeq_epi8(aHxaL, zero);
+  iL = simde_mm256_andnot_si256(z, iL);
+
+  /* Fused output: apply M to (iH, iL) directly instead of tower_join then M. */
+  const simde__m256i fused_lo = simde_mm256_broadcastsi128_si256(simde_x_gf2p8_fused_tower_lo(M, HEDLEY_STATIC_CAST(uint8_t, b)));
+  const simde__m256i fused_hi = simde_mm256_broadcastsi128_si256(simde_x_gf2p8_fused_tower_hi(M));
+  return simde_mm256_xor_si256(simde_mm256_shuffle_epi8(fused_lo, iL),
+                               simde_mm256_shuffle_epi8(fused_hi, iH));
+}
+
+/* GF(2^8) multiply via the tower field (Karatsuba over GF(2^4)), 256-bit. */
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_gf2p8mul_tower (simde__m256i a, simde__m256i b) {
+  simde__m256i aL = simde_x_mm256_gf2p8_tower_lo(a), aH = simde_x_mm256_gf2p8_tower_hi(a);
+  simde__m256i bL = simde_x_mm256_gf2p8_tower_lo(b), bH = simde_x_mm256_gf2p8_tower_hi(b);
+  simde__m256i p = simde_x_mm256_gf2p4_mul(aL, bL);
+  simde__m256i q = simde_x_mm256_gf2p4_mul(aH, bH);
+  simde__m256i r = simde_x_mm256_gf2p4_mul(simde_mm256_xor_si256(aH, aL), simde_mm256_xor_si256(bH, bL));
+  simde__m256i oH = simde_mm256_xor_si256(r, p);
+  simde__m256i oL = simde_mm256_xor_si256(p,
+    simde_mm256_shuffle_epi8(simde_mm256_broadcastsi128_si256(simde_x_gf2p4_mulnu.m128i), q));
+  return simde_x_mm256_gf2p8_tower_join(oH, oL);
+}
+#endif /* SIMDE_X_GFNI_HAVE_SHUFFLE && SIMDE_X86_AVX2_NATIVE */
+
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_x_mm_gf2p8matrix_multiply_epi64_epi8 (simde__m128i x, simde__m128i A) {
@@ -951,6 +1125,12 @@ simde_x_mm_gf2p8inverse_epi8 (simde__m128i x) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m256i
 simde_x_mm256_gf2p8inverse_epi8 (simde__m256i x) {
+  #if !defined(SIMDE_X_GFNI_HAVE_AES) && defined(SIMDE_X_GFNI_HAVE_SHUFFLE) && defined(SIMDE_X86_AVX2_NATIVE)
+    /* Without AES the tower inverse runs at full ymm width. With AES the
+     * 128-bit AES-borrow path below stays cheaper (aesenclast is 128-bit
+     * anyway until a VAES path exists). */
+    return simde_x_mm256_gf2p8inverse_tower(x);
+  #else
     simde__m256i_private
       r_,
       x_ = simde__m256i_to_private(x);
@@ -963,6 +1143,7 @@ simde_x_mm256_gf2p8inverse_epi8 (simde__m256i x) {
     }
 
     return simde__m256i_from_private(r_);
+  #endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -1158,10 +1339,14 @@ simde_mm256_gf2p8affineinv_epi64_epi8 (simde__m256i x, simde__m256i A, int b)
     if (SIMDE_CHECK_CONSTANT_(cA_.u64[0]) && SIMDE_CHECK_CONSTANT_(cA_.u64[1]) &&
         SIMDE_CHECK_CONSTANT_(cA_.u64[2]) && SIMDE_CHECK_CONSTANT_(cA_.u64[3]) && SIMDE_CHECK_CONSTANT_(b) &&
         (cA_.u64[0] == cA_.u64[1]) && (cA_.u64[0] == cA_.u64[2]) && (cA_.u64[0] == cA_.u64[3])) {
+    #if defined(SIMDE_X86_AVX2_NATIVE)
+      return simde_x_mm256_gf2p8affineinv_tower_const(x, cA_.u64[0], b);
+    #else
       simde__m256i_private r_, x_ = simde__m256i_to_private(x);
       r_.m128i[0] = simde_x_mm_gf2p8affineinv_tower_const(x_.m128i[0], cA_.u64[0], b);
       r_.m128i[1] = simde_x_mm_gf2p8affineinv_tower_const(x_.m128i[1], cA_.u64[0], b);
       return simde__m256i_from_private(r_);
+    #endif
     }
   #endif
   return simde_mm256_xor_si256(simde_x_mm256_gf2p8matrix_multiply_inverse_epi64_epi8(x, A), simde_mm256_set1_epi8(HEDLEY_STATIC_CAST(int8_t, b)));
@@ -1200,8 +1385,13 @@ simde_mm512_gf2p8affineinv_epi64_epi8 (simde__m512i x, simde__m512i A, int b)
         (cA_.u64[0] == cA_.u64[1]) && (cA_.u64[0] == cA_.u64[2]) && (cA_.u64[0] == cA_.u64[3]) &&
         (cA_.u64[0] == cA_.u64[4]) && (cA_.u64[0] == cA_.u64[5]) && (cA_.u64[0] == cA_.u64[6]) && (cA_.u64[0] == cA_.u64[7])) {
       simde__m512i_private r_, x_ = simde__m512i_to_private(x);
+    #if defined(SIMDE_X86_AVX2_NATIVE)
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++)
+        r_.m256i[i] = simde_x_mm256_gf2p8affineinv_tower_const(x_.m256i[i], cA_.u64[0], b);
+    #else
       for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++)
         r_.m128i[i] = simde_x_mm_gf2p8affineinv_tower_const(x_.m128i[i], cA_.u64[0], b);
+    #endif
       return simde__m512i_from_private(r_);
     }
   #endif
@@ -1440,6 +1630,26 @@ simde_mm256_gf2p8mul_epi8 (simde__m256i a, simde__m256i b) {
   #if defined(SIMDE_X86_GFNI_NATIVE) && (defined(SIMDE_X86_AVX512VL_NATIVE) || (defined(SIMDE_X86_AVX_NATIVE) && !defined(SIMDE_X86_AVX512F_NATIVE)))
     return _mm256_gf2p8mul_epi8(a, b);
   #else
+  #if defined(SIMDE_CHECK_CONSTANT_) && defined(SIMDE_X_GFNI_HAVE_SHUFFLE) && defined(SIMDE_X86_AVX2_NATIVE)
+    {
+      /* Same constant-multiplier degeneration as the 128-bit version, kept at
+        * 256-bit width so the matrix multiply takes its ymm nibble path. */
+      simde__m256i_private simde_x_gfni_bc_ = simde__m256i_to_private(b);
+      if (SIMDE_CHECK_CONSTANT_(simde_x_gfni_bc_.u64[0]) &&
+          (simde_x_gfni_bc_.u64[0] == simde_x_gfni_bc_.u64[1]) &&
+          (simde_x_gfni_bc_.u64[0] == simde_x_gfni_bc_.u64[2]) &&
+          (simde_x_gfni_bc_.u64[0] == simde_x_gfni_bc_.u64[3]) &&
+          (simde_x_gfni_bc_.u64[0] == HEDLEY_STATIC_CAST(uint64_t, simde_x_gfni_bc_.u8[0]) * UINT64_C(0x0101010101010101))) {
+        if (simde_x_gfni_bc_.u8[0] == 0x00) return simde_mm256_setzero_si256();  /* a (x) 0 = 0 */
+        if (simde_x_gfni_bc_.u8[0] == 0x01) return a;                            /* a (x) 1 = a */
+        return simde_x_mm256_gf2p8matrix_multiply_epi64_epi8(a,
+          simde_mm256_set1_epi64x(HEDLEY_STATIC_CAST(int64_t, simde_x_gf2p8_mul_matrix_lut[simde_x_gfni_bc_.u8[0]])));
+      }
+    }
+  #endif
+  #if defined(SIMDE_X_GFNI_HAVE_SHUFFLE) && defined(SIMDE_X86_AVX2_NATIVE)
+    return simde_x_mm256_gf2p8mul_tower(a, b);
+  #else
     simde__m256i_private
       r_,
       a_ = simde__m256i_to_private(a),
@@ -1453,6 +1663,7 @@ simde_mm256_gf2p8mul_epi8 (simde__m256i a, simde__m256i b) {
     }
 
     return simde__m256i_from_private(r_);
+  #endif
   #endif
 }
 #if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
@@ -1474,8 +1685,8 @@ simde_mm512_gf2p8mul_epi8 (simde__m512i a, simde__m512i b) {
     #if !defined(__INTEL_COMPILER)
       SIMDE_VECTORIZE
     #endif
-    for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
-      r_.m128i[i] = simde_mm_gf2p8mul_epi8(a_.m128i[i], b_.m128i[i]);
+    for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+      r_.m256i[i] = simde_mm256_gf2p8mul_epi8(a_.m256i[i], b_.m256i[i]);
     }
 
     return simde__m512i_from_private(r_);

--- a/test/x86/gfni.c
+++ b/test/x86/gfni.c
@@ -5070,6 +5070,30 @@ test_simde_mm_gf2p8mul_epi8(SIMDE_MUNIT_TEST_ARGS) {
 }
 
 static int
+test_simde_mm_gf2p8mul_epi8_const(SIMDE_MUNIT_TEST_ARGS) {
+  /* Multiplying by a compile-time-constant broadcast degenerates to an affine
+   * transform; check it matches the run-time (general) multiply. */
+  #define SIMDE_TEST_GFNI_MUL_CONST(K) \
+    do { \
+      volatile int vk_ = (K); \
+      simde__m128i rc = simde_mm_gf2p8mul_epi8(a, simde_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, (K)))); \
+      simde__m128i rr = simde_mm_gf2p8mul_epi8(a, simde_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, vk_))); \
+      simde_assert_m128i_i8(rc, ==, rr); \
+    } while (0)
+
+  for (int t = 0 ; t < 16 ; t++) {
+    simde__m128i a = simde_test_x86_random_i8x16();
+    SIMDE_TEST_GFNI_MUL_CONST(0x00); SIMDE_TEST_GFNI_MUL_CONST(0x01);
+    SIMDE_TEST_GFNI_MUL_CONST(0x02); SIMDE_TEST_GFNI_MUL_CONST(0x1b);
+    SIMDE_TEST_GFNI_MUL_CONST(0x53); SIMDE_TEST_GFNI_MUL_CONST(0x57);
+    SIMDE_TEST_GFNI_MUL_CONST(0x80); SIMDE_TEST_GFNI_MUL_CONST(0xff);
+  }
+
+  #undef SIMDE_TEST_GFNI_MUL_CONST
+  return 0;
+}
+
+static int
 test_simde_mm256_gf2p8mul_epi8(SIMDE_MUNIT_TEST_ARGS) {
   const struct {
     simde__m256i a;
@@ -7437,6 +7461,7 @@ SIMDE_TEST_FUNC_LIST_BEGIN
   SIMDE_TEST_FUNC_LIST_ENTRY(mm512_maskz_gf2p8affineinv_epi64_epi8)
 
   SIMDE_TEST_FUNC_LIST_ENTRY(mm_gf2p8mul_epi8)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_gf2p8mul_epi8_const)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm256_gf2p8mul_epi8)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm512_gf2p8mul_epi8)
 

--- a/test/x86/gfni.c
+++ b/test/x86/gfni.c
@@ -5101,7 +5101,9 @@ test_simde_mm_gf2p8mul_epi8_const(SIMDE_MUNIT_TEST_ARGS) {
   #define SIMDE_TEST_GFNI_MUL_CONST(K) \
     do { \
       volatile int vk_ = (K); \
-      simde__m128i rc = simde_mm_gf2p8mul_epi8(a, simde_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, (K)))); \
+      /* Sign-extend K to keep the constant in int8_t range; MSVC warns (C4309)
+       * when a static_cast truncates a constant such as 0x80 or 0xff. */ \
+      simde__m128i rc = simde_mm_gf2p8mul_epi8(a, simde_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, ((K) ^ 0x80) - 0x80))); \
       simde__m128i rr = simde_mm_gf2p8mul_epi8(a, simde_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, vk_))); \
       simde_assert_m128i_i8(rc, ==, rr); \
     } while (0)

--- a/test/x86/gfni.c
+++ b/test/x86/gfni.c
@@ -2620,6 +2620,31 @@ test_simde_mm_gf2p8affineinv_epi64_epi8(SIMDE_MUNIT_TEST_ARGS) {
 }
 
 static int
+test_simde_mm_gf2p8affineinv_epi64_epi8_const(SIMDE_MUNIT_TEST_ARGS) {
+  /* Exercises the compile-time-constant-matrix AES-fused affineinv path
+   * (incl. M=A_aes,c=0x63 -> SubBytes) vs the run-time (general) path. */
+  #define SIMDE_TEST_GFNI_AINV_CONST(Q, C) \
+    do { \
+      volatile int64_t vm_ = HEDLEY_STATIC_CAST(int64_t, UINT64_C(Q)); \
+      simde__m128i rc = simde_mm_gf2p8affineinv_epi64_epi8(x, simde_mm_set1_epi64x(HEDLEY_STATIC_CAST(int64_t, UINT64_C(Q))), INT8_C(C)); \
+      simde__m128i rr = simde_mm_gf2p8affineinv_epi64_epi8(x, simde_mm_set1_epi64x(vm_), INT8_C(C)); \
+      simde_assert_m128i_i8(rc, ==, rr); \
+    } while (0)
+
+  for (int t = 0 ; t < 16 ; t++) {
+    simde__m128i x = simde_test_x86_random_i8x16();
+    SIMDE_TEST_GFNI_AINV_CONST(0xF1E3C78F1F3E7CF8, 0x63); /* AES S-box */
+    SIMDE_TEST_GFNI_AINV_CONST(0xF1E3C78F1F3E7CF8, 0x11); /* M=A_aes, c!=0x63 */
+    SIMDE_TEST_GFNI_AINV_CONST(0x0102040810204080, 0x00); /* identity -> inverse */
+    SIMDE_TEST_GFNI_AINV_CONST(0x123456789ABCDEF0, 0x37);
+    SIMDE_TEST_GFNI_AINV_CONST(0xFFFFFFFFFFFFFFFF, 0x5A);
+  }
+
+  #undef SIMDE_TEST_GFNI_AINV_CONST
+  return 0;
+}
+
+static int
 test_simde_mm256_gf2p8affineinv_epi64_epi8(SIMDE_MUNIT_TEST_ARGS) {
   const struct {
     simde__m256i x;
@@ -7449,6 +7474,7 @@ SIMDE_TEST_FUNC_LIST_BEGIN
   SIMDE_TEST_FUNC_LIST_ENTRY(mm512_maskz_gf2p8affine_epi64_epi8)
 
   SIMDE_TEST_FUNC_LIST_ENTRY(mm_gf2p8affineinv_epi64_epi8)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_gf2p8affineinv_epi64_epi8_const)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm256_gf2p8affineinv_epi64_epi8)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm512_gf2p8affineinv_epi64_epi8)
 

--- a/test/x86/gfni.c
+++ b/test/x86/gfni.c
@@ -145,6 +145,31 @@ test_simde_mm_gf2p8affine_epi64_epi8(SIMDE_MUNIT_TEST_ARGS) {
 }
 
 static int
+test_simde_mm_gf2p8affine_epi64_epi8_const(SIMDE_MUNIT_TEST_ARGS) {
+  /* Exercises the compile-time-constant-matrix nibble path and checks it agrees
+   * with the same matrix supplied at run time (which takes the general path). */
+  #define SIMDE_TEST_GFNI_AFF_CONST(Q) \
+    do { \
+      volatile int64_t vm_ = HEDLEY_STATIC_CAST(int64_t, UINT64_C(Q)); \
+      simde__m128i rc = simde_mm_gf2p8affine_epi64_epi8(x, simde_mm_set1_epi64x(HEDLEY_STATIC_CAST(int64_t, UINT64_C(Q))), INT8_C(0x63)); \
+      simde__m128i rr = simde_mm_gf2p8affine_epi64_epi8(x, simde_mm_set1_epi64x(vm_), INT8_C(0x63)); \
+      simde_assert_m128i_i8(rc, ==, rr); \
+    } while (0)
+
+  for (int t = 0 ; t < 16 ; t++) {
+    simde__m128i x = simde_test_x86_random_i8x16();
+    SIMDE_TEST_GFNI_AFF_CONST(0x0102040810204080); /* identity */
+    SIMDE_TEST_GFNI_AFF_CONST(0xF1E3C78F1F3E7CF8); /* AES forward affine */
+    SIMDE_TEST_GFNI_AFF_CONST(0x12345678ABCDEF01);
+    SIMDE_TEST_GFNI_AFF_CONST(0x0000000000000000);
+    SIMDE_TEST_GFNI_AFF_CONST(0xFFFFFFFFFFFFFFFF);
+  }
+
+  #undef SIMDE_TEST_GFNI_AFF_CONST
+  return 0;
+}
+
+static int
 test_simde_mm256_gf2p8affine_epi64_epi8(SIMDE_MUNIT_TEST_ARGS) {
   const struct {
     simde__m256i x;
@@ -7387,6 +7412,7 @@ test_simde_mm512_maskz_gf2p8mul_epi8(SIMDE_MUNIT_TEST_ARGS) {
 
 SIMDE_TEST_FUNC_LIST_BEGIN
   SIMDE_TEST_FUNC_LIST_ENTRY(mm_gf2p8affine_epi64_epi8)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_gf2p8affine_epi64_epi8_const)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm256_gf2p8affine_epi64_epi8)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm512_gf2p8affine_epi64_epi8)
 


### PR DESCRIPTION
#### Summary
This change makes the GFNI emulation faster.
The changed files are `simde/x86/gfni.h` and `test/x86/gfni.c`.

#### New feature detection.

The macro `SIMDE_X_GFNI_HAVE_AES` detects hardware AES support.
The support comes from AES-NI on x86 or the crypto extension on ARMv8.
The macro `SIMDE_X_GFNI_HAVE_SHUFFLE` detects byte-shuffle support.

#### New AES path.

When the hardware has AES, the function `simde_x_mm_gf2p8inverse_epi8` uses the AES S-box to compute the GF(2⁸) inverse.
New lookup tables undo the ShiftRows and affine steps of AES.
When the matrix is A_aes and the constant is 0x63, the affineinv operation becomes one SubBytes operation.

#### New tower-field path.

When the hardware has shuffle but no AES, the code computes the inverse and the multiply in the tower field GF((2⁴)²).
New lookup tables hold the log, exp, square, and basis-change values of GF(2⁴).
The multiply uses the Karatsuba method over GF(2⁴).

#### New constant-matrix path.

When the matrix is a compile-time constant, the code turns the matrix into two nibble lookup tables.
The affine transform then becomes two shuffles and one XOR at run time.
The new 256-entry table `simde_x_gf2p8_mul_matrix_lut` turns a multiply by a GF(2⁸) constant into an affine transform.
This path needs the two conditions `SIMDE_CHECK_CONSTANT_` and `SIMDE_X_GFNI_HAVE_SHUFFLE`.
Without shuffle, the matrix multiply uses a slower movemask loop.
In that condition, the usual schoolbook multiply is faster.
Thus the code does not use the constant-multiply path without shuffle.

#### Removed old code.

This change removes the old lookup-table inverse implementations for SSE4.1, AVX2, and AVX512BW; the new methods are faster than a large table lookup.
CPUs that support AVX512 but not GFNI become much slower with 512-bit operations; thus the 512-bit functions now use the 256-bit fallback path.

#### New tests.
The file `test/x86/gfni.c` gets new test functions.
